### PR TITLE
[ffigen] Remove `.ref.pointer`

### DIFF
--- a/pkgs/ffigen/example/objective_c/avf_audio_bindings.dart
+++ b/pkgs/ffigen/example/objective_c/avf_audio_bindings.dart
@@ -104,6 +104,7 @@ extension type AVAudioPlayer._(objc.ObjCObject object$)
 extension AVAudioPlayer$Methods on AVAudioPlayer {
   /// averagePowerForChannel:
   double averagePowerForChannel(int channelNumber) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.averagePowerForChannel:',
       iOS: (false, (2, 2, 0)),
@@ -111,12 +112,12 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     );
     return objc.useMsgSendVariants
         ? _objc_msgSend_65s5ywFpret(
-            object$.ref.pointer,
+            _$$.pointer,
             _sel_averagePowerForChannel_,
             channelNumber,
           )
         : _objc_msgSend_65s5yw(
-            object$.ref.pointer,
+            _$$.pointer,
             _sel_averagePowerForChannel_,
             channelNumber,
           );
@@ -124,15 +125,13 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// channelAssignments
   objc.NSArray? get channelAssignments {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.channelAssignments',
       iOS: (false, (7, 0, 0)),
       macOS: (true, null),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_channelAssignments,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_channelAssignments);
     return $ret.address == 0
         ? null
         : objc.NSArray.fromPointer($ret, retain: true, release: true);
@@ -140,12 +139,13 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// currentDevice
   objc.NSString? get currentDevice {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.currentDevice',
       iOS: (true, null),
       macOS: (false, (10, 13, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_currentDevice);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_currentDevice);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -153,24 +153,26 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// currentTime
   double get currentTime {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.currentTime',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_currentTime)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_currentTime);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_currentTime)
+        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_currentTime);
   }
 
   /// data
   objc.NSData? get data {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.data',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_data);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_data);
     return $ret.address == 0
         ? null
         : objc.NSData.fromPointer($ret, retain: true, release: true);
@@ -178,12 +180,13 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// delegate
   AVAudioPlayerDelegate? get delegate {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.delegate',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_delegate);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_delegate);
     return $ret.address == 0
         ? null
         : AVAudioPlayerDelegate.fromPointer($ret, retain: true, release: true);
@@ -191,68 +194,69 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// deviceCurrentTime
   double get deviceCurrentTime {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.deviceCurrentTime',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(
-            object$.ref.pointer,
-            _sel_deviceCurrentTime,
-          )
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_deviceCurrentTime);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_deviceCurrentTime)
+        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_deviceCurrentTime);
   }
 
   /// duration
   double get duration {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.duration',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_duration)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_duration);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_duration)
+        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_duration);
   }
 
   /// enableRate
   bool get enableRate {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.enableRate',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_enableRate);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_enableRate);
   }
 
   /// format
   AVAudioFormat get format {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.format',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_format);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_format);
     return AVAudioFormat.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   AVAudioPlayer init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return AVAudioPlayer.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:error:
   AVAudioPlayer? initWithContentsOfURL(objc.NSURL url) {
+    final _$$ = object$.ref;
+    final _$$$1 = url.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.initWithContentsOfURL:error:',
       iOS: (false, (2, 2, 0)),
@@ -261,9 +265,9 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1lhpu4m(
-        object$.ref.retainAndReturnPointer(),
+        _$$.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_error_,
-        url.ref.pointer,
+        _$$$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -280,6 +284,9 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     objc.NSURL url, {
     objc.NSString? fileTypeHint,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = url.ref;
+    final _$$$2 = fileTypeHint?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.initWithContentsOfURL:fileTypeHint:error:',
       iOS: (false, (7, 0, 0)),
@@ -288,10 +295,10 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1pnyuds(
-        object$.ref.retainAndReturnPointer(),
+        _$$.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_fileTypeHint_error_,
-        url.ref.pointer,
-        fileTypeHint?.ref.pointer ?? ffi.nullptr,
+        _$$$1.pointer,
+        _$$$2?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -305,6 +312,8 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// initWithData:error:
   AVAudioPlayer? initWithData(objc.NSData data) {
+    final _$$ = object$.ref;
+    final _$$$1 = data.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.initWithData:error:',
       iOS: (false, (2, 2, 0)),
@@ -313,9 +322,9 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1lhpu4m(
-        object$.ref.retainAndReturnPointer(),
+        _$$.retainAndReturnPointer(),
         _sel_initWithData_error_,
-        data.ref.pointer,
+        _$$$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -332,6 +341,9 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     objc.NSData data, {
     objc.NSString? fileTypeHint,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = data.ref;
+    final _$$$2 = fileTypeHint?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.initWithData:fileTypeHint:error:',
       iOS: (false, (7, 0, 0)),
@@ -340,10 +352,10 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1pnyuds(
-        object$.ref.retainAndReturnPointer(),
+        _$$.retainAndReturnPointer(),
         _sel_initWithData_fileTypeHint_error_,
-        data.ref.pointer,
-        fileTypeHint?.ref.pointer ?? ffi.nullptr,
+        _$$$1.pointer,
+        _$$$2?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -357,13 +369,14 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// intendedSpatialExperience
   CASpatialAudioExperience get intendedSpatialExperience {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.intendedSpatialExperience',
       iOS: (true, null),
       macOS: (true, null),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_intendedSpatialExperience,
     );
     return CASpatialAudioExperience.fromPointer(
@@ -375,68 +388,75 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// isMeteringEnabled
   bool get isMeteringEnabled {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.isMeteringEnabled',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isMeteringEnabled);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isMeteringEnabled);
   }
 
   /// isPlaying
   bool get isPlaying {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.isPlaying',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isPlaying);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isPlaying);
   }
 
   /// numberOfChannels
   int get numberOfChannels {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.numberOfChannels',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_numberOfChannels);
+    return _objc_msgSend_xw2lbc(_$$.pointer, _sel_numberOfChannels);
   }
 
   /// numberOfLoops
   int get numberOfLoops {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.numberOfLoops',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_numberOfLoops);
+    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_numberOfLoops);
   }
 
   /// pan
   double get pan {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.pan',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(object$.ref.pointer, _sel_pan)
-        : _objc_msgSend_2cgrxl(object$.ref.pointer, _sel_pan);
+        ? _objc_msgSend_2cgrxlFpret(_$$.pointer, _sel_pan)
+        : _objc_msgSend_2cgrxl(_$$.pointer, _sel_pan);
   }
 
   /// pause
   void pause() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.pause',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_pause);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_pause);
   }
 
   /// peakPowerForChannel:
   double peakPowerForChannel(int channelNumber) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.peakPowerForChannel:',
       iOS: (false, (2, 2, 0)),
@@ -444,12 +464,12 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     );
     return objc.useMsgSendVariants
         ? _objc_msgSend_65s5ywFpret(
-            object$.ref.pointer,
+            _$$.pointer,
             _sel_peakPowerForChannel_,
             channelNumber,
           )
         : _objc_msgSend_65s5yw(
-            object$.ref.pointer,
+            _$$.pointer,
             _sel_peakPowerForChannel_,
             channelNumber,
           );
@@ -457,181 +477,201 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// play
   bool play() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.play',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_play);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_play);
   }
 
   /// playAtTime:
   bool playAtTime(double time) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.playAtTime:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_18chyc(object$.ref.pointer, _sel_playAtTime_, time);
+    return _objc_msgSend_18chyc(_$$.pointer, _sel_playAtTime_, time);
   }
 
   /// prepareToPlay
   bool prepareToPlay() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.prepareToPlay',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_prepareToPlay);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_prepareToPlay);
   }
 
   /// rate
   double get rate {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.rate',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(object$.ref.pointer, _sel_rate)
-        : _objc_msgSend_2cgrxl(object$.ref.pointer, _sel_rate);
+        ? _objc_msgSend_2cgrxlFpret(_$$.pointer, _sel_rate)
+        : _objc_msgSend_2cgrxl(_$$.pointer, _sel_rate);
   }
 
   /// setChannelAssignments:
   set channelAssignments(objc.NSArray? value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setChannelAssignments:',
       iOS: (false, (7, 0, 0)),
       macOS: (true, null),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setChannelAssignments_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setCurrentDevice:
   set currentDevice(objc.NSString? value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setCurrentDevice:',
       iOS: (true, null),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setCurrentDevice_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setCurrentTime:
   set currentTime(double value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setCurrentTime:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_hwm8nu(object$.ref.pointer, _sel_setCurrentTime_, value);
+    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setCurrentTime_, value);
   }
 
   /// setDelegate:
   set delegate(AVAudioPlayerDelegate? value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setDelegate:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setDelegate_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setEnableRate:
   set enableRate(bool value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setEnableRate:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
-    _objc_msgSend_1s56lr9(object$.ref.pointer, _sel_setEnableRate_, value);
+    _objc_msgSend_1s56lr9(_$$.pointer, _sel_setEnableRate_, value);
   }
 
   /// setIntendedSpatialExperience:
   set intendedSpatialExperience(CASpatialAudioExperience value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setIntendedSpatialExperience:',
       iOS: (true, null),
       macOS: (true, null),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setIntendedSpatialExperience_,
-      value.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// setMeteringEnabled:
   set isMeteringEnabled(bool value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setMeteringEnabled:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1s56lr9(object$.ref.pointer, _sel_setMeteringEnabled_, value);
+    _objc_msgSend_1s56lr9(_$$.pointer, _sel_setMeteringEnabled_, value);
   }
 
   /// setNumberOfLoops:
   set numberOfLoops(int value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setNumberOfLoops:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_4sp4xj(object$.ref.pointer, _sel_setNumberOfLoops_, value);
+    _objc_msgSend_4sp4xj(_$$.pointer, _sel_setNumberOfLoops_, value);
   }
 
   /// setPan:
   set pan(double value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setPan:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_v5hmet(object$.ref.pointer, _sel_setPan_, value);
+    _objc_msgSend_v5hmet(_$$.pointer, _sel_setPan_, value);
   }
 
   /// setRate:
   set rate(double value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setRate:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
-    _objc_msgSend_v5hmet(object$.ref.pointer, _sel_setRate_, value);
+    _objc_msgSend_v5hmet(_$$.pointer, _sel_setRate_, value);
   }
 
   /// setVolume:
   set volume(double value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setVolume:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_v5hmet(object$.ref.pointer, _sel_setVolume_, value);
+    _objc_msgSend_v5hmet(_$$.pointer, _sel_setVolume_, value);
   }
 
   /// setVolume:fadeDuration:
   void setVolume(double volume, {required double fadeDuration}) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setVolume:fadeDuration:',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
     _objc_msgSend_1p4uk9e(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setVolume_fadeDuration_,
       volume,
       fadeDuration,
@@ -640,43 +680,47 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// settings
   objc.NSDictionary get settings {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.settings',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_settings);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_settings);
     return objc.NSDictionary.fromPointer($ret, retain: true, release: true);
   }
 
   /// stop
   void stop() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.stop',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_stop);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_stop);
   }
 
   /// updateMeters
   void updateMeters() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.updateMeters',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_updateMeters);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_updateMeters);
   }
 
   /// url
   objc.NSURL? get url {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.url',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_url);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_url);
     return $ret.address == 0
         ? null
         : objc.NSURL.fromPointer($ret, retain: true, release: true);
@@ -684,14 +728,15 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// volume
   double get volume {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.volume',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(object$.ref.pointer, _sel_volume)
-        : _objc_msgSend_2cgrxl(object$.ref.pointer, _sel_volume);
+        ? _objc_msgSend_2cgrxlFpret(_$$.pointer, _sel_volume)
+        : _objc_msgSend_2cgrxl(_$$.pointer, _sel_volume);
   }
 }
 

--- a/pkgs/ffigen/example/objective_c/avf_audio_bindings.dart
+++ b/pkgs/ffigen/example/objective_c/avf_audio_bindings.dart
@@ -104,7 +104,7 @@ extension type AVAudioPlayer._(objc.ObjCObject object$)
 extension AVAudioPlayer$Methods on AVAudioPlayer {
   /// averagePowerForChannel:
   double averagePowerForChannel(int channelNumber) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.averagePowerForChannel:',
       iOS: (false, (2, 2, 0)),
@@ -112,12 +112,12 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     );
     return objc.useMsgSendVariants
         ? _objc_msgSend_65s5ywFpret(
-            _$$.pointer,
+            _$$ref.pointer,
             _sel_averagePowerForChannel_,
             channelNumber,
           )
         : _objc_msgSend_65s5yw(
-            _$$.pointer,
+            _$$ref.pointer,
             _sel_averagePowerForChannel_,
             channelNumber,
           );
@@ -125,13 +125,13 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// channelAssignments
   objc.NSArray? get channelAssignments {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.channelAssignments',
       iOS: (false, (7, 0, 0)),
       macOS: (true, null),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_channelAssignments);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_channelAssignments);
     return $ret.address == 0
         ? null
         : objc.NSArray.fromPointer($ret, retain: true, release: true);
@@ -139,13 +139,13 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// currentDevice
   objc.NSString? get currentDevice {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.currentDevice',
       iOS: (true, null),
       macOS: (false, (10, 13, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_currentDevice);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_currentDevice);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -153,26 +153,26 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// currentTime
   double get currentTime {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.currentTime',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_currentTime)
-        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_currentTime);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_currentTime)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_currentTime);
   }
 
   /// data
   objc.NSData? get data {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.data',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_data);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_data);
     return $ret.address == 0
         ? null
         : objc.NSData.fromPointer($ret, retain: true, release: true);
@@ -180,13 +180,13 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// delegate
   AVAudioPlayerDelegate? get delegate {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.delegate',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_delegate);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_delegate);
     return $ret.address == 0
         ? null
         : AVAudioPlayerDelegate.fromPointer($ret, retain: true, release: true);
@@ -194,69 +194,72 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// deviceCurrentTime
   double get deviceCurrentTime {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.deviceCurrentTime',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_deviceCurrentTime)
-        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_deviceCurrentTime);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_deviceCurrentTime)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_deviceCurrentTime);
   }
 
   /// duration
   double get duration {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.duration',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_duration)
-        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_duration);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_duration)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_duration);
   }
 
   /// enableRate
   bool get enableRate {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.enableRate',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_enableRate);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_enableRate);
   }
 
   /// format
   AVAudioFormat get format {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.format',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_format);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_format);
     return AVAudioFormat.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   AVAudioPlayer init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return AVAudioPlayer.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:error:
   AVAudioPlayer? initWithContentsOfURL(objc.NSURL url) {
-    final _$$ = object$.ref;
-    final _$$$1 = url.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.initWithContentsOfURL:error:',
       iOS: (false, (2, 2, 0)),
@@ -265,9 +268,9 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1lhpu4m(
-        _$$.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_error_,
-        _$$$1.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -284,9 +287,9 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     objc.NSURL url, {
     objc.NSString? fileTypeHint,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = url.ref;
-    final _$$$2 = fileTypeHint?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
+    final _$$ref$2 = fileTypeHint?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.initWithContentsOfURL:fileTypeHint:error:',
       iOS: (false, (7, 0, 0)),
@@ -295,10 +298,10 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1pnyuds(
-        _$$.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_fileTypeHint_error_,
-        _$$$1.pointer,
-        _$$$2?.pointer ?? ffi.nullptr,
+        _$$ref$1.pointer,
+        _$$ref$2?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -312,8 +315,8 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// initWithData:error:
   AVAudioPlayer? initWithData(objc.NSData data) {
-    final _$$ = object$.ref;
-    final _$$$1 = data.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.initWithData:error:',
       iOS: (false, (2, 2, 0)),
@@ -322,9 +325,9 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1lhpu4m(
-        _$$.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithData_error_,
-        _$$$1.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -341,9 +344,9 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     objc.NSData data, {
     objc.NSString? fileTypeHint,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = data.ref;
-    final _$$$2 = fileTypeHint?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
+    final _$$ref$2 = fileTypeHint?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.initWithData:fileTypeHint:error:',
       iOS: (false, (7, 0, 0)),
@@ -352,10 +355,10 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1pnyuds(
-        _$$.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithData_fileTypeHint_error_,
-        _$$$1.pointer,
-        _$$$2?.pointer ?? ffi.nullptr,
+        _$$ref$1.pointer,
+        _$$ref$2?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -369,14 +372,14 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// intendedSpatialExperience
   CASpatialAudioExperience get intendedSpatialExperience {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.intendedSpatialExperience',
       iOS: (true, null),
       macOS: (true, null),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_intendedSpatialExperience,
     );
     return CASpatialAudioExperience.fromPointer(
@@ -388,75 +391,75 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// isMeteringEnabled
   bool get isMeteringEnabled {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.isMeteringEnabled',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isMeteringEnabled);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isMeteringEnabled);
   }
 
   /// isPlaying
   bool get isPlaying {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.isPlaying',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isPlaying);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isPlaying);
   }
 
   /// numberOfChannels
   int get numberOfChannels {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.numberOfChannels',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_xw2lbc(_$$.pointer, _sel_numberOfChannels);
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_numberOfChannels);
   }
 
   /// numberOfLoops
   int get numberOfLoops {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.numberOfLoops',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_numberOfLoops);
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_numberOfLoops);
   }
 
   /// pan
   double get pan {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.pan',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(_$$.pointer, _sel_pan)
-        : _objc_msgSend_2cgrxl(_$$.pointer, _sel_pan);
+        ? _objc_msgSend_2cgrxlFpret(_$$ref.pointer, _sel_pan)
+        : _objc_msgSend_2cgrxl(_$$ref.pointer, _sel_pan);
   }
 
   /// pause
   void pause() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.pause',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_pause);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_pause);
   }
 
   /// peakPowerForChannel:
   double peakPowerForChannel(int channelNumber) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.peakPowerForChannel:',
       iOS: (false, (2, 2, 0)),
@@ -464,12 +467,12 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
     );
     return objc.useMsgSendVariants
         ? _objc_msgSend_65s5ywFpret(
-            _$$.pointer,
+            _$$ref.pointer,
             _sel_peakPowerForChannel_,
             channelNumber,
           )
         : _objc_msgSend_65s5yw(
-            _$$.pointer,
+            _$$ref.pointer,
             _sel_peakPowerForChannel_,
             channelNumber,
           );
@@ -477,201 +480,201 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// play
   bool play() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.play',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_play);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_play);
   }
 
   /// playAtTime:
   bool playAtTime(double time) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.playAtTime:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_18chyc(_$$.pointer, _sel_playAtTime_, time);
+    return _objc_msgSend_18chyc(_$$ref.pointer, _sel_playAtTime_, time);
   }
 
   /// prepareToPlay
   bool prepareToPlay() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.prepareToPlay',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_prepareToPlay);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_prepareToPlay);
   }
 
   /// rate
   double get rate {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.rate',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(_$$.pointer, _sel_rate)
-        : _objc_msgSend_2cgrxl(_$$.pointer, _sel_rate);
+        ? _objc_msgSend_2cgrxlFpret(_$$ref.pointer, _sel_rate)
+        : _objc_msgSend_2cgrxl(_$$ref.pointer, _sel_rate);
   }
 
   /// setChannelAssignments:
   set channelAssignments(objc.NSArray? value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setChannelAssignments:',
       iOS: (false, (7, 0, 0)),
       macOS: (true, null),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setChannelAssignments_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setCurrentDevice:
   set currentDevice(objc.NSString? value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setCurrentDevice:',
       iOS: (true, null),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setCurrentDevice_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setCurrentTime:
   set currentTime(double value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setCurrentTime:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setCurrentTime_, value);
+    _objc_msgSend_hwm8nu(_$$ref.pointer, _sel_setCurrentTime_, value);
   }
 
   /// setDelegate:
   set delegate(AVAudioPlayerDelegate? value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setDelegate:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setDelegate_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setEnableRate:
   set enableRate(bool value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setEnableRate:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
-    _objc_msgSend_1s56lr9(_$$.pointer, _sel_setEnableRate_, value);
+    _objc_msgSend_1s56lr9(_$$ref.pointer, _sel_setEnableRate_, value);
   }
 
   /// setIntendedSpatialExperience:
   set intendedSpatialExperience(CASpatialAudioExperience value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setIntendedSpatialExperience:',
       iOS: (true, null),
       macOS: (true, null),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setIntendedSpatialExperience_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// setMeteringEnabled:
   set isMeteringEnabled(bool value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setMeteringEnabled:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1s56lr9(_$$.pointer, _sel_setMeteringEnabled_, value);
+    _objc_msgSend_1s56lr9(_$$ref.pointer, _sel_setMeteringEnabled_, value);
   }
 
   /// setNumberOfLoops:
   set numberOfLoops(int value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setNumberOfLoops:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_4sp4xj(_$$.pointer, _sel_setNumberOfLoops_, value);
+    _objc_msgSend_4sp4xj(_$$ref.pointer, _sel_setNumberOfLoops_, value);
   }
 
   /// setPan:
   set pan(double value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setPan:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_v5hmet(_$$.pointer, _sel_setPan_, value);
+    _objc_msgSend_v5hmet(_$$ref.pointer, _sel_setPan_, value);
   }
 
   /// setRate:
   set rate(double value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setRate:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
-    _objc_msgSend_v5hmet(_$$.pointer, _sel_setRate_, value);
+    _objc_msgSend_v5hmet(_$$ref.pointer, _sel_setRate_, value);
   }
 
   /// setVolume:
   set volume(double value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setVolume:',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_v5hmet(_$$.pointer, _sel_setVolume_, value);
+    _objc_msgSend_v5hmet(_$$ref.pointer, _sel_setVolume_, value);
   }
 
   /// setVolume:fadeDuration:
   void setVolume(double volume, {required double fadeDuration}) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.setVolume:fadeDuration:',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
     _objc_msgSend_1p4uk9e(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setVolume_fadeDuration_,
       volume,
       fadeDuration,
@@ -680,47 +683,47 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// settings
   objc.NSDictionary get settings {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.settings',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_settings);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_settings);
     return objc.NSDictionary.fromPointer($ret, retain: true, release: true);
   }
 
   /// stop
   void stop() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.stop',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_stop);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_stop);
   }
 
   /// updateMeters
   void updateMeters() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.updateMeters',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_updateMeters);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_updateMeters);
   }
 
   /// url
   objc.NSURL? get url {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.url',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_url);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_url);
     return $ret.address == 0
         ? null
         : objc.NSURL.fromPointer($ret, retain: true, release: true);
@@ -728,15 +731,15 @@ extension AVAudioPlayer$Methods on AVAudioPlayer {
 
   /// volume
   double get volume {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AVAudioPlayer.volume',
       iOS: (false, (2, 2, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(_$$.pointer, _sel_volume)
-        : _objc_msgSend_2cgrxl(_$$.pointer, _sel_volume);
+        ? _objc_msgSend_2cgrxlFpret(_$$ref.pointer, _sel_volume)
+        : _objc_msgSend_2cgrxl(_$$ref.pointer, _sel_volume);
   }
 }
 

--- a/pkgs/ffigen/example/swift/swift_api_bindings.dart
+++ b/pkgs/ffigen/example/swift/swift_api_bindings.dart
@@ -65,33 +65,36 @@ extension type SwiftClass._(objc.ObjCObject object$)
 extension SwiftClass$Methods on SwiftClass {
   /// init
   SwiftClass init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'SwiftClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return SwiftClass.fromPointer($ret, retain: false, release: true);
   }
 
   /// sayHello
   objc.NSString sayHello() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_sayHello);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_sayHello);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// setSomeField:
   set someField(int value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_4sp4xj(_$$.pointer, _sel_setSomeField_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_4sp4xj(_$$ref.pointer, _sel_setSomeField_, value);
   }
 
   /// someField
   int get someField {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_someField);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_someField);
   }
 }
 

--- a/pkgs/ffigen/example/swift/swift_api_bindings.dart
+++ b/pkgs/ffigen/example/swift/swift_api_bindings.dart
@@ -65,32 +65,33 @@ extension type SwiftClass._(objc.ObjCObject object$)
 extension SwiftClass$Methods on SwiftClass {
   /// init
   SwiftClass init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'SwiftClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return SwiftClass.fromPointer($ret, retain: false, release: true);
   }
 
   /// sayHello
   objc.NSString sayHello() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_sayHello);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_sayHello);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// setSomeField:
   set someField(int value) {
-    _objc_msgSend_4sp4xj(object$.ref.pointer, _sel_setSomeField_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_4sp4xj(_$$.pointer, _sel_setSomeField_, value);
   }
 
   /// someField
   int get someField {
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_someField);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_someField);
   }
 }
 

--- a/pkgs/ffigen/lib/src/code_generator/enum_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/enum_class.dart
@@ -10,6 +10,7 @@ import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'binding_string.dart';
 import 'imports.dart';
+import 'local_variables.dart';
 import 'scope.dart';
 import 'type.dart';
 import 'utils.dart';
@@ -275,6 +276,7 @@ class EnumClass extends BindingType with HasLocalScope {
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
+    required LocalVariables localVariables,
   }) => sameDartAndFfiDartType ? value : '$value.value';
 
   @override

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -190,20 +190,12 @@ external $ffiReturnType $nativeFuncName($ffiArgDeclString);
 
 ''');
       if (needsWrapper) {
-        if (localVars.isNotEmpty) {
-          s.write('''
+        s.write('''
 $dartReturnType $enclosingFuncName($dartArgDeclString) {
-  ${localVars.generateDeclarations()}
-  return $funcImplCall;
+${localVars.generateDeclarations(indent: '  ')}  return $funcImplCall;
 }
 
 ''');
-        } else {
-          s.write('''
-$dartReturnType $enclosingFuncName($dartArgDeclString) => $funcImplCall;
-
-''');
-        }
       }
 
       if (exposeSymbolAddress) {
@@ -222,12 +214,7 @@ $dartReturnType $enclosingFuncName($dartArgDeclString) => $funcImplCall;
       // Write enclosing function.
       s.write('''
 $dartReturnType $enclosingFuncName($dartArgDeclString) {
-''');
-      if (localVars.isNotEmpty) {
-        s.write('  ${localVars.generateDeclarations()}\n');
-      }
-      s.write('''
-  return $funcImplCall;
+${localVars.generateDeclarations(indent: '  ')}  return $funcImplCall;
 }
 
 ''');

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -192,7 +192,8 @@ external $ffiReturnType $nativeFuncName($ffiArgDeclString);
       if (needsWrapper) {
         s.write('''
 $dartReturnType $enclosingFuncName($dartArgDeclString) {
-${localVars.generateDeclarations(indent: '  ')}  return $funcImplCall;
+  ${localVars.generateDeclarations()}
+  return $funcImplCall;
 }
 
 ''');
@@ -214,7 +215,8 @@ ${localVars.generateDeclarations(indent: '  ')}  return $funcImplCall;
       // Write enclosing function.
       s.write('''
 $dartReturnType $enclosingFuncName($dartArgDeclString) {
-${localVars.generateDeclarations(indent: '  ')}  return $funcImplCall;
+  ${localVars.generateDeclarations()}
+  return $funcImplCall;
 }
 
 ''');

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -5,8 +5,8 @@
 import '../code_generator.dart';
 import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
-
 import 'binding_string.dart';
+import 'local_variables.dart';
 import 'scope.dart';
 import 'utils.dart';
 import 'writer.dart';
@@ -136,6 +136,8 @@ class Func extends LookUpBinding with HasLocalScope {
     final String dartReturnType;
     final String dartArgDeclString;
     final String funcImplCall;
+    final localVars = LocalVariables(localScope);
+
     if (needsWrapper) {
       dartReturnType = functionType.returnType.getDartType(context);
       dartArgDeclString = functionType.dartTypeParameters
@@ -149,6 +151,7 @@ class Func extends LookUpBinding with HasLocalScope {
               p.name,
               objCRetain: p.objCConsumed,
               objCAutorelease: false,
+              localVariables: localVars,
             );
             return '$type,\n';
           })
@@ -187,10 +190,20 @@ external $ffiReturnType $nativeFuncName($ffiArgDeclString);
 
 ''');
       if (needsWrapper) {
-        s.write('''
+        if (localVars.isNotEmpty) {
+          s.write('''
+$dartReturnType $enclosingFuncName($dartArgDeclString) {
+  ${localVars.generateDeclarations()}
+  return $funcImplCall;
+}
+
+''');
+        } else {
+          s.write('''
 $dartReturnType $enclosingFuncName($dartArgDeclString) => $funcImplCall;
 
 ''');
+        }
       }
 
       if (exposeSymbolAddress) {
@@ -209,6 +222,11 @@ $dartReturnType $enclosingFuncName($dartArgDeclString) => $funcImplCall;
       // Write enclosing function.
       s.write('''
 $dartReturnType $enclosingFuncName($dartArgDeclString) {
+''');
+      if (localVars.isNotEmpty) {
+        s.write('  ${localVars.generateDeclarations()}\n');
+      }
+      s.write('''
   return $funcImplCall;
 }
 

--- a/pkgs/ffigen/lib/src/code_generator/global.dart
+++ b/pkgs/ffigen/lib/src/code_generator/global.dart
@@ -84,9 +84,7 @@ class Global extends LookUpBinding with HasLocalScope {
         s.write('''set $globalVarName($dartType value) {
   $releaseOldValue.ref.release();
 ''');
-        if (localVars.isNotEmpty) {
-          s.write('  ${localVars.generateDeclarations()}\n');
-        }
+        s.write(localVars.generateDeclarations(indent: '  '));
         s.write('''  $pointerValue = $newValue;
 }''');
       }

--- a/pkgs/ffigen/lib/src/code_generator/global.dart
+++ b/pkgs/ffigen/lib/src/code_generator/global.dart
@@ -7,6 +7,7 @@ import 'binding.dart';
 import 'binding_string.dart';
 import 'compound.dart';
 import 'imports.dart';
+import 'local_variables.dart';
 import 'pointer.dart';
 import 'scope.dart';
 import 'type.dart';
@@ -23,7 +24,7 @@ import 'writer.dart';
 /// ```dart
 /// final int a = _dylib.lookup<ffi.Int32>('a').value;
 /// ```
-class Global extends LookUpBinding {
+class Global extends LookUpBinding with HasLocalScope {
   final Type type;
   final bool exposeSymbolAddress;
   final bool constant;
@@ -72,15 +73,21 @@ class Global extends LookUpBinding {
           pointerValue,
           objCRetain: false,
         );
+        final localVars = LocalVariables(localScope);
         final newValue = type.convertDartTypeToFfiDartType(
           context,
           'value',
           objCRetain: true,
           objCAutorelease: false,
+          localVariables: localVars,
         );
         s.write('''set $globalVarName($dartType value) {
   $releaseOldValue.ref.release();
-  $pointerValue = $newValue;
+''');
+        if (localVars.isNotEmpty) {
+          s.write('  ${localVars.generateDeclarations()}\n');
+        }
+        s.write('''  $pointerValue = $newValue;
 }''');
       }
     }

--- a/pkgs/ffigen/lib/src/code_generator/global.dart
+++ b/pkgs/ffigen/lib/src/code_generator/global.dart
@@ -83,9 +83,8 @@ class Global extends LookUpBinding with HasLocalScope {
         );
         s.write('''set $globalVarName($dartType value) {
   $releaseOldValue.ref.release();
-''');
-        s.write(localVars.generateDeclarations(indent: '  '));
-        s.write('''  $pointerValue = $newValue;
+  ${localVars.generateDeclarations()}
+  $pointerValue = $newValue;
 }''');
       }
     }

--- a/pkgs/ffigen/lib/src/code_generator/local_variables.dart
+++ b/pkgs/ffigen/lib/src/code_generator/local_variables.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'scope.dart';
+
+/// Manages local variable declarations for a method or block of code.
+class LocalVariables {
+  final Scope scope;
+  final List<String> _declarations = [];
+
+  LocalVariables(this.scope);
+
+  /// Adds a new local variable with the given [value] and returns its name.
+  ///
+  /// [nameHint] is used to generate a unique private name.
+  String addVariable({required String value, String nameHint = 'temp'}) {
+    final name = scope.addPrivate('_\$$nameHint');
+    _declarations.add('final $name = $value;');
+    return name;
+  }
+
+  /// Returns whether any local variables have been declared.
+  bool get isNotEmpty => _declarations.isNotEmpty;
+
+  /// Generates the declarations of all local variables.
+  String generateDeclarations() {
+    return _declarations.join('\n');
+  }
+}

--- a/pkgs/ffigen/lib/src/code_generator/local_variables.dart
+++ b/pkgs/ffigen/lib/src/code_generator/local_variables.dart
@@ -12,10 +12,8 @@ class LocalVariables {
   LocalVariables(this.scope);
 
   /// Adds a new local variable with the given [value] and returns its name.
-  ///
-  /// [nameHint] is used to generate a unique private name.
-  String addVariable({required String value, String nameHint = 'temp'}) {
-    final name = scope.addPrivate('_\$$nameHint');
+  String addVariable(String value) {
+    final name = scope.addPrivate('_\$\$');
     _declarations.add('final $name = $value;');
     return name;
   }
@@ -24,10 +22,7 @@ class LocalVariables {
   bool get isNotEmpty => _declarations.isNotEmpty;
 
   /// Generates the declarations of all local variables.
-  ///
-  /// [indent] is the string used for indentation (e.g., '  ').
-  String generateDeclarations({String indent = '  '}) {
-    if (_declarations.isEmpty) return '';
-    return '${_declarations.map((d) => '$indent$d').join('\n')}\n';
+  String generateDeclarations() {
+    return _declarations.join('  \n');
   }
 }

--- a/pkgs/ffigen/lib/src/code_generator/local_variables.dart
+++ b/pkgs/ffigen/lib/src/code_generator/local_variables.dart
@@ -12,8 +12,8 @@ class LocalVariables {
   LocalVariables(this.scope);
 
   /// Adds a new local variable with the given [value] and returns its name.
-  String addVariable(String value) {
-    final name = scope.addPrivate('_\$\$');
+  String addVariable(String nameHint, String value) {
+    final name = scope.addPrivate('_\$\$$nameHint');
     _declarations.add('final $name = $value;');
     return name;
   }

--- a/pkgs/ffigen/lib/src/code_generator/local_variables.dart
+++ b/pkgs/ffigen/lib/src/code_generator/local_variables.dart
@@ -24,7 +24,10 @@ class LocalVariables {
   bool get isNotEmpty => _declarations.isNotEmpty;
 
   /// Generates the declarations of all local variables.
-  String generateDeclarations() {
-    return _declarations.join('\n');
+  ///
+  /// [indent] is the string used for indentation (e.g., '  ').
+  String generateDeclarations({String indent = '  '}) {
+    if (_declarations.isEmpty) return '';
+    return '${_declarations.map((d) => '$indent$d').join('\n')}\n';
   }
 }

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -560,6 +560,7 @@ $ret $fnName(id target, $argRecv) {
     required bool objCAutorelease,
     required LocalVariables localVariables,
   }) => ObjCInterface.generateGetId(
+    context,
     value,
     objCRetain,
     objCAutorelease,

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -6,8 +6,8 @@ import '../code_generator.dart';
 import '../context.dart';
 import '../strings.dart' as strings;
 import '../visitor/ast.dart';
-
 import 'binding_string.dart';
+import 'local_variables.dart';
 import 'scope.dart';
 import 'writer.dart';
 
@@ -213,13 +213,20 @@ class ObjCBlock extends BindingType with HasLocalScope {
           ),
         )
         .join(', ');
+    final closureLocalVars = LocalVariables(localScope);
     final convFnInvocation = returnType.convertDartTypeToFfiDartType(
       context,
       'fn($convertedFnArgs)',
       objCRetain: true,
       objCAutorelease: !returnsRetained,
+      localVariables: closureLocalVars,
     );
-    final convFn = '(${_helper.paramsFfiDartType}) => $convFnInvocation';
+    final convFn = closureLocalVars.isNotEmpty
+        ? '(${_helper.paramsFfiDartType}) {\n'
+              '    ${closureLocalVars.generateDeclarations()}\n'
+              '    return $convFnInvocation;\n'
+              '  }'
+        : '(${_helper.paramsFfiDartType}) => $convFnInvocation';
 
     // Write the wrapper class.
     s.write('''
@@ -269,14 +276,20 @@ abstract final class $name {
             ),
           )
           .join(', ');
+      final listenerLocalVars = LocalVariables(localScope);
       final listenerConvFnInvocation = returnType.convertDartTypeToFfiDartType(
         context,
         'fn($listenerConvertedFnArgs)',
         objCRetain: true,
         objCAutorelease: !returnsRetained,
+        localVariables: listenerLocalVars,
       );
-      final listenerConvFn =
-          '(${_helper.paramsFfiDartType}) => $listenerConvFnInvocation';
+      final listenerConvFn = listenerLocalVars.isNotEmpty
+          ? '(${_helper.paramsFfiDartType}) {\n'
+                '    ${listenerLocalVars.generateDeclarations()}\n'
+                '    return $listenerConvFnInvocation;\n'
+                '  }'
+          : '(${_helper.paramsFfiDartType}) => $listenerConvFnInvocation';
       final wrapListenerFn = _blockWrappers!.listenerWrapper.name;
       final wrapBlockingFn = _blockWrappers!.blockingWrapper.name;
 
@@ -368,7 +381,9 @@ abstract final class $name {
     s.write('''
 /// Call operator for `$blockType`.
 extension $name\$CallExtension on $blockType {
-  ${returnType.getDartType(context)} call(${_helper.paramsDartType}) =>''');
+  ${returnType.getDartType(context)} call(${_helper.paramsDartType})''');
+
+    final callLocalVars = LocalVariables(localScope);
     final callMethodArgs = params
         .map(
           (p) => p.type.convertDartTypeToFfiDartType(
@@ -376,9 +391,19 @@ extension $name\$CallExtension on $blockType {
             p.name,
             objCRetain: p.objCConsumed,
             objCAutorelease: false,
+            localVariables: callLocalVars,
           ),
         )
         .join(', ');
+
+    if (callLocalVars.isNotEmpty) {
+      s.write(''' {
+    ${callLocalVars.generateDeclarations()}
+    return ''');
+    } else {
+      s.write(' => ');
+    }
+
     final callMethodInvocation =
         '''
 ref.pointer.ref.invoke.cast<${_helper.trampNatFnCType}>()
@@ -392,6 +417,9 @@ ref.pointer.ref.invoke.cast<${_helper.trampNatFnCType}>()
       ),
     );
     s.write(';\n');
+    if (callLocalVars.isNotEmpty) {
+      s.write('  }\n');
+    }
 
     s.write('}\n\n');
     return BindingString(
@@ -536,7 +564,13 @@ $ret $fnName(id target, $argRecv) {
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
-  }) => ObjCInterface.generateGetId(value, objCRetain, objCAutorelease);
+    required LocalVariables localVariables,
+  }) => ObjCInterface.generateGetId(
+    value,
+    objCRetain,
+    objCAutorelease,
+    localVariables,
+  );
 
   @override
   String convertFfiDartTypeToDartType(

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -222,10 +222,11 @@ class ObjCBlock extends BindingType with HasLocalScope {
       localVariables: closureLocalVars,
     );
     final convFn =
-        '(${_helper.paramsFfiDartType}) {\n'
-        '${closureLocalVars.generateDeclarations(indent: '    ')}'
-        '    return $convFnInvocation;\n'
-        '  }';
+        '''
+(${_helper.paramsFfiDartType}) {
+  ${closureLocalVars.generateDeclarations()}
+  return $convFnInvocation;
+}''';
 
     // Write the wrapper class.
     s.write('''
@@ -284,10 +285,11 @@ abstract final class $name {
         localVariables: listenerLocalVars,
       );
       final listenerConvFn =
-          '(${_helper.paramsFfiDartType}) {\n'
-          '${listenerLocalVars.generateDeclarations(indent: '    ')}'
-          '    return $listenerConvFnInvocation;\n'
-          '  }';
+          '''
+(${_helper.paramsFfiDartType}) {
+  ${listenerLocalVars.generateDeclarations()}
+  return $listenerConvFnInvocation;
+}''';
       final wrapListenerFn = _blockWrappers!.listenerWrapper.name;
       final wrapBlockingFn = _blockWrappers!.blockingWrapper.name;
 
@@ -395,7 +397,8 @@ extension $name\$CallExtension on $blockType {
         .join(', ');
 
     s.write(''' {
-${callLocalVars.generateDeclarations(indent: '    ')}    return ''');
+    ${callLocalVars.generateDeclarations()}
+    return ''');
 
     final callMethodInvocation =
         '''

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -221,12 +221,11 @@ class ObjCBlock extends BindingType with HasLocalScope {
       objCAutorelease: !returnsRetained,
       localVariables: closureLocalVars,
     );
-    final convFn = closureLocalVars.isNotEmpty
-        ? '(${_helper.paramsFfiDartType}) {\n'
-              '    ${closureLocalVars.generateDeclarations()}\n'
-              '    return $convFnInvocation;\n'
-              '  }'
-        : '(${_helper.paramsFfiDartType}) => $convFnInvocation';
+    final convFn =
+        '(${_helper.paramsFfiDartType}) {\n'
+        '${closureLocalVars.generateDeclarations(indent: '    ')}'
+        '    return $convFnInvocation;\n'
+        '  }';
 
     // Write the wrapper class.
     s.write('''
@@ -284,12 +283,11 @@ abstract final class $name {
         objCAutorelease: !returnsRetained,
         localVariables: listenerLocalVars,
       );
-      final listenerConvFn = listenerLocalVars.isNotEmpty
-          ? '(${_helper.paramsFfiDartType}) {\n'
-                '    ${listenerLocalVars.generateDeclarations()}\n'
-                '    return $listenerConvFnInvocation;\n'
-                '  }'
-          : '(${_helper.paramsFfiDartType}) => $listenerConvFnInvocation';
+      final listenerConvFn =
+          '(${_helper.paramsFfiDartType}) {\n'
+          '${listenerLocalVars.generateDeclarations(indent: '    ')}'
+          '    return $listenerConvFnInvocation;\n'
+          '  }';
       final wrapListenerFn = _blockWrappers!.listenerWrapper.name;
       final wrapBlockingFn = _blockWrappers!.blockingWrapper.name;
 
@@ -396,13 +394,8 @@ extension $name\$CallExtension on $blockType {
         )
         .join(', ');
 
-    if (callLocalVars.isNotEmpty) {
-      s.write(''' {
-    ${callLocalVars.generateDeclarations()}
-    return ''');
-    } else {
-      s.write(' => ');
-    }
+    s.write(''' {
+${callLocalVars.generateDeclarations(indent: '    ')}    return ''');
 
     final callMethodInvocation =
         '''
@@ -417,9 +410,7 @@ ref.pointer.ref.invoke.cast<${_helper.trampNatFnCType}>()
       ),
     );
     s.write(';\n');
-    if (callLocalVars.isNotEmpty) {
-      s.write('  }\n');
-    }
+    s.write('  }\n');
 
     s.write('}\n\n');
     return BindingString(

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -7,6 +7,7 @@ import '../context.dart';
 import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'binding_string.dart';
+import 'local_variables.dart';
 import 'scope.dart';
 import 'utils.dart';
 import 'writer.dart';
@@ -211,17 +212,30 @@ ${generateInstanceMethodBindings(w, this)}
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
-  }) => ObjCInterface.generateGetId(value, objCRetain, objCAutorelease);
+    required LocalVariables localVariables,
+  }) => ObjCInterface.generateGetId(
+    value,
+    objCRetain,
+    objCAutorelease,
+    localVariables,
+  );
 
   static String generateGetId(
     String value,
     bool objCRetain,
     bool objCAutorelease,
-  ) => objCRetain
-      ? (objCAutorelease
-            ? '$value.ref.retainAndAutorelease()'
-            : '$value.ref.retainAndReturnPointer()')
-      : (objCAutorelease ? '$value.ref.autorelease()' : '$value.ref.pointer');
+    LocalVariables localVariables,
+  ) {
+    if (value.contains('.') || value.contains('(')) {
+      final name = localVariables.addVariable(value: value, nameHint: 'obj');
+      value = name;
+    }
+    return objCRetain
+        ? (objCAutorelease
+              ? '$value.ref.retainAndAutorelease()'
+              : '$value.ref.retainAndReturnPointer()')
+        : (objCAutorelease ? '$value.ref.autorelease()' : '$value.ref.pointer');
+  }
 
   @override
   String convertFfiDartTypeToDartType(

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -227,7 +227,7 @@ ${generateInstanceMethodBindings(w, this)}
     LocalVariables localVariables,
   ) {
     if (value.contains('.') || value.contains('(')) {
-      final name = localVariables.addVariable(value: value, nameHint: 'obj');
+      final name = localVariables.addVariable(value);
       value = name;
     }
     return objCRetain

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -214,6 +214,7 @@ ${generateInstanceMethodBindings(w, this)}
     required bool objCAutorelease,
     required LocalVariables localVariables,
   }) => ObjCInterface.generateGetId(
+    context,
     value,
     objCRetain,
     objCAutorelease,
@@ -221,20 +222,25 @@ ${generateInstanceMethodBindings(w, this)}
   );
 
   static String generateGetId(
+    Context context,
     String value,
     bool objCRetain,
     bool objCAutorelease,
-    LocalVariables localVariables,
-  ) {
-    if (value.contains('.') || value.contains('(')) {
-      final name = localVariables.addVariable(value);
-      value = name;
-    }
-    return objCRetain
+    LocalVariables localVariables, {
+    bool isNullable = false,
+  }) {
+    final dot = isNullable ? '?.' : '.';
+    final fallback = isNullable
+        ? ' ?? ${context.libs.prefix(ffiImport)}.nullptr'
+        : '';
+    final refExpr = '$value${dot}ref';
+    final refName = localVariables.addVariable(refExpr);
+    final method = objCRetain
         ? (objCAutorelease
-              ? '$value.ref.retainAndAutorelease()'
-              : '$value.ref.retainAndReturnPointer()')
-        : (objCAutorelease ? '$value.ref.autorelease()' : '$value.ref.pointer');
+              ? 'retainAndAutorelease()'
+              : 'retainAndReturnPointer()')
+        : (objCAutorelease ? 'autorelease()' : 'pointer');
+    return '$refName$dot$method$fallback';
   }
 
   @override

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -234,7 +234,9 @@ ${generateInstanceMethodBindings(w, this)}
         ? ' ?? ${context.libs.prefix(ffiImport)}.nullptr'
         : '';
     final refExpr = '$value${dot}ref';
-    final refName = localVariables.addVariable(refExpr);
+    // We store object.ref in a local variable to work around a limitation of
+    // Finalizable. See https://dartbug.com/63348 for context.
+    final refName = localVariables.addVariable('ref', refExpr);
     final method = objCRetain
         ? (objCAutorelease
               ? 'retainAndAutorelease()'

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -517,7 +517,7 @@ class ObjCMethod extends AstNode with HasLocalScope {
     s.write(' {\n');
 
     // Emit local variable declarations.
-    s.write(localVars.generateDeclarations(indent: '    '));
+    s.write(localVars.generateDeclarations());
 
     // Implementation.
     final versionCheck = apiAvailability.runtimeCheck(

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -517,9 +517,7 @@ class ObjCMethod extends AstNode with HasLocalScope {
     s.write(' {\n');
 
     // Emit local variable declarations.
-    if (localVars.isNotEmpty) {
-      s.write('    ${localVars.generateDeclarations()}\n');
-    }
+    s.write(localVars.generateDeclarations(indent: '    '));
 
     // Implementation.
     final versionCheck = apiAvailability.runtimeCheck(

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -9,6 +9,7 @@ import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'func.dart';
 import 'imports.dart';
+import 'local_variables.dart';
 import 'native_type.dart';
 import 'objc_block.dart';
 import 'objc_built_in_functions.dart';
@@ -446,10 +447,39 @@ class ObjCMethod extends AstNode with HasLocalScope {
     const finalizableVar = '\$finalizable';
     const errVar = '\$err';
 
-    final s = StringBuffer();
     final targetType = target.getDartType(context);
     final returnTypeStr = _getConvertedReturnType(context, targetType);
     final paramStr = _joinParamStr(context, params);
+
+    final localVars = LocalVariables(localScope);
+
+    // Evaluate targetStr and msgSendParams first to populate localVars.
+    late String targetStr;
+    if (isClassMethod) {
+      targetStr = (target as ObjCInterface).classObject.name;
+    } else {
+      targetStr = target.convertDartTypeToFfiDartType(
+        context,
+        'object\$',
+        objCRetain: consumesSelf,
+        objCAutorelease: false,
+        localVariables: localVars,
+      );
+    }
+
+    final msgSendParams = [
+      for (final p in params)
+        p.type.convertDartTypeToFfiDartType(
+          context,
+          p.name,
+          objCRetain: p.objCConsumed,
+          objCAutorelease: false,
+          localVariables: localVars,
+        ),
+      if (throwNSError) errVar,
+    ];
+
+    final s = StringBuffer();
 
     // The method declaration.
     final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
@@ -458,9 +488,8 @@ class ObjCMethod extends AstNode with HasLocalScope {
       s.write('  $deprecatedAnnotation\n');
     }
     s.write('  ');
-    late String targetStr;
+
     if (isClassMethod) {
-      targetStr = (target as ObjCInterface).classObject.name;
       switch (kind) {
         case ObjCMethodKind.method:
           s.write('static $returnTypeStr $methodName($paramStr)');
@@ -473,12 +502,6 @@ class ObjCMethod extends AstNode with HasLocalScope {
           break;
       }
     } else {
-      targetStr = target.convertDartTypeToFfiDartType(
-        context,
-        'object\$',
-        objCRetain: consumesSelf,
-        objCAutorelease: false,
-      );
       switch (kind) {
         case ObjCMethodKind.method:
           s.write('$returnTypeStr $methodName($paramStr)');
@@ -492,6 +515,11 @@ class ObjCMethod extends AstNode with HasLocalScope {
       }
     }
     s.write(' {\n');
+
+    // Emit local variable declarations.
+    if (localVars.isNotEmpty) {
+      s.write('    ${localVars.generateDeclarations()}\n');
+    }
 
     // Implementation.
     final versionCheck = apiAvailability.runtimeCheck(
@@ -527,16 +555,6 @@ class ObjCMethod extends AstNode with HasLocalScope {
     final convertReturn =
         kind != ObjCMethodKind.propertySetter &&
         !returnType.sameDartAndFfiDartType;
-    final msgSendParams = [
-      for (final p in params)
-        p.type.convertDartTypeToFfiDartType(
-          context,
-          p.name,
-          objCRetain: p.objCConsumed,
-          objCAutorelease: false,
-        ),
-      if (throwNSError) errVar,
-    ];
 
     if (msgSend!.isStret) {
       assert(!convertReturn);

--- a/pkgs/ffigen/lib/src/code_generator/objc_nullable.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_nullable.dart
@@ -61,24 +61,14 @@ class ObjCNullable extends Type {
     required bool objCRetain,
     required bool objCAutorelease,
     required LocalVariables localVariables,
-  }) {
-    if (value.contains('.') || value.contains('(')) {
-      final name = localVariables.addVariable(value);
-      value = name;
-    }
-    // Just appending `?` to `value` like this is a bit of a hack, but works for
-    // all the types that are allowed to be a child type. If we add more allowed
-    // child types, we may have to start special casing each type. For example,
-    // `value.pointer` becomes `value?.pointer ?? nullptr`.
-    final convertedValue = child.convertDartTypeToFfiDartType(
-      context,
-      '$value?',
-      objCRetain: objCRetain,
-      objCAutorelease: objCAutorelease,
-      localVariables: localVariables,
-    );
-    return '$convertedValue ?? ${context.libs.prefix(ffiImport)}.nullptr';
-  }
+  }) => ObjCInterface.generateGetId(
+    context,
+    value,
+    objCRetain,
+    objCAutorelease,
+    localVariables,
+    isNullable: true,
+  );
 
   @override
   String convertFfiDartTypeToDartType(

--- a/pkgs/ffigen/lib/src/code_generator/objc_nullable.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_nullable.dart
@@ -63,10 +63,7 @@ class ObjCNullable extends Type {
     required LocalVariables localVariables,
   }) {
     if (value.contains('.') || value.contains('(')) {
-      final name = localVariables.addVariable(
-        value: value,
-        nameHint: 'nullableObj',
-      );
+      final name = localVariables.addVariable(value);
       value = name;
     }
     // Just appending `?` to `value` like this is a bit of a hack, but works for

--- a/pkgs/ffigen/lib/src/code_generator/objc_nullable.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_nullable.dart
@@ -5,6 +5,7 @@
 import '../code_generator.dart';
 import '../context.dart';
 import '../visitor/ast.dart';
+import 'local_variables.dart';
 
 /// An ObjC type annotated with nullable. Eg:
 /// +(nullable NSObject*) methodWithNullableResult;
@@ -59,7 +60,15 @@ class ObjCNullable extends Type {
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
+    required LocalVariables localVariables,
   }) {
+    if (value.contains('.') || value.contains('(')) {
+      final name = localVariables.addVariable(
+        value: value,
+        nameHint: 'nullableObj',
+      );
+      value = name;
+    }
     // Just appending `?` to `value` like this is a bit of a hack, but works for
     // all the types that are allowed to be a child type. If we add more allowed
     // child types, we may have to start special casing each type. For example,
@@ -69,6 +78,7 @@ class ObjCNullable extends Type {
       '$value?',
       objCRetain: objCRetain,
       objCAutorelease: objCAutorelease,
+      localVariables: localVariables,
     );
     return '$convertedValue ?? ${context.libs.prefix(ffiImport)}.nullptr';
   }

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -7,6 +7,7 @@ import '../context.dart';
 import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'binding_string.dart';
+import 'local_variables.dart';
 import 'scope.dart';
 import 'utils.dart';
 import 'writer.dart';
@@ -375,7 +376,13 @@ Protocol* _${libraryId}_$originalName(void) { return @protocol($originalName); }
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
-  }) => ObjCInterface.generateGetId(value, objCRetain, objCAutorelease);
+    required LocalVariables localVariables,
+  }) => ObjCInterface.generateGetId(
+    value,
+    objCRetain,
+    objCAutorelease,
+    localVariables,
+  );
 
   @override
   String convertFfiDartTypeToDartType(

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -378,6 +378,7 @@ Protocol* _${libraryId}_$originalName(void) { return @protocol($originalName); }
     required bool objCAutorelease,
     required LocalVariables localVariables,
   }) => ObjCInterface.generateGetId(
+    context,
     value,
     objCRetain,
     objCAutorelease,

--- a/pkgs/ffigen/lib/src/code_generator/pointer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/pointer.dart
@@ -5,6 +5,7 @@
 import '../code_generator.dart';
 import '../context.dart';
 import '../visitor/ast.dart';
+import 'local_variables.dart';
 
 /// Represents a pointer.
 class PointerType extends Type {
@@ -142,7 +143,13 @@ class ObjCObjectPointer extends PointerType {
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
-  }) => ObjCInterface.generateGetId(value, objCRetain, objCAutorelease);
+    required LocalVariables localVariables,
+  }) => ObjCInterface.generateGetId(
+    value,
+    objCRetain,
+    objCAutorelease,
+    localVariables,
+  );
 
   @override
   String convertFfiDartTypeToDartType(

--- a/pkgs/ffigen/lib/src/code_generator/pointer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/pointer.dart
@@ -145,6 +145,7 @@ class ObjCObjectPointer extends PointerType {
     required bool objCAutorelease,
     required LocalVariables localVariables,
   }) => ObjCInterface.generateGetId(
+    context,
     value,
     objCRetain,
     objCAutorelease,

--- a/pkgs/ffigen/lib/src/code_generator/type.dart
+++ b/pkgs/ffigen/lib/src/code_generator/type.dart
@@ -5,6 +5,7 @@
 import '../code_generator.dart';
 import '../context.dart';
 import '../visitor/ast.dart';
+import 'local_variables.dart';
 import 'scope.dart';
 
 /// Type class for return types, variable types, etc.
@@ -93,6 +94,7 @@ abstract class Type extends AstNode {
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
+    required LocalVariables localVariables,
   }) => value;
 
   /// Returns generated Dart code that converts the given value from its
@@ -217,6 +219,7 @@ abstract class BindingType extends NoLookUpBinding implements Type {
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
+    required LocalVariables localVariables,
   }) => value;
 
   @override

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -7,6 +7,7 @@ import '../context.dart';
 import '../strings.dart' as strings;
 import '../visitor/ast.dart';
 import 'binding_string.dart';
+import 'local_variables.dart';
 import 'scope.dart';
 import 'utils.dart';
 import 'writer.dart';
@@ -183,11 +184,13 @@ class Typealias extends BindingType {
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
+    required LocalVariables localVariables,
   }) => type.convertDartTypeToFfiDartType(
     context,
     value,
     objCRetain: objCRetain,
     objCAutorelease: objCAutorelease,
+    localVariables: localVariables,
   );
 
   @override
@@ -249,7 +252,13 @@ class ObjCInstanceType extends Typealias {
     String value, {
     required bool objCRetain,
     required bool objCAutorelease,
-  }) => ObjCInterface.generateGetId(value, objCRetain, objCAutorelease);
+    required LocalVariables localVariables,
+  }) => ObjCInterface.generateGetId(
+    value,
+    objCRetain,
+    objCAutorelease,
+    localVariables,
+  );
 
   @override
   String convertFfiDartTypeToDartType(

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -254,6 +254,7 @@ class ObjCInstanceType extends Typealias {
     required bool objCAutorelease,
     required LocalVariables localVariables,
   }) => ObjCInterface.generateGetId(
+    context,
     value,
     objCRetain,
     objCAutorelease,

--- a/pkgs/ffigen/test/native_objc_test/arc_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/arc_test_bindings.dart
@@ -70,15 +70,13 @@ extension type ArcDtorTestObject._(objc.ObjCObject object$)
 extension ArcDtorTestObject$Methods on ArcDtorTestObject {
   /// init
   ArcDtorTestObject init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'ArcDtorTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return ArcDtorTestObject.fromPointer($ret, retain: false, release: true);
   }
 
@@ -87,8 +85,9 @@ extension ArcDtorTestObject$Methods on ArcDtorTestObject {
     ffi.Pointer<ffi.Int32> _dtorCounter, {
     required ffi.Pointer<ffi.Int32> onMainThread,
   }) {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_b5hsh3(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithCounters_onMainThread_,
       _dtorCounter,
       onMainThread,
@@ -150,10 +149,11 @@ extension type ArcTestObject._(objc.ObjCObject object$)
 
   /// consumeArg:
   static void consumeArg(ArcTestObject arg) {
+    final _$$ = arg.ref;
     _objc_msgSend_4js6t(
       _class_ArcTestObject,
       _sel_consumeArg_,
-      arg.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
     );
   }
 
@@ -190,41 +190,37 @@ extension type ArcTestObject._(objc.ObjCObject object$)
 extension ArcTestObject$Methods on ArcTestObject {
   /// assignedProperty
   ArcTestObject get assignedProperty {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_assignedProperty,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_assignedProperty);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copiedProperty
   ArcTestObject get copiedProperty {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_copiedProperty,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copiedProperty);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyMe
   ArcTestObject copyMe() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_copyMe);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMe);
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// copyMeAutorelease
   ArcTestObject copyMeAutorelease() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_copyMeAutorelease,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMeAutorelease);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyMeConsumeSelf
   ArcTestObject copyMeConsumeSelf() {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_copyMeConsumeSelf,
     );
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
@@ -232,37 +228,34 @@ extension ArcTestObject$Methods on ArcTestObject {
 
   /// copyMeNoRetain
   ArcTestObject copyMeNoRetain() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_copyMeNoRetain,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMeNoRetain);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyWithZone:
   objc.ObjCObject copyWithZone$1(ffi.Pointer<objc.NSZone> zone) {
-    final $ret = _objc_msgSend_1cwp428(
-      object$.ref.pointer,
-      _sel_copyWithZone_,
-      zone,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_1cwp428(_$$.pointer, _sel_copyWithZone_, zone);
     return objc.ObjCObject($ret, retain: false, release: true);
   }
 
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_dealloc);
+    final _$$ = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
   }
 
   /// init
   ArcTestObject init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'ArcTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
@@ -270,8 +263,9 @@ extension ArcTestObject$Methods on ArcTestObject {
 
   /// initWithCounter:
   ArcTestObject initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );
@@ -280,58 +274,50 @@ extension ArcTestObject$Methods on ArcTestObject {
 
   /// mutableCopyMe
   ArcTestObject mutableCopyMe() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_mutableCopyMe);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_mutableCopyMe);
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// retainedProperty
   ArcTestObject get retainedProperty {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_retainedProperty,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_retainedProperty);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// returnsRetained
   ArcTestObject returnsRetained() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_returnsRetained,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_returnsRetained);
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// setAssignedProperty:
   set assignedProperty(ArcTestObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setAssignedProperty_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setAssignedProperty_, _$$$1.pointer);
   }
 
   /// setCopiedProperty:
   set copiedProperty(ArcTestObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setCopiedProperty_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setCopiedProperty_, _$$$1.pointer);
   }
 
   /// setCounter:
   void setCounter(ffi.Pointer<ffi.Int32> _counter) {
-    _objc_msgSend_yhkuco(object$.ref.pointer, _sel_setCounter_, _counter);
+    final _$$ = object$.ref;
+    _objc_msgSend_yhkuco(_$$.pointer, _sel_setCounter_, _counter);
   }
 
   /// setRetainedProperty:
   set retainedProperty(ArcTestObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setRetainedProperty_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setRetainedProperty_, _$$$1.pointer);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/arc_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/arc_test_bindings.dart
@@ -70,13 +70,16 @@ extension type ArcDtorTestObject._(objc.ObjCObject object$)
 extension ArcDtorTestObject$Methods on ArcDtorTestObject {
   /// init
   ArcDtorTestObject init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'ArcDtorTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return ArcDtorTestObject.fromPointer($ret, retain: false, release: true);
   }
 
@@ -85,9 +88,9 @@ extension ArcDtorTestObject$Methods on ArcDtorTestObject {
     ffi.Pointer<ffi.Int32> _dtorCounter, {
     required ffi.Pointer<ffi.Int32> onMainThread,
   }) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_b5hsh3(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCounters_onMainThread_,
       _dtorCounter,
       onMainThread,
@@ -149,11 +152,11 @@ extension type ArcTestObject._(objc.ObjCObject object$)
 
   /// consumeArg:
   static void consumeArg(ArcTestObject arg) {
-    final _$$ = arg.ref;
+    final _$$ref = arg.ref;
     _objc_msgSend_4js6t(
       _class_ArcTestObject,
       _sel_consumeArg_,
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
     );
   }
 
@@ -190,37 +193,37 @@ extension type ArcTestObject._(objc.ObjCObject object$)
 extension ArcTestObject$Methods on ArcTestObject {
   /// assignedProperty
   ArcTestObject get assignedProperty {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_assignedProperty);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_assignedProperty);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copiedProperty
   ArcTestObject get copiedProperty {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copiedProperty);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copiedProperty);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyMe
   ArcTestObject copyMe() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMe);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copyMe);
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// copyMeAutorelease
   ArcTestObject copyMeAutorelease() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMeAutorelease);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copyMeAutorelease);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyMeConsumeSelf
   ArcTestObject copyMeConsumeSelf() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_copyMeConsumeSelf,
     );
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
@@ -228,34 +231,38 @@ extension ArcTestObject$Methods on ArcTestObject {
 
   /// copyMeNoRetain
   ArcTestObject copyMeNoRetain() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMeNoRetain);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copyMeNoRetain);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyWithZone:
   objc.ObjCObject copyWithZone$1(ffi.Pointer<objc.NSZone> zone) {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_1cwp428(_$$.pointer, _sel_copyWithZone_, zone);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_1cwp428(
+      _$$ref.pointer,
+      _sel_copyWithZone_,
+      zone,
+    );
     return objc.ObjCObject($ret, retain: false, release: true);
   }
 
   /// dealloc
   void dealloc() {
-    final _$$ = object$.ref;
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_dealloc);
   }
 
   /// init
   ArcTestObject init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'ArcTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
@@ -263,9 +270,9 @@ extension ArcTestObject$Methods on ArcTestObject {
 
   /// initWithCounter:
   ArcTestObject initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );
@@ -274,50 +281,62 @@ extension ArcTestObject$Methods on ArcTestObject {
 
   /// mutableCopyMe
   ArcTestObject mutableCopyMe() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_mutableCopyMe);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_mutableCopyMe);
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// retainedProperty
   ArcTestObject get retainedProperty {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_retainedProperty);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_retainedProperty);
     return ArcTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// returnsRetained
   ArcTestObject returnsRetained() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_returnsRetained);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_returnsRetained);
     return ArcTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// setAssignedProperty:
   set assignedProperty(ArcTestObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setAssignedProperty_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_setAssignedProperty_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// setCopiedProperty:
   set copiedProperty(ArcTestObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setCopiedProperty_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_setCopiedProperty_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// setCounter:
   void setCounter(ffi.Pointer<ffi.Int32> _counter) {
-    final _$$ = object$.ref;
-    _objc_msgSend_yhkuco(_$$.pointer, _sel_setCounter_, _counter);
+    final _$$ref = object$.ref;
+    _objc_msgSend_yhkuco(_$$ref.pointer, _sel_setCounter_, _counter);
   }
 
   /// setRetainedProperty:
   set retainedProperty(ArcTestObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setRetainedProperty_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_setRetainedProperty_,
+      _$$ref$1.pointer,
+    );
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/bad_method_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_method_test_bindings.dart
@@ -61,49 +61,37 @@ extension type BadMethodTestObject._(objc.ObjCObject object$)
 extension BadMethodTestObject$Methods on BadMethodTestObject {
   /// bitFieldPointerParam:
   int bitFieldPointerParam(ffi.Pointer<BitField> x) {
-    return _objc_msgSend_zol7v(
-      object$.ref.pointer,
-      _sel_bitFieldPointerParam_,
-      x,
-    );
+    final _$$ = object$.ref;
+    return _objc_msgSend_zol7v(_$$.pointer, _sel_bitFieldPointerParam_, x);
   }
 
   /// bitFieldPointerReturn
   ffi.Pointer<BitField> bitFieldPointerReturn() {
-    return _objc_msgSend_hic16b(
-      object$.ref.pointer,
-      _sel_bitFieldPointerReturn,
-    );
+    final _$$ = object$.ref;
+    return _objc_msgSend_hic16b(_$$.pointer, _sel_bitFieldPointerReturn);
   }
 
   /// incompletePointerParam:
   int incompletePointerParam(ffi.Pointer<IncompleteStruct> x) {
-    return _objc_msgSend_1onbdcj(
-      object$.ref.pointer,
-      _sel_incompletePointerParam_,
-      x,
-    );
+    final _$$ = object$.ref;
+    return _objc_msgSend_1onbdcj(_$$.pointer, _sel_incompletePointerParam_, x);
   }
 
   /// incompletePointerReturn
   ffi.Pointer<IncompleteStruct> incompletePointerReturn() {
-    return _objc_msgSend_17u7wb(
-      object$.ref.pointer,
-      _sel_incompletePointerReturn,
-    );
+    final _$$ = object$.ref;
+    return _objc_msgSend_17u7wb(_$$.pointer, _sel_incompletePointerReturn);
   }
 
   /// init
   BadMethodTestObject init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'BadMethodTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return BadMethodTestObject.fromPointer($ret, retain: false, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/bad_method_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_method_test_bindings.dart
@@ -61,37 +61,44 @@ extension type BadMethodTestObject._(objc.ObjCObject object$)
 extension BadMethodTestObject$Methods on BadMethodTestObject {
   /// bitFieldPointerParam:
   int bitFieldPointerParam(ffi.Pointer<BitField> x) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_zol7v(_$$.pointer, _sel_bitFieldPointerParam_, x);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_zol7v(_$$ref.pointer, _sel_bitFieldPointerParam_, x);
   }
 
   /// bitFieldPointerReturn
   ffi.Pointer<BitField> bitFieldPointerReturn() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_hic16b(_$$.pointer, _sel_bitFieldPointerReturn);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_hic16b(_$$ref.pointer, _sel_bitFieldPointerReturn);
   }
 
   /// incompletePointerParam:
   int incompletePointerParam(ffi.Pointer<IncompleteStruct> x) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1onbdcj(_$$.pointer, _sel_incompletePointerParam_, x);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1onbdcj(
+      _$$ref.pointer,
+      _sel_incompletePointerParam_,
+      x,
+    );
   }
 
   /// incompletePointerReturn
   ffi.Pointer<IncompleteStruct> incompletePointerReturn() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_17u7wb(_$$.pointer, _sel_incompletePointerReturn);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_17u7wb(_$$ref.pointer, _sel_incompletePointerReturn);
   }
 
   /// init
   BadMethodTestObject init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'BadMethodTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return BadMethodTestObject.fromPointer($ret, retain: false, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/bad_override_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_test_bindings.dart
@@ -61,15 +61,13 @@ extension type BadOverrideAunt._(objc.ObjCObject object$)
 extension BadOverrideAunt$Methods on BadOverrideAunt {
   /// init
   BadOverrideAunt init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideAunt.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return BadOverrideAunt.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -129,32 +127,33 @@ extension type BadOverrideChild._(objc.ObjCObject object$)
 extension BadOverrideChild$Methods on BadOverrideChild {
   /// contravariantReturn
   Polygon contravariantReturn() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_contravariantReturn,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_contravariantReturn);
     return Polygon.fromPointer($ret, retain: true, release: true);
   }
 
   /// covariantArg:
   objc.NSString covariantArg(Rectangle rect) {
+    final _$$ = object$.ref;
+    final _$$$1 = rect.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_covariantArg_,
-      rect.ref.pointer,
+      _$$$1.pointer,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BadOverrideChild init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideChild.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideChild.fromPointer($ret, retain: false, release: true);
@@ -162,7 +161,8 @@ extension BadOverrideChild$Methods on BadOverrideChild {
 
   /// methodVsGetter
   int get methodVsGetter {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_methodVsGetter);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -236,13 +236,14 @@ extension type BadOverrideGrandchild._(objc.ObjCObject object$)
 extension BadOverrideGrandchild$Methods on BadOverrideGrandchild {
   /// init
   BadOverrideGrandchild init() {
+    final _$$$2 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideGrandchild.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideGrandchild.fromPointer(
@@ -254,7 +255,8 @@ extension BadOverrideGrandchild$Methods on BadOverrideGrandchild {
 
   /// methodVsGetter
   int get methodVsGetter {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_methodVsGetter);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -328,13 +330,14 @@ extension type BadOverrideGrandparent._(objc.ObjCObject object$)
 extension BadOverrideGrandparent$Methods on BadOverrideGrandparent {
   /// init
   BadOverrideGrandparent init() {
+    final _$$$3 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideGrandparent.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$3.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideGrandparent.fromPointer(
@@ -400,32 +403,33 @@ extension type BadOverrideParent._(objc.ObjCObject object$)
 extension BadOverrideParent$Methods on BadOverrideParent {
   /// contravariantReturn
   Polygon contravariantReturn() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_contravariantReturn,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_contravariantReturn);
     return Polygon.fromPointer($ret, retain: true, release: true);
   }
 
   /// covariantArg:
   objc.NSString covariantArg(Polygon poly) {
+    final _$$ = object$.ref;
+    final _$$$1 = poly.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_covariantArg_,
-      poly.ref.pointer,
+      _$$$1.pointer,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BadOverrideParent init() {
+    final _$$$4 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideParent.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$4.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideParent.fromPointer($ret, retain: false, release: true);
@@ -433,7 +437,8 @@ extension BadOverrideParent$Methods on BadOverrideParent {
 
   /// methodVsGetter
   int get methodVsGetter {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_methodVsGetter);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -492,13 +497,14 @@ extension type BadOverrideSibbling._(objc.ObjCObject object$)
 extension BadOverrideSibbling$Methods on BadOverrideSibbling {
   /// init
   BadOverrideSibbling init() {
+    final _$$$5 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideSibbling.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$5.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideSibbling.fromPointer($ret, retain: false, release: true);
@@ -506,7 +512,8 @@ extension BadOverrideSibbling$Methods on BadOverrideSibbling {
 
   /// methodVsGetter
   int get methodVsGetter {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_methodVsGetter);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -565,13 +572,14 @@ extension type BadOverrideUncle._(objc.ObjCObject object$)
 extension BadOverrideUncle$Methods on BadOverrideUncle {
   /// init
   BadOverrideUncle init() {
+    final _$$$6 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideUncle.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$6.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideUncle.fromPointer($ret, retain: false, release: true);
@@ -579,7 +587,8 @@ extension BadOverrideUncle$Methods on BadOverrideUncle {
 
   /// methodVsGetter
   int methodVsGetter() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_methodVsGetter);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -638,13 +647,14 @@ extension type Polygon._(objc.ObjCObject object$)
 extension Polygon$Methods on Polygon {
   /// init
   Polygon init() {
+    final _$$$7 = object$.ref;
     objc.checkOsVersionInternal(
       'Polygon.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$7.retainAndReturnPointer(),
       _sel_init,
     );
     return Polygon.fromPointer($ret, retain: false, release: true);
@@ -652,7 +662,8 @@ extension Polygon$Methods on Polygon {
 
   /// name
   objc.NSString name() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_name);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -712,13 +723,14 @@ extension type Rectangle._(objc.ObjCObject object$)
 extension Rectangle$Methods on Rectangle {
   /// init
   Rectangle init() {
+    final _$$$8 = object$.ref;
     objc.checkOsVersionInternal(
       'Rectangle.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$8.retainAndReturnPointer(),
       _sel_init,
     );
     return Rectangle.fromPointer($ret, retain: false, release: true);
@@ -726,7 +738,8 @@ extension Rectangle$Methods on Rectangle {
 
   /// name
   objc.NSString name() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_name);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -786,13 +799,14 @@ extension type Square._(objc.ObjCObject object$)
 extension Square$Methods on Square {
   /// init
   Square init() {
+    final _$$$9 = object$.ref;
     objc.checkOsVersionInternal(
       'Square.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$9.retainAndReturnPointer(),
       _sel_init,
     );
     return Square.fromPointer($ret, retain: false, release: true);
@@ -800,7 +814,8 @@ extension Square$Methods on Square {
 
   /// name
   objc.NSString name() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_name);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -860,13 +875,14 @@ extension type Triangle._(objc.ObjCObject object$)
 extension Triangle$Methods on Triangle {
   /// init
   Triangle init() {
+    final _$$$10 = object$.ref;
     objc.checkOsVersionInternal(
       'Triangle.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$10.retainAndReturnPointer(),
       _sel_init,
     );
     return Triangle.fromPointer($ret, retain: false, release: true);
@@ -874,7 +890,8 @@ extension Triangle$Methods on Triangle {
 
   /// name
   objc.NSString name() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_name);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/bad_override_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_test_bindings.dart
@@ -61,13 +61,16 @@ extension type BadOverrideAunt._(objc.ObjCObject object$)
 extension BadOverrideAunt$Methods on BadOverrideAunt {
   /// init
   BadOverrideAunt init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideAunt.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return BadOverrideAunt.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -127,33 +130,36 @@ extension type BadOverrideChild._(objc.ObjCObject object$)
 extension BadOverrideChild$Methods on BadOverrideChild {
   /// contravariantReturn
   Polygon contravariantReturn() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_contravariantReturn);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.pointer,
+      _sel_contravariantReturn,
+    );
     return Polygon.fromPointer($ret, retain: true, release: true);
   }
 
   /// covariantArg:
   objc.NSString covariantArg(Rectangle rect) {
-    final _$$ = object$.ref;
-    final _$$$1 = rect.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = rect.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_covariantArg_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BadOverrideChild init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideChild.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideChild.fromPointer($ret, retain: false, release: true);
@@ -161,8 +167,8 @@ extension BadOverrideChild$Methods on BadOverrideChild {
 
   /// methodVsGetter
   int get methodVsGetter {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -236,14 +242,14 @@ extension type BadOverrideGrandchild._(objc.ObjCObject object$)
 extension BadOverrideGrandchild$Methods on BadOverrideGrandchild {
   /// init
   BadOverrideGrandchild init() {
-    final _$$$2 = object$.ref;
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideGrandchild.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideGrandchild.fromPointer(
@@ -255,8 +261,8 @@ extension BadOverrideGrandchild$Methods on BadOverrideGrandchild {
 
   /// methodVsGetter
   int get methodVsGetter {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -330,14 +336,14 @@ extension type BadOverrideGrandparent._(objc.ObjCObject object$)
 extension BadOverrideGrandparent$Methods on BadOverrideGrandparent {
   /// init
   BadOverrideGrandparent init() {
-    final _$$$3 = object$.ref;
+    final _$$ref$3 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideGrandparent.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$3.retainAndReturnPointer(),
+      _$$ref$3.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideGrandparent.fromPointer(
@@ -403,33 +409,36 @@ extension type BadOverrideParent._(objc.ObjCObject object$)
 extension BadOverrideParent$Methods on BadOverrideParent {
   /// contravariantReturn
   Polygon contravariantReturn() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_contravariantReturn);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.pointer,
+      _sel_contravariantReturn,
+    );
     return Polygon.fromPointer($ret, retain: true, release: true);
   }
 
   /// covariantArg:
   objc.NSString covariantArg(Polygon poly) {
-    final _$$ = object$.ref;
-    final _$$$1 = poly.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = poly.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_covariantArg_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BadOverrideParent init() {
-    final _$$$4 = object$.ref;
+    final _$$ref$4 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideParent.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$4.retainAndReturnPointer(),
+      _$$ref$4.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideParent.fromPointer($ret, retain: false, release: true);
@@ -437,8 +446,8 @@ extension BadOverrideParent$Methods on BadOverrideParent {
 
   /// methodVsGetter
   int get methodVsGetter {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -497,14 +506,14 @@ extension type BadOverrideSibbling._(objc.ObjCObject object$)
 extension BadOverrideSibbling$Methods on BadOverrideSibbling {
   /// init
   BadOverrideSibbling init() {
-    final _$$$5 = object$.ref;
+    final _$$ref$5 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideSibbling.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$5.retainAndReturnPointer(),
+      _$$ref$5.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideSibbling.fromPointer($ret, retain: false, release: true);
@@ -512,8 +521,8 @@ extension BadOverrideSibbling$Methods on BadOverrideSibbling {
 
   /// methodVsGetter
   int get methodVsGetter {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -572,14 +581,14 @@ extension type BadOverrideUncle._(objc.ObjCObject object$)
 extension BadOverrideUncle$Methods on BadOverrideUncle {
   /// init
   BadOverrideUncle init() {
-    final _$$$6 = object$.ref;
+    final _$$ref$6 = object$.ref;
     objc.checkOsVersionInternal(
       'BadOverrideUncle.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$6.retainAndReturnPointer(),
+      _$$ref$6.retainAndReturnPointer(),
       _sel_init,
     );
     return BadOverrideUncle.fromPointer($ret, retain: false, release: true);
@@ -587,8 +596,8 @@ extension BadOverrideUncle$Methods on BadOverrideUncle {
 
   /// methodVsGetter
   int methodVsGetter() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_methodVsGetter);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_methodVsGetter);
   }
 }
 
@@ -647,14 +656,14 @@ extension type Polygon._(objc.ObjCObject object$)
 extension Polygon$Methods on Polygon {
   /// init
   Polygon init() {
-    final _$$$7 = object$.ref;
+    final _$$ref$7 = object$.ref;
     objc.checkOsVersionInternal(
       'Polygon.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$7.retainAndReturnPointer(),
+      _$$ref$7.retainAndReturnPointer(),
       _sel_init,
     );
     return Polygon.fromPointer($ret, retain: false, release: true);
@@ -662,8 +671,8 @@ extension Polygon$Methods on Polygon {
 
   /// name
   objc.NSString name() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_name);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -723,14 +732,14 @@ extension type Rectangle._(objc.ObjCObject object$)
 extension Rectangle$Methods on Rectangle {
   /// init
   Rectangle init() {
-    final _$$$8 = object$.ref;
+    final _$$ref$8 = object$.ref;
     objc.checkOsVersionInternal(
       'Rectangle.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$8.retainAndReturnPointer(),
+      _$$ref$8.retainAndReturnPointer(),
       _sel_init,
     );
     return Rectangle.fromPointer($ret, retain: false, release: true);
@@ -738,8 +747,8 @@ extension Rectangle$Methods on Rectangle {
 
   /// name
   objc.NSString name() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_name);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -799,14 +808,14 @@ extension type Square._(objc.ObjCObject object$)
 extension Square$Methods on Square {
   /// init
   Square init() {
-    final _$$$9 = object$.ref;
+    final _$$ref$9 = object$.ref;
     objc.checkOsVersionInternal(
       'Square.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$9.retainAndReturnPointer(),
+      _$$ref$9.retainAndReturnPointer(),
       _sel_init,
     );
     return Square.fromPointer($ret, retain: false, release: true);
@@ -814,8 +823,8 @@ extension Square$Methods on Square {
 
   /// name
   objc.NSString name() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_name);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -875,14 +884,14 @@ extension type Triangle._(objc.ObjCObject object$)
 extension Triangle$Methods on Triangle {
   /// init
   Triangle init() {
-    final _$$$10 = object$.ref;
+    final _$$ref$10 = object$.ref;
     objc.checkOsVersionInternal(
       'Triangle.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$10.retainAndReturnPointer(),
+      _$$ref$10.retainAndReturnPointer(),
       _sel_init,
     );
     return Triangle.fromPointer($ret, retain: false, release: true);
@@ -890,8 +899,8 @@ extension Triangle$Methods on Triangle {
 
   /// name
   objc.NSString name() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_name);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/block_annotation_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_annotation_test_bindings.dart
@@ -1652,26 +1652,27 @@ extension ObjCBlock_EmptyBlock_ffiVoid$CallExtension
         objc.ObjCBlock<
           objc.ObjCBlock<ffi.Void Function()> Function(ffi.Pointer<ffi.Void>)
         > {
-  DartEmptyBlock call(ffi.Pointer<ffi.Void> arg0) =>
-      ObjCBlock_ffiVoid.fromPointer(
-        ref.pointer.ref.invoke
-            .cast<
-              ffi.NativeFunction<
-                EmptyBlock Function(
-                  ffi.Pointer<objc.ObjCBlockImpl> block,
-                  ffi.Pointer<ffi.Void> arg0,
-                )
-              >
-            >()
-            .asFunction<
+  DartEmptyBlock call(ffi.Pointer<ffi.Void> arg0) {
+    return ObjCBlock_ffiVoid.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
               EmptyBlock Function(
-                ffi.Pointer<objc.ObjCBlockImpl>,
-                ffi.Pointer<ffi.Void>,
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
               )
-            >()(ref.pointer, arg0),
-        retain: true,
-        release: true,
-      );
+            >
+          >()
+          .asFunction<
+            EmptyBlock Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+            )
+          >()(ref.pointer, arg0),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<objc.Retained<objc.ObjCBlock<ffi.Void Function()>> Function(ffi.Pointer<ffi.Void>)>`.
@@ -1789,26 +1790,27 @@ extension ObjCBlock_EmptyBlock_ffiVoid$1$CallExtension
             ffi.Pointer<ffi.Void>,
           )
         > {
-  DartEmptyBlock call(ffi.Pointer<ffi.Void> arg0) =>
-      ObjCBlock_ffiVoid.fromPointer(
-        ref.pointer.ref.invoke
-            .cast<
-              ffi.NativeFunction<
-                EmptyBlock Function(
-                  ffi.Pointer<objc.ObjCBlockImpl> block,
-                  ffi.Pointer<ffi.Void> arg0,
-                )
-              >
-            >()
-            .asFunction<
+  DartEmptyBlock call(ffi.Pointer<ffi.Void> arg0) {
+    return ObjCBlock_ffiVoid.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
               EmptyBlock Function(
-                ffi.Pointer<objc.ObjCBlockImpl>,
-                ffi.Pointer<ffi.Void>,
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
               )
-            >()(ref.pointer, arg0),
-        retain: false,
-        release: true,
-      );
+            >
+          >()
+          .asFunction<
+            EmptyBlock Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+            )
+          >()(ref.pointer, arg0),
+      retain: false,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)>`.
@@ -1906,25 +1908,27 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid {
 /// Call operator for `objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)>`.
 extension ObjCBlock_EmptyObject_ffiVoid$CallExtension
     on objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)> {
-  EmptyObject call(ffi.Pointer<ffi.Void> arg0) => EmptyObject.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  EmptyObject call(ffi.Pointer<ffi.Void> arg0) {
+    return EmptyObject.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >()(ref.pointer, arg0),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<objc.Retained<EmptyObject> Function(ffi.Pointer<ffi.Void>)>`.
@@ -2036,25 +2040,27 @@ extension ObjCBlock_EmptyObject_ffiVoid$1$CallExtension
         objc.ObjCBlock<
           objc.Retained<EmptyObject> Function(ffi.Pointer<ffi.Void>)
         > {
-  EmptyObject call(ffi.Pointer<ffi.Void> arg0) => EmptyObject.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  EmptyObject call(ffi.Pointer<ffi.Void> arg0) {
+    return EmptyObject.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >()(ref.pointer, arg0),
-    retain: false,
-    release: true,
-  );
+          >()(ref.pointer, arg0),
+      retain: false,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)>`.
@@ -2183,28 +2189,29 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$CallExtension
         objc.ObjCBlock<
           EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)
         > {
-  EmptyObject call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) =>
-      EmptyObject.fromPointer(
-        ref.pointer.ref.invoke
-            .cast<
-              ffi.NativeFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl> block,
-                  ffi.Pointer<ffi.Void> arg0,
-                  ffi.Pointer<objc.ObjCObjectImpl> arg1,
-                )
-              >
-            >()
-            .asFunction<
+  EmptyObject call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
+    return EmptyObject.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
               ffi.Pointer<objc.ObjCObjectImpl> Function(
-                ffi.Pointer<objc.ObjCBlockImpl>,
-                ffi.Pointer<ffi.Void>,
-                ffi.Pointer<objc.ObjCObjectImpl>,
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+                ffi.Pointer<objc.ObjCObjectImpl> arg1,
               )
-            >()(ref.pointer, arg0, arg1.ref.pointer),
-        retain: true,
-        release: true,
-      );
+            >
+          >()
+          .asFunction<
+            ffi.Pointer<objc.ObjCObjectImpl> Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
+            )
+          >()(ref.pointer, arg0, arg1.ref.pointer),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>, objc.Consumed<EmptyObject>)>`.
@@ -2339,28 +2346,29 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1$CallExtension
             objc.Consumed<EmptyObject>,
           )
         > {
-  EmptyObject call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) =>
-      EmptyObject.fromPointer(
-        ref.pointer.ref.invoke
-            .cast<
-              ffi.NativeFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl> block,
-                  ffi.Pointer<ffi.Void> arg0,
-                  ffi.Pointer<objc.ObjCObjectImpl> arg1,
-                )
-              >
-            >()
-            .asFunction<
+  EmptyObject call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
+    return EmptyObject.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
               ffi.Pointer<objc.ObjCObjectImpl> Function(
-                ffi.Pointer<objc.ObjCBlockImpl>,
-                ffi.Pointer<ffi.Void>,
-                ffi.Pointer<objc.ObjCObjectImpl>,
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+                ffi.Pointer<objc.ObjCObjectImpl> arg1,
               )
-            >()(ref.pointer, arg0, arg1.ref.retainAndReturnPointer()),
-        retain: true,
-        release: true,
-      );
+            >
+          >()
+          .asFunction<
+            ffi.Pointer<objc.ObjCObjectImpl> Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
+            )
+          >()(ref.pointer, arg0, arg1.ref.retainAndReturnPointer()),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function()>`.
@@ -2401,7 +2409,9 @@ abstract final class ObjCBlock_ffiVoid {
     void Function() fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function()>(
-    objc.newClosureBlock(_closureCallable, () => fn(), keepIsolateAlive),
+    objc.newClosureBlock(_closureCallable, () {
+      return fn();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -2421,7 +2431,9 @@ abstract final class ObjCBlock_ffiVoid {
   }) {
     final raw = objc.newClosureBlock(
       _listenerCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final wrapper = _z0xonr_wrapListenerBlock_1pl9qdv(raw);
@@ -2449,12 +2461,16 @@ abstract final class ObjCBlock_ffiVoid {
   }) {
     final raw = objc.newClosureBlock(
       _blockingCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final wrapper = _z0xonr_wrapBlockingBlock_1pl9qdv(
@@ -2539,16 +2555,17 @@ abstract final class ObjCBlock_ffiVoid {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function()>`.
 extension ObjCBlock_ffiVoid$CallExtension
     on objc.ObjCBlock<ffi.Void Function()> {
-  void call() =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<objc.ObjCBlockImpl> block)
-            >
-          >()
-          .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>)>()(
-        ref.pointer,
-      );
+  void call() {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(ffi.Pointer<objc.ObjCBlockImpl> block)
+          >
+        >()
+        .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>)>()(
+      ref.pointer,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)>`.
@@ -2600,12 +2617,15 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject {
     void Function(ffi.Pointer<ffi.Void>, EmptyObject) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, EmptyObject.fromPointer(arg1, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
+        arg0,
+        EmptyObject.fromPointer(arg1, retain: true, release: true),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -2624,12 +2644,15 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject {
     void Function(ffi.Pointer<ffi.Void>, EmptyObject) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, EmptyObject.fromPointer(arg1, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
+        arg0,
+        EmptyObject.fromPointer(arg1, retain: false, release: true),
+      );
+    }, keepIsolateAlive);
     final wrapper = _z0xonr_wrapListenerBlock_18v1jvf(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -2652,16 +2675,23 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject {
     void Function(ffi.Pointer<ffi.Void>, EmptyObject) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, EmptyObject.fromPointer(arg1, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
+        arg0,
+        EmptyObject.fromPointer(arg1, retain: false, release: true),
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, EmptyObject.fromPointer(arg1, retain: false, release: true)),
+      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) {
+        return fn(
+          arg0,
+          EmptyObject.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _z0xonr_wrapBlockingBlock_18v1jvf(
@@ -2809,26 +2839,25 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)>`.
 extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> {
-  void call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  void call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0, arg1.ref.pointer);
+        >()(ref.pointer, arg0, arg1.ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, objc.Consumed<EmptyObject>)>`.
@@ -2891,15 +2920,15 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1 {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<ffi.Void>, objc.Consumed<EmptyObject>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-              fn(
-                arg0,
-                EmptyObject.fromPointer(arg1, retain: false, release: true),
-              ),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          return fn(
+            arg0,
+            EmptyObject.fromPointer(arg1, retain: false, release: true),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -2920,12 +2949,15 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1 {
     void Function(ffi.Pointer<ffi.Void>, EmptyObject) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, EmptyObject.fromPointer(arg1, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
+        arg0,
+        EmptyObject.fromPointer(arg1, retain: false, release: true),
+      );
+    }, keepIsolateAlive);
     final wrapper = _z0xonr_wrapListenerBlock_6yc3kd(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -2950,16 +2982,23 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1 {
     void Function(ffi.Pointer<ffi.Void>, EmptyObject) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, EmptyObject.fromPointer(arg1, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
+        arg0,
+        EmptyObject.fromPointer(arg1, retain: false, release: true),
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, EmptyObject.fromPointer(arg1, retain: false, release: true)),
+      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) {
+        return fn(
+          arg0,
+          EmptyObject.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _z0xonr_wrapBlockingBlock_6yc3kd(
@@ -3110,26 +3149,25 @@ extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<ffi.Void>, objc.Consumed<EmptyObject>)
         > {
-  void call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  void call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0, arg1.ref.retainAndReturnPointer());
+        >()(ref.pointer, arg0, arg1.ref.retainAndReturnPointer());
+  }
 }
 
 late final _class_BlockAnnotationTest = objc.getClass("BlockAnnotationTest");

--- a/pkgs/ffigen/test/native_objc_test/block_annotation_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_annotation_test_bindings.dart
@@ -195,10 +195,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
     >
     block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_w08mvv(
       _class_BlockAnnotationTest,
       _sel_invokeBlockProducer_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
   }
@@ -207,10 +208,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static NSThread invokeConsumedObjectListenerAsync(
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeConsumedObjectListenerAsync_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return NSThread.fromPointer($ret, retain: true, release: true);
   }
@@ -219,10 +221,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static void invokeConsumedObjectListenerSync(
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> block,
   ) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockAnnotationTest,
       _sel_invokeConsumedObjectListenerSync_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
@@ -231,10 +234,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
     objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)>
     block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeConsumedObjectReceiver_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -243,10 +247,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static NSThread invokeObjectListenerAsync(
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeObjectListenerAsync_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return NSThread.fromPointer($ret, retain: true, release: true);
   }
@@ -255,10 +260,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static void invokeObjectListenerSync(
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> block,
   ) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockAnnotationTest,
       _sel_invokeObjectListenerSync_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
@@ -266,10 +272,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static EmptyObject invokeObjectProducer(
     objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)> block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeObjectProducer_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -279,10 +286,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
     objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)>
     block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeObjectReceiver_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -294,10 +302,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
     >
     block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_w08mvv(
       _class_BlockAnnotationTest,
       _sel_invokeRetainedBlockProducer_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
   }
@@ -306,10 +315,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static EmptyObject invokeRetainedObjectProducer(
     objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)> block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeRetainedObjectProducer_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -419,15 +429,13 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
 extension BlockAnnotationTest$Methods on BlockAnnotationTest {
   /// init
   BlockAnnotationTest init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'BlockAnnotationTest.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return BlockAnnotationTest.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -458,68 +466,70 @@ extension type BlockAnnotationTestProtocol._(objc.ObjCProtocol object$)
 extension BlockAnnotationTestProtocol$Methods on BlockAnnotationTestProtocol {
   /// listenConsumedObject:
   void listenConsumedObject(EmptyObject obj) {
+    final _$$ = object$.ref;
+    final _$$$1 = obj.ref;
     _objc_msgSend_4js6t(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_listenConsumedObject_,
-      obj.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
     );
   }
 
   /// listenObject:
   void listenObject(EmptyObject obj) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_listenObject_,
-      obj.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = obj.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_listenObject_, _$$$1.pointer);
   }
 
   /// produceBlock
   DartEmptyBlock produceBlock() {
-    final $ret = _objc_msgSend_uwvaik(object$.ref.pointer, _sel_produceBlock);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_produceBlock);
     return ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
   }
 
   /// produceObject
   EmptyObject produceObject() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_produceObject);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_produceObject);
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// produceRetainedBlock
   DartEmptyBlock produceRetainedBlock() {
-    final $ret = _objc_msgSend_uwvaik(
-      object$.ref.pointer,
-      _sel_produceRetainedBlock,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_produceRetainedBlock);
     return ObjCBlock_ffiVoid.fromPointer($ret, retain: false, release: true);
   }
 
   /// produceRetainedObject
   EmptyObject produceRetainedObject() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_produceRetainedObject,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_produceRetainedObject);
     return EmptyObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// receiveConsumedObject:
   EmptyObject receiveConsumedObject(EmptyObject obj) {
+    final _$$ = object$.ref;
+    final _$$$1 = obj.ref;
     final $ret = _objc_msgSend_1ploomx(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_receiveConsumedObject_,
-      obj.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// receiveObject:
   EmptyObject receiveObject(EmptyObject obj) {
+    final _$$ = object$.ref;
+    final _$$$1 = obj.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_receiveObject_,
-      obj.ref.pointer,
+      _$$$1.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -1135,13 +1145,14 @@ extension type EmptyObject._(objc.ObjCObject object$)
 extension EmptyObject$Methods on EmptyObject {
   /// init
   EmptyObject init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'EmptyObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return EmptyObject.fromPointer($ret, retain: false, release: true);
@@ -1227,12 +1238,14 @@ extension type NSThread._(objc.ObjCObject object$)
     required objc.ObjCObject toTarget,
     objc.ObjCObject? withObject,
   }) {
+    final _$$ = toTarget.ref;
+    final _$$$1 = withObject?.ref;
     _objc_msgSend_lzbvjm(
       _class_NSThread,
       _sel_detachNewThreadSelector_toTarget_withObject_,
       selector,
-      toTarget.ref.pointer,
-      withObject?.ref.pointer ?? ffi.nullptr,
+      _$$.pointer,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -1240,6 +1253,7 @@ extension type NSThread._(objc.ObjCObject object$)
   static void detachNewThreadWithBlock(
     objc.ObjCBlock<ffi.Void Function()> block,
   ) {
+    final _$$ = block.ref;
     objc.checkOsVersionInternal(
       'NSThread.detachNewThreadWithBlock:',
       iOS: (false, (10, 0, 0)),
@@ -1248,7 +1262,7 @@ extension type NSThread._(objc.ObjCObject object$)
     _objc_msgSend_f167m6(
       _class_NSThread,
       _sel_detachNewThreadWithBlock_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
@@ -1301,11 +1315,8 @@ extension type NSThread._(objc.ObjCObject object$)
 
   /// sleepUntilDate:
   static void sleepUntilDate(objc.NSDate date) {
-    _objc_msgSend_xtuoz7(
-      _class_NSThread,
-      _sel_sleepUntilDate_,
-      date.ref.pointer,
-    );
+    final _$$ = date.ref;
+    _objc_msgSend_xtuoz7(_class_NSThread, _sel_sleepUntilDate_, _$$.pointer);
   }
 
   /// threadPriority
@@ -1322,23 +1333,25 @@ extension type NSThread._(objc.ObjCObject object$)
 extension NSThread$Methods on NSThread {
   /// cancel
   void cancel() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.cancel',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_cancel);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_cancel);
   }
 
   /// init
   NSThread init() {
+    final _$$$2 = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_init,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
@@ -1346,15 +1359,17 @@ extension NSThread$Methods on NSThread {
 
   /// initWithBlock:
   NSThread initWithBlock(objc.ObjCBlock<ffi.Void Function()> block) {
+    final _$$ = object$.ref;
+    final _$$$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSThread.initWithBlock:',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithBlock_,
-      block.ref.pointer,
+      _$$$1.pointer,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
@@ -1365,79 +1380,88 @@ extension NSThread$Methods on NSThread {
     required ffi.Pointer<objc.ObjCSelector> selector,
     objc.ObjCObject? object,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = target.ref;
+    final _$$$2 = object?.ref;
     objc.checkOsVersionInternal(
       'NSThread.initWithTarget:selector:object:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_1eldwyi(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithTarget_selector_object_,
-      target.ref.pointer,
+      _$$$1.pointer,
       selector,
-      object?.ref.pointer ?? ffi.nullptr,
+      _$$$2?.pointer ?? ffi.nullptr,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
 
   /// isCancelled
   bool get isCancelled {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isCancelled',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isCancelled);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isCancelled);
   }
 
   /// isExecuting
   bool get isExecuting {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isExecuting',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isExecuting);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isExecuting);
   }
 
   /// isFinished
   bool get isFinished {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isFinished',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isFinished);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isFinished);
   }
 
   /// isMainThread
   bool get isMainThread {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isMainThread',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isMainThread);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isMainThread);
   }
 
   /// main
   void main() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.main',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_main);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_main);
   }
 
   /// name
   objc.NSString? get name {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.name',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_name);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -1445,92 +1469,91 @@ extension NSThread$Methods on NSThread {
 
   /// qualityOfService
   objc.NSQualityOfService get qualityOfService {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.qualityOfService',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
-    final $ret = _objc_msgSend_oi8iq9(
-      object$.ref.pointer,
-      _sel_qualityOfService,
-    );
+    final $ret = _objc_msgSend_oi8iq9(_$$.pointer, _sel_qualityOfService);
     return objc.NSQualityOfService.fromValue($ret);
   }
 
   /// setName:
   set name(objc.NSString? value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSThread.setName:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setName_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setQualityOfService:
   set qualityOfService(objc.NSQualityOfService value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setQualityOfService:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
-    _objc_msgSend_n2da1l(
-      object$.ref.pointer,
-      _sel_setQualityOfService_,
-      value.value,
-    );
+    _objc_msgSend_n2da1l(_$$.pointer, _sel_setQualityOfService_, value.value);
   }
 
   /// setStackSize:
   set stackSize(int value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setStackSize:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1i9r4xy(object$.ref.pointer, _sel_setStackSize_, value);
+    _objc_msgSend_1i9r4xy(_$$.pointer, _sel_setStackSize_, value);
   }
 
   /// setThreadPriority:
   set threadPriority(double value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setThreadPriority:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    _objc_msgSend_hwm8nu(object$.ref.pointer, _sel_setThreadPriority_, value);
+    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setThreadPriority_, value);
   }
 
   /// stackSize
   int get stackSize {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.stackSize',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_stackSize);
+    return _objc_msgSend_xw2lbc(_$$.pointer, _sel_stackSize);
   }
 
   /// start
   void start() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.start',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_start);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_start);
   }
 
   /// threadDictionary
   objc.NSMutableDictionary get threadDictionary {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_threadDictionary,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_threadDictionary);
     return objc.NSMutableDictionary.fromPointer(
       $ret,
       retain: true,
@@ -1540,14 +1563,15 @@ extension NSThread$Methods on NSThread {
 
   /// threadPriority
   double get threadPriority {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.threadPriority',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_threadPriority)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_threadPriority);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_threadPriority)
+        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_threadPriority);
   }
 }
 
@@ -1607,8 +1631,8 @@ abstract final class ObjCBlock_EmptyBlock_ffiVoid {
         objc.ObjCBlock<ffi.Void Function()> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$obj = fn(arg0);
-          return _$obj.ref.retainAndAutorelease();
+          final _$$ = fn(arg0).ref;
+          return _$$.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -1743,8 +1767,8 @@ abstract final class ObjCBlock_EmptyBlock_ffiVoid$1 {
         )
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$obj = fn(arg0);
-          return _$obj.ref.retainAndReturnPointer();
+          final _$$ = fn(arg0).ref;
+          return _$$.retainAndReturnPointer();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -1860,8 +1884,8 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)>(
     objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-      final _$obj = fn(arg0);
-      return _$obj.ref.retainAndAutorelease();
+      final _$$ = fn(arg0).ref;
+      return _$$.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -1989,8 +2013,8 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid$1 {
         objc.Retained<EmptyObject> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$obj = fn(arg0);
-          return _$obj.ref.retainAndReturnPointer();
+          final _$$ = fn(arg0).ref;
+          return _$$.retainAndReturnPointer();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2124,11 +2148,11 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid_EmptyObject {
           ffi.Pointer<ffi.Void> arg0,
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
         ) {
-          final _$obj = fn(
+          final _$$ = fn(
             arg0,
             EmptyObject.fromPointer(arg1, retain: true, release: true),
-          );
-          return _$obj.ref.retainAndAutorelease();
+          ).ref;
+          return _$$.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2190,6 +2214,7 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$CallExtension
           EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)
         > {
   EmptyObject call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
+    final _$$$1 = arg1.ref;
     return EmptyObject.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -2207,7 +2232,7 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$CallExtension
               ffi.Pointer<ffi.Void>,
               ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >()(ref.pointer, arg0, arg1.ref.pointer),
+          >()(ref.pointer, arg0, _$$$1.pointer),
       retain: true,
       release: true,
     );
@@ -2278,11 +2303,11 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1 {
           ffi.Pointer<ffi.Void> arg0,
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
         ) {
-          final _$obj = fn(
+          final _$$ = fn(
             arg0,
             EmptyObject.fromPointer(arg1, retain: false, release: true),
-          );
-          return _$obj.ref.retainAndAutorelease();
+          ).ref;
+          return _$$.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2347,6 +2372,7 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1$CallExtension
           )
         > {
   EmptyObject call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
+    final _$$$1 = arg1.ref;
     return EmptyObject.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -2364,7 +2390,7 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1$CallExtension
               ffi.Pointer<ffi.Void>,
               ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >()(ref.pointer, arg0, arg1.ref.retainAndReturnPointer()),
+          >()(ref.pointer, arg0, _$$$1.retainAndReturnPointer()),
       retain: true,
       release: true,
     );
@@ -2840,6 +2866,7 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject {
 extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> {
   void call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
+    final _$$ = arg1.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -2856,7 +2883,7 @@ extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$CallExtension
             ffi.Pointer<ffi.Void>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0, arg1.ref.pointer);
+        >()(ref.pointer, arg0, _$$.pointer);
   }
 }
 
@@ -3150,6 +3177,7 @@ extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1$CallExtension
           ffi.Void Function(ffi.Pointer<ffi.Void>, objc.Consumed<EmptyObject>)
         > {
   void call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
+    final _$$ = arg1.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -3166,7 +3194,7 @@ extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1$CallExtension
             ffi.Pointer<ffi.Void>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0, arg1.ref.retainAndReturnPointer());
+        >()(ref.pointer, arg0, _$$.retainAndReturnPointer());
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/block_annotation_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_annotation_test_bindings.dart
@@ -1606,11 +1606,10 @@ abstract final class ObjCBlock_EmptyBlock_ffiVoid {
       objc.ObjCBlock<
         objc.ObjCBlock<ffi.Void Function()> Function(ffi.Pointer<ffi.Void>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+          final _$obj = fn(arg0);
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -1742,11 +1741,10 @@ abstract final class ObjCBlock_EmptyBlock_ffiVoid$1 {
           ffi.Pointer<ffi.Void>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndReturnPointer(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+          final _$obj = fn(arg0);
+          return _$obj.ref.retainAndReturnPointer();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -1859,11 +1857,10 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid {
     EmptyObject Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+      final _$obj = fn(arg0);
+      return _$obj.ref.retainAndAutorelease();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1987,11 +1984,10 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid$1 {
       objc.ObjCBlock<
         objc.Retained<EmptyObject> Function(ffi.Pointer<ffi.Void>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndReturnPointer(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+          final _$obj = fn(arg0);
+          return _$obj.ref.retainAndReturnPointer();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -2118,15 +2114,16 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid_EmptyObject {
     bool keepIsolateAlive = true,
   }) =>
       objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)>(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-              fn(
-                arg0,
-                EmptyObject.fromPointer(arg1, retain: true, release: true),
-              ).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          final _$obj = fn(
+            arg0,
+            EmptyObject.fromPointer(arg1, retain: true, release: true),
+          );
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -2270,15 +2267,16 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1 {
       objc.ObjCBlock<
         EmptyObject Function(ffi.Pointer<ffi.Void>, objc.Consumed<EmptyObject>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-              fn(
-                arg0,
-                EmptyObject.fromPointer(arg1, retain: false, release: true),
-              ).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          final _$obj = fn(
+            arg0,
+            EmptyObject.fromPointer(arg1, retain: false, release: true),
+          );
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );

--- a/pkgs/ffigen/test/native_objc_test/block_annotation_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_annotation_test_bindings.dart
@@ -195,11 +195,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
     >
     block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_w08mvv(
       _class_BlockAnnotationTest,
       _sel_invokeBlockProducer_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
   }
@@ -208,11 +208,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static NSThread invokeConsumedObjectListenerAsync(
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeConsumedObjectListenerAsync_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return NSThread.fromPointer($ret, retain: true, release: true);
   }
@@ -221,11 +221,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static void invokeConsumedObjectListenerSync(
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockAnnotationTest,
       _sel_invokeConsumedObjectListenerSync_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -234,11 +234,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
     objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)>
     block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeConsumedObjectReceiver_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -247,11 +247,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static NSThread invokeObjectListenerAsync(
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeObjectListenerAsync_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return NSThread.fromPointer($ret, retain: true, release: true);
   }
@@ -260,11 +260,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static void invokeObjectListenerSync(
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockAnnotationTest,
       _sel_invokeObjectListenerSync_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -272,11 +272,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static EmptyObject invokeObjectProducer(
     objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeObjectProducer_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -286,11 +286,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
     objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)>
     block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeObjectReceiver_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -302,11 +302,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
     >
     block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_w08mvv(
       _class_BlockAnnotationTest,
       _sel_invokeRetainedBlockProducer_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
   }
@@ -315,11 +315,11 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
   static EmptyObject invokeRetainedObjectProducer(
     objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockAnnotationTest,
       _sel_invokeRetainedObjectProducer_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -429,13 +429,16 @@ extension type BlockAnnotationTest._(objc.ObjCObject object$)
 extension BlockAnnotationTest$Methods on BlockAnnotationTest {
   /// init
   BlockAnnotationTest init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'BlockAnnotationTest.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return BlockAnnotationTest.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -466,70 +469,76 @@ extension type BlockAnnotationTestProtocol._(objc.ObjCProtocol object$)
 extension BlockAnnotationTestProtocol$Methods on BlockAnnotationTestProtocol {
   /// listenConsumedObject:
   void listenConsumedObject(EmptyObject obj) {
-    final _$$ = object$.ref;
-    final _$$$1 = obj.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj.ref;
     _objc_msgSend_4js6t(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_listenConsumedObject_,
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
     );
   }
 
   /// listenObject:
   void listenObject(EmptyObject obj) {
-    final _$$ = object$.ref;
-    final _$$$1 = obj.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_listenObject_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_listenObject_, _$$ref$1.pointer);
   }
 
   /// produceBlock
   DartEmptyBlock produceBlock() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_produceBlock);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_produceBlock);
     return ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
   }
 
   /// produceObject
   EmptyObject produceObject() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_produceObject);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_produceObject);
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// produceRetainedBlock
   DartEmptyBlock produceRetainedBlock() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_produceRetainedBlock);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(
+      _$$ref.pointer,
+      _sel_produceRetainedBlock,
+    );
     return ObjCBlock_ffiVoid.fromPointer($ret, retain: false, release: true);
   }
 
   /// produceRetainedObject
   EmptyObject produceRetainedObject() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_produceRetainedObject);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.pointer,
+      _sel_produceRetainedObject,
+    );
     return EmptyObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// receiveConsumedObject:
   EmptyObject receiveConsumedObject(EmptyObject obj) {
-    final _$$ = object$.ref;
-    final _$$$1 = obj.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj.ref;
     final $ret = _objc_msgSend_1ploomx(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_receiveConsumedObject_,
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// receiveObject:
   EmptyObject receiveObject(EmptyObject obj) {
-    final _$$ = object$.ref;
-    final _$$$1 = obj.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_receiveObject_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return EmptyObject.fromPointer($ret, retain: true, release: true);
   }
@@ -1145,14 +1154,14 @@ extension type EmptyObject._(objc.ObjCObject object$)
 extension EmptyObject$Methods on EmptyObject {
   /// init
   EmptyObject init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'EmptyObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return EmptyObject.fromPointer($ret, retain: false, release: true);
@@ -1238,14 +1247,14 @@ extension type NSThread._(objc.ObjCObject object$)
     required objc.ObjCObject toTarget,
     objc.ObjCObject? withObject,
   }) {
-    final _$$ = toTarget.ref;
-    final _$$$1 = withObject?.ref;
+    final _$$ref = toTarget.ref;
+    final _$$ref$1 = withObject?.ref;
     _objc_msgSend_lzbvjm(
       _class_NSThread,
       _sel_detachNewThreadSelector_toTarget_withObject_,
       selector,
-      _$$.pointer,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -1253,7 +1262,7 @@ extension type NSThread._(objc.ObjCObject object$)
   static void detachNewThreadWithBlock(
     objc.ObjCBlock<ffi.Void Function()> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     objc.checkOsVersionInternal(
       'NSThread.detachNewThreadWithBlock:',
       iOS: (false, (10, 0, 0)),
@@ -1262,7 +1271,7 @@ extension type NSThread._(objc.ObjCObject object$)
     _objc_msgSend_f167m6(
       _class_NSThread,
       _sel_detachNewThreadWithBlock_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -1315,8 +1324,8 @@ extension type NSThread._(objc.ObjCObject object$)
 
   /// sleepUntilDate:
   static void sleepUntilDate(objc.NSDate date) {
-    final _$$ = date.ref;
-    _objc_msgSend_xtuoz7(_class_NSThread, _sel_sleepUntilDate_, _$$.pointer);
+    final _$$ref = date.ref;
+    _objc_msgSend_xtuoz7(_class_NSThread, _sel_sleepUntilDate_, _$$ref.pointer);
   }
 
   /// threadPriority
@@ -1333,25 +1342,25 @@ extension type NSThread._(objc.ObjCObject object$)
 extension NSThread$Methods on NSThread {
   /// cancel
   void cancel() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.cancel',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_cancel);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_cancel);
   }
 
   /// init
   NSThread init() {
-    final _$$$2 = object$.ref;
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
@@ -1359,17 +1368,17 @@ extension NSThread$Methods on NSThread {
 
   /// initWithBlock:
   NSThread initWithBlock(objc.ObjCBlock<ffi.Void Function()> block) {
-    final _$$ = object$.ref;
-    final _$$$1 = block.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSThread.initWithBlock:',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBlock_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
@@ -1380,88 +1389,88 @@ extension NSThread$Methods on NSThread {
     required ffi.Pointer<objc.ObjCSelector> selector,
     objc.ObjCObject? object,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = target.ref;
-    final _$$$2 = object?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = target.ref;
+    final _$$ref$2 = object?.ref;
     objc.checkOsVersionInternal(
       'NSThread.initWithTarget:selector:object:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_1eldwyi(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithTarget_selector_object_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
       selector,
-      _$$$2?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
 
   /// isCancelled
   bool get isCancelled {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isCancelled',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isCancelled);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isCancelled);
   }
 
   /// isExecuting
   bool get isExecuting {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isExecuting',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isExecuting);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isExecuting);
   }
 
   /// isFinished
   bool get isFinished {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isFinished',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isFinished);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isFinished);
   }
 
   /// isMainThread
   bool get isMainThread {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isMainThread',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isMainThread);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isMainThread);
   }
 
   /// main
   void main() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.main',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_main);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_main);
   }
 
   /// name
   objc.NSString? get name {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.name',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_name);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -1469,91 +1478,95 @@ extension NSThread$Methods on NSThread {
 
   /// qualityOfService
   objc.NSQualityOfService get qualityOfService {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.qualityOfService',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
-    final $ret = _objc_msgSend_oi8iq9(_$$.pointer, _sel_qualityOfService);
+    final $ret = _objc_msgSend_oi8iq9(_$$ref.pointer, _sel_qualityOfService);
     return objc.NSQualityOfService.fromValue($ret);
   }
 
   /// setName:
   set name(objc.NSString? value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSThread.setName:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setName_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setQualityOfService:
   set qualityOfService(objc.NSQualityOfService value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setQualityOfService:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
-    _objc_msgSend_n2da1l(_$$.pointer, _sel_setQualityOfService_, value.value);
+    _objc_msgSend_n2da1l(
+      _$$ref.pointer,
+      _sel_setQualityOfService_,
+      value.value,
+    );
   }
 
   /// setStackSize:
   set stackSize(int value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setStackSize:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1i9r4xy(_$$.pointer, _sel_setStackSize_, value);
+    _objc_msgSend_1i9r4xy(_$$ref.pointer, _sel_setStackSize_, value);
   }
 
   /// setThreadPriority:
   set threadPriority(double value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setThreadPriority:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setThreadPriority_, value);
+    _objc_msgSend_hwm8nu(_$$ref.pointer, _sel_setThreadPriority_, value);
   }
 
   /// stackSize
   int get stackSize {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.stackSize',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_xw2lbc(_$$.pointer, _sel_stackSize);
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_stackSize);
   }
 
   /// start
   void start() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.start',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_start);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_start);
   }
 
   /// threadDictionary
   objc.NSMutableDictionary get threadDictionary {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_threadDictionary);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_threadDictionary);
     return objc.NSMutableDictionary.fromPointer(
       $ret,
       retain: true,
@@ -1563,15 +1576,15 @@ extension NSThread$Methods on NSThread {
 
   /// threadPriority
   double get threadPriority {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.threadPriority',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_threadPriority)
-        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_threadPriority);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_threadPriority)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_threadPriority);
   }
 }
 
@@ -1631,8 +1644,8 @@ abstract final class ObjCBlock_EmptyBlock_ffiVoid {
         objc.ObjCBlock<ffi.Void Function()> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$$ = fn(arg0).ref;
-          return _$$.retainAndAutorelease();
+          final _$$ref = fn(arg0).ref;
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -1767,8 +1780,8 @@ abstract final class ObjCBlock_EmptyBlock_ffiVoid$1 {
         )
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$$ = fn(arg0).ref;
-          return _$$.retainAndReturnPointer();
+          final _$$ref = fn(arg0).ref;
+          return _$$ref.retainAndReturnPointer();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -1884,8 +1897,8 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<EmptyObject Function(ffi.Pointer<ffi.Void>)>(
     objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-      final _$$ = fn(arg0).ref;
-      return _$$.retainAndAutorelease();
+      final _$$ref = fn(arg0).ref;
+      return _$$ref.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -2013,8 +2026,8 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid$1 {
         objc.Retained<EmptyObject> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$$ = fn(arg0).ref;
-          return _$$.retainAndReturnPointer();
+          final _$$ref = fn(arg0).ref;
+          return _$$ref.retainAndReturnPointer();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2148,11 +2161,11 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid_EmptyObject {
           ffi.Pointer<ffi.Void> arg0,
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
         ) {
-          final _$$ = fn(
+          final _$$ref = fn(
             arg0,
             EmptyObject.fromPointer(arg1, retain: true, release: true),
           ).ref;
-          return _$$.retainAndAutorelease();
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2214,7 +2227,7 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$CallExtension
           EmptyObject Function(ffi.Pointer<ffi.Void>, EmptyObject)
         > {
   EmptyObject call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
-    final _$$$1 = arg1.ref;
+    final _$$ref$1 = arg1.ref;
     return EmptyObject.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -2232,7 +2245,7 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$CallExtension
               ffi.Pointer<ffi.Void>,
               ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >()(ref.pointer, arg0, _$$$1.pointer),
+          >()(ref.pointer, arg0, _$$ref$1.pointer),
       retain: true,
       release: true,
     );
@@ -2303,11 +2316,11 @@ abstract final class ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1 {
           ffi.Pointer<ffi.Void> arg0,
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
         ) {
-          final _$$ = fn(
+          final _$$ref = fn(
             arg0,
             EmptyObject.fromPointer(arg1, retain: false, release: true),
           ).ref;
-          return _$$.retainAndAutorelease();
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2372,7 +2385,7 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1$CallExtension
           )
         > {
   EmptyObject call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
-    final _$$$1 = arg1.ref;
+    final _$$ref$1 = arg1.ref;
     return EmptyObject.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -2390,7 +2403,7 @@ extension ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1$CallExtension
               ffi.Pointer<ffi.Void>,
               ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >()(ref.pointer, arg0, _$$$1.retainAndReturnPointer()),
+          >()(ref.pointer, arg0, _$$ref$1.retainAndReturnPointer()),
       retain: true,
       release: true,
     );
@@ -2866,7 +2879,7 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_EmptyObject {
 extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, EmptyObject)> {
   void call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
-    final _$$ = arg1.ref;
+    final _$$ref = arg1.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -2883,7 +2896,7 @@ extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$CallExtension
             ffi.Pointer<ffi.Void>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0, _$$.pointer);
+        >()(ref.pointer, arg0, _$$ref.pointer);
   }
 }
 
@@ -3177,7 +3190,7 @@ extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1$CallExtension
           ffi.Void Function(ffi.Pointer<ffi.Void>, objc.Consumed<EmptyObject>)
         > {
   void call(ffi.Pointer<ffi.Void> arg0, EmptyObject arg1) {
-    final _$$ = arg1.ref;
+    final _$$ref = arg1.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -3194,7 +3207,7 @@ extension ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1$CallExtension
             ffi.Pointer<ffi.Void>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0, _$$.retainAndReturnPointer());
+        >()(ref.pointer, arg0, _$$ref.retainAndReturnPointer());
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test_bindings.dart
@@ -410,23 +410,25 @@ abstract final class ObjCBlock_Mammal {
 
 /// Call operator for `objc.ObjCBlock<Mammal Function()>`.
 extension ObjCBlock_Mammal$CallExtension on objc.ObjCBlock<Mammal Function()> {
-  Mammal call() => Mammal.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  Mammal call() {
+    return Mammal.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCBlockImpl>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-          )
-        >()(ref.pointer),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<Platypus Function()>`.
@@ -505,23 +507,25 @@ abstract final class ObjCBlock_Platypus {
 /// Call operator for `objc.ObjCBlock<Platypus Function()>`.
 extension ObjCBlock_Platypus$CallExtension
     on objc.ObjCBlock<Platypus Function()> {
-  Platypus call() => Platypus.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  Platypus call() {
+    return Platypus.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCBlockImpl>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-          )
-        >()(ref.pointer),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(Mammal)>`.
@@ -567,12 +571,11 @@ abstract final class ObjCBlock_bool_Mammal {
     bool Function(Mammal) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Bool Function(Mammal)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(Mammal.fromPointer(arg0, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(Mammal.fromPointer(arg0, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -614,21 +617,23 @@ abstract final class ObjCBlock_bool_Mammal {
 /// Call operator for `objc.ObjCBlock<ffi.Bool Function(Mammal)>`.
 extension ObjCBlock_bool_Mammal$CallExtension
     on objc.ObjCBlock<ffi.Bool Function(Mammal)> {
-  bool call(Mammal arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  bool call(Mammal arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        bool Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, arg0.ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(Platypus)>`.
@@ -674,12 +679,11 @@ abstract final class ObjCBlock_bool_Platypus {
     bool Function(Platypus) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Bool Function(Platypus)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(Platypus.fromPointer(arg0, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(Platypus.fromPointer(arg0, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -721,21 +725,23 @@ abstract final class ObjCBlock_bool_Platypus {
 /// Call operator for `objc.ObjCBlock<ffi.Bool Function(Platypus)>`.
 extension ObjCBlock_bool_Platypus$CallExtension
     on objc.ObjCBlock<ffi.Bool Function(Platypus)> {
-  bool call(Platypus arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  bool call(Platypus arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        bool Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, arg0.ref.pointer);
+  }
 }
 
 /// Platypus

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test_bindings.dart
@@ -66,16 +66,19 @@ extension type BlockInheritTestBase._(objc.ObjCObject object$)
 extension BlockInheritTestBase$Methods on BlockInheritTestBase {
   /// acceptAnimal:
   bool acceptAnimal(Platypus platypus) {
+    final _$$ = object$.ref;
+    final _$$$1 = platypus.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_acceptAnimal_,
-      platypus.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// getAccepter
   DartAcceptPlatypus getAccepter() {
-    final $ret = _objc_msgSend_uwvaik(object$.ref.pointer, _sel_getAccepter);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getAccepter);
     return ObjCBlock_bool_Platypus.fromPointer(
       $ret,
       retain: true,
@@ -85,45 +88,49 @@ extension BlockInheritTestBase$Methods on BlockInheritTestBase {
 
   /// getAnimal
   Mammal getAnimal() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_getAnimal);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_getAnimal);
     return Mammal.fromPointer($ret, retain: true, release: true);
   }
 
   /// getReturner
   DartReturnMammal getReturner() {
-    final $ret = _objc_msgSend_uwvaik(object$.ref.pointer, _sel_getReturner);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getReturner);
     return ObjCBlock_Mammal.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BlockInheritTestBase init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'BlockInheritTestBase.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return BlockInheritTestBase.fromPointer($ret, retain: false, release: true);
   }
 
   /// invokeAccepter:
   bool invokeAccepter(DartAcceptMammal accepter) {
+    final _$$ = object$.ref;
+    final _$$$1 = accepter.ref;
     return _objc_msgSend_z0nr1o(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_invokeAccepter_,
-      accepter.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// invokeReturner:
   Mammal invokeReturner(DartReturnPlatypus returner) {
+    final _$$ = object$.ref;
+    final _$$$1 = returner.ref;
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_invokeReturner_,
-      returner.ref.pointer,
+      _$$$1.pointer,
     );
     return Mammal.fromPointer($ret, retain: true, release: true);
   }
@@ -199,40 +206,46 @@ extension type BlockInheritTestChild._(objc.ObjCObject object$)
 extension BlockInheritTestChild$Methods on BlockInheritTestChild {
   /// acceptAnimal:
   bool acceptAnimal(Mammal mammal) {
+    final _$$ = object$.ref;
+    final _$$$1 = mammal.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_acceptAnimal_,
-      mammal.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// getAccepter
   DartAcceptMammal getAccepter() {
-    final $ret = _objc_msgSend_uwvaik(object$.ref.pointer, _sel_getAccepter);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getAccepter);
     return ObjCBlock_bool_Mammal.fromPointer($ret, retain: true, release: true);
   }
 
   /// getAnimal
   Platypus getAnimal() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_getAnimal);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_getAnimal);
     return Platypus.fromPointer($ret, retain: true, release: true);
   }
 
   /// getReturner
   DartReturnPlatypus getReturner() {
-    final $ret = _objc_msgSend_uwvaik(object$.ref.pointer, _sel_getReturner);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getReturner);
     return ObjCBlock_Platypus.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BlockInheritTestChild init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'BlockInheritTestChild.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return BlockInheritTestChild.fromPointer(
@@ -244,19 +257,23 @@ extension BlockInheritTestChild$Methods on BlockInheritTestChild {
 
   /// invokeAccepter:
   bool invokeAccepter(DartAcceptPlatypus accepter) {
+    final _$$ = object$.ref;
+    final _$$$1 = accepter.ref;
     return _objc_msgSend_z0nr1o(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_invokeAccepter_,
-      accepter.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// invokeReturner:
   Mammal invokeReturner(DartReturnMammal returner) {
+    final _$$ = object$.ref;
+    final _$$$1 = returner.ref;
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_invokeReturner_,
-      returner.ref.pointer,
+      _$$$1.pointer,
     );
     return Mammal.fromPointer($ret, retain: true, release: true);
   }
@@ -317,13 +334,14 @@ extension type Mammal._(objc.ObjCObject object$)
 extension Mammal$Methods on Mammal {
   /// init
   Mammal init() {
+    final _$$$2 = object$.ref;
     objc.checkOsVersionInternal(
       'Mammal.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_init,
     );
     return Mammal.fromPointer($ret, retain: false, release: true);
@@ -331,7 +349,8 @@ extension Mammal$Methods on Mammal {
 
   /// laysEggs
   bool laysEggs() {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_laysEggs);
+    final _$$ = object$.ref;
+    return _objc_msgSend_91o635(_$$.pointer, _sel_laysEggs);
   }
 }
 
@@ -375,8 +394,8 @@ abstract final class ObjCBlock_Mammal {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<Mammal Function()>(
     objc.newClosureBlock(_closureCallable, () {
-      final _$obj = fn();
-      return _$obj.ref.retainAndAutorelease();
+      final _$$ = fn().ref;
+      return _$$.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -471,8 +490,8 @@ abstract final class ObjCBlock_Platypus {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<Platypus Function()>(
     objc.newClosureBlock(_closureCallable, () {
-      final _$obj = fn();
-      return _$obj.ref.retainAndAutorelease();
+      final _$$ = fn().ref;
+      return _$$.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -618,6 +637,7 @@ abstract final class ObjCBlock_bool_Mammal {
 extension ObjCBlock_bool_Mammal$CallExtension
     on objc.ObjCBlock<ffi.Bool Function(Mammal)> {
   bool call(Mammal arg0) {
+    final _$$ = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -632,7 +652,7 @@ extension ObjCBlock_bool_Mammal$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, _$$.pointer);
   }
 }
 
@@ -726,6 +746,7 @@ abstract final class ObjCBlock_bool_Platypus {
 extension ObjCBlock_bool_Platypus$CallExtension
     on objc.ObjCBlock<ffi.Bool Function(Platypus)> {
   bool call(Platypus arg0) {
+    final _$$ = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -740,7 +761,7 @@ extension ObjCBlock_bool_Platypus$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, _$$.pointer);
   }
 }
 
@@ -799,13 +820,14 @@ extension type Platypus._(objc.ObjCObject object$)
 extension Platypus$Methods on Platypus {
   /// init
   Platypus init() {
+    final _$$$3 = object$.ref;
     objc.checkOsVersionInternal(
       'Platypus.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$3.retainAndReturnPointer(),
       _sel_init,
     );
     return Platypus.fromPointer($ret, retain: false, release: true);

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test_bindings.dart
@@ -374,11 +374,10 @@ abstract final class ObjCBlock_Mammal {
     Mammal Function() fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<Mammal Function()>(
-    objc.newClosureBlock(
-      _closureCallable,
-      () => fn().ref.retainAndAutorelease(),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, () {
+      final _$obj = fn();
+      return _$obj.ref.retainAndAutorelease();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -469,11 +468,10 @@ abstract final class ObjCBlock_Platypus {
     Platypus Function() fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<Platypus Function()>(
-    objc.newClosureBlock(
-      _closureCallable,
-      () => fn().ref.retainAndAutorelease(),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, () {
+      final _$obj = fn();
+      return _$obj.ref.retainAndAutorelease();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test_bindings.dart
@@ -66,19 +66,19 @@ extension type BlockInheritTestBase._(objc.ObjCObject object$)
 extension BlockInheritTestBase$Methods on BlockInheritTestBase {
   /// acceptAnimal:
   bool acceptAnimal(Platypus platypus) {
-    final _$$ = object$.ref;
-    final _$$$1 = platypus.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = platypus.ref;
     return _objc_msgSend_19nvye5(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_acceptAnimal_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// getAccepter
   DartAcceptPlatypus getAccepter() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getAccepter);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_getAccepter);
     return ObjCBlock_bool_Platypus.fromPointer(
       $ret,
       retain: true,
@@ -88,49 +88,52 @@ extension BlockInheritTestBase$Methods on BlockInheritTestBase {
 
   /// getAnimal
   Mammal getAnimal() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_getAnimal);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_getAnimal);
     return Mammal.fromPointer($ret, retain: true, release: true);
   }
 
   /// getReturner
   DartReturnMammal getReturner() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getReturner);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_getReturner);
     return ObjCBlock_Mammal.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BlockInheritTestBase init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'BlockInheritTestBase.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return BlockInheritTestBase.fromPointer($ret, retain: false, release: true);
   }
 
   /// invokeAccepter:
   bool invokeAccepter(DartAcceptMammal accepter) {
-    final _$$ = object$.ref;
-    final _$$$1 = accepter.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = accepter.ref;
     return _objc_msgSend_z0nr1o(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_invokeAccepter_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// invokeReturner:
   Mammal invokeReturner(DartReturnPlatypus returner) {
-    final _$$ = object$.ref;
-    final _$$$1 = returner.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = returner.ref;
     final $ret = _objc_msgSend_nnxkei(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_invokeReturner_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return Mammal.fromPointer($ret, retain: true, release: true);
   }
@@ -206,46 +209,46 @@ extension type BlockInheritTestChild._(objc.ObjCObject object$)
 extension BlockInheritTestChild$Methods on BlockInheritTestChild {
   /// acceptAnimal:
   bool acceptAnimal(Mammal mammal) {
-    final _$$ = object$.ref;
-    final _$$$1 = mammal.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = mammal.ref;
     return _objc_msgSend_19nvye5(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_acceptAnimal_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// getAccepter
   DartAcceptMammal getAccepter() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getAccepter);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_getAccepter);
     return ObjCBlock_bool_Mammal.fromPointer($ret, retain: true, release: true);
   }
 
   /// getAnimal
   Platypus getAnimal() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_getAnimal);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_getAnimal);
     return Platypus.fromPointer($ret, retain: true, release: true);
   }
 
   /// getReturner
   DartReturnPlatypus getReturner() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getReturner);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_getReturner);
     return ObjCBlock_Platypus.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BlockInheritTestChild init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'BlockInheritTestChild.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return BlockInheritTestChild.fromPointer(
@@ -257,23 +260,23 @@ extension BlockInheritTestChild$Methods on BlockInheritTestChild {
 
   /// invokeAccepter:
   bool invokeAccepter(DartAcceptPlatypus accepter) {
-    final _$$ = object$.ref;
-    final _$$$1 = accepter.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = accepter.ref;
     return _objc_msgSend_z0nr1o(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_invokeAccepter_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// invokeReturner:
   Mammal invokeReturner(DartReturnMammal returner) {
-    final _$$ = object$.ref;
-    final _$$$1 = returner.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = returner.ref;
     final $ret = _objc_msgSend_nnxkei(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_invokeReturner_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return Mammal.fromPointer($ret, retain: true, release: true);
   }
@@ -334,14 +337,14 @@ extension type Mammal._(objc.ObjCObject object$)
 extension Mammal$Methods on Mammal {
   /// init
   Mammal init() {
-    final _$$$2 = object$.ref;
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'Mammal.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return Mammal.fromPointer($ret, retain: false, release: true);
@@ -349,8 +352,8 @@ extension Mammal$Methods on Mammal {
 
   /// laysEggs
   bool laysEggs() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_91o635(_$$.pointer, _sel_laysEggs);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_laysEggs);
   }
 }
 
@@ -394,8 +397,8 @@ abstract final class ObjCBlock_Mammal {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<Mammal Function()>(
     objc.newClosureBlock(_closureCallable, () {
-      final _$$ = fn().ref;
-      return _$$.retainAndAutorelease();
+      final _$$ref = fn().ref;
+      return _$$ref.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -490,8 +493,8 @@ abstract final class ObjCBlock_Platypus {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<Platypus Function()>(
     objc.newClosureBlock(_closureCallable, () {
-      final _$$ = fn().ref;
-      return _$$.retainAndAutorelease();
+      final _$$ref = fn().ref;
+      return _$$ref.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -637,7 +640,7 @@ abstract final class ObjCBlock_bool_Mammal {
 extension ObjCBlock_bool_Mammal$CallExtension
     on objc.ObjCBlock<ffi.Bool Function(Mammal)> {
   bool call(Mammal arg0) {
-    final _$$ = arg0.ref;
+    final _$$ref = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -652,7 +655,7 @@ extension ObjCBlock_bool_Mammal$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, _$$.pointer);
+        >()(ref.pointer, _$$ref.pointer);
   }
 }
 
@@ -746,7 +749,7 @@ abstract final class ObjCBlock_bool_Platypus {
 extension ObjCBlock_bool_Platypus$CallExtension
     on objc.ObjCBlock<ffi.Bool Function(Platypus)> {
   bool call(Platypus arg0) {
-    final _$$ = arg0.ref;
+    final _$$ref = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -761,7 +764,7 @@ extension ObjCBlock_bool_Platypus$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, _$$.pointer);
+        >()(ref.pointer, _$$ref.pointer);
   }
 }
 
@@ -820,14 +823,14 @@ extension type Platypus._(objc.ObjCObject object$)
 extension Platypus$Methods on Platypus {
   /// init
   Platypus init() {
-    final _$$$3 = object$.ref;
+    final _$$ref$3 = object$.ref;
     objc.checkOsVersionInternal(
       'Platypus.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$3.retainAndReturnPointer(),
+      _$$ref$3.retainAndReturnPointer(),
       _sel_init,
     );
     return Platypus.fromPointer($ret, retain: false, release: true);

--- a/pkgs/ffigen/test/native_objc_test/block_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test_bindings.dart
@@ -1187,25 +1187,27 @@ abstract final class ObjCBlock_DummyObject_DummyObject {
 /// Call operator for `objc.ObjCBlock<DummyObject Function(DummyObject)>`.
 extension ObjCBlock_DummyObject_DummyObject$CallExtension
     on objc.ObjCBlock<DummyObject Function(DummyObject)> {
-  DummyObject call(DummyObject arg0) => DummyObject.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  DummyObject call(DummyObject arg0) {
+    return DummyObject.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<objc.ObjCObjectImpl>,
-          )
-        >()(ref.pointer, arg0.ref.pointer),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0.ref.pointer),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<DummyObject? Function(DummyObject?)>`.
@@ -1313,44 +1315,45 @@ abstract final class ObjCBlock_DummyObject_DummyObject$1 {
 /// Call operator for `objc.ObjCBlock<DummyObject? Function(DummyObject?)>`.
 extension ObjCBlock_DummyObject_DummyObject$1$CallExtension
     on objc.ObjCBlock<DummyObject? Function(DummyObject?)> {
-  DummyObject? call(DummyObject? arg0) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  DummyObject? call(DummyObject? arg0) {
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr)
-              .address ==
-          0
-      ? null
-      : DummyObject.fromPointer(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr)
+                .address ==
+            0
+        ? null
+        : DummyObject.fromPointer(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.
@@ -1391,11 +1394,9 @@ abstract final class ObjCBlock_Int32_Int32 {
     int Function(int) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (int arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1425,20 +1426,21 @@ abstract final class ObjCBlock_Int32_Int32 {
 /// Call operator for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.
 extension ObjCBlock_Int32_Int32$CallExtension
     on objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> {
-  int call(int arg0) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Int32 Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Int32 arg0,
-              )
-            >
-          >()
-          .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
-        ref.pointer,
-        arg0,
-      );
+  int call(int arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Int32 Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Int32 arg0,
+            )
+          >
+        >()
+        .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> Function(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>)>`.
@@ -1549,22 +1551,24 @@ extension ObjCBlock_IntBlock_IntBlock$CallExtension
             objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>,
           )
         > {
-  DartIntBlock call(DartIntBlock arg0) => ObjCBlock_Int32_Int32.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
-            IntBlock Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              IntBlock arg0,
-            )
-          >
-        >()
-        .asFunction<
-          IntBlock Function(ffi.Pointer<objc.ObjCBlockImpl>, IntBlock)
-        >()(ref.pointer, arg0.ref.pointer),
-    retain: true,
-    release: true,
-  );
+  DartIntBlock call(DartIntBlock arg0) {
+    return ObjCBlock_Int32_Int32.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              IntBlock Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                IntBlock arg0,
+              )
+            >
+          >()
+          .asFunction<
+            IntBlock Function(ffi.Pointer<objc.ObjCBlockImpl>, IntBlock)
+          >()(ref.pointer, arg0.ref.pointer),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<objc.NSString? Function(objc.NSString?)>`.
@@ -1672,44 +1676,45 @@ abstract final class ObjCBlock_NSString_NSString {
 /// Call operator for `objc.ObjCBlock<objc.NSString? Function(objc.NSString?)>`.
 extension ObjCBlock_NSString_NSString$CallExtension
     on objc.ObjCBlock<objc.NSString? Function(objc.NSString?)> {
-  objc.NSString? call(objc.NSString? arg0) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  objc.NSString? call(objc.NSString? arg0) {
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr)
-              .address ==
-          0
-      ? null
-      : objc.NSString.fromPointer(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr)
+                .address ==
+            0
+        ? null
+        : objc.NSString.fromPointer(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<Vec4 Function(Vec4)>`.
@@ -1750,11 +1755,9 @@ abstract final class ObjCBlock_Vec4_Vec4 {
     Vec4 Function(Vec4) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<Vec4 Function(Vec4)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (Vec4 arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (Vec4 arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1784,17 +1787,18 @@ abstract final class ObjCBlock_Vec4_Vec4 {
 /// Call operator for `objc.ObjCBlock<Vec4 Function(Vec4)>`.
 extension ObjCBlock_Vec4_Vec4$CallExtension
     on objc.ObjCBlock<Vec4 Function(Vec4)> {
-  Vec4 call(Vec4 arg0) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              Vec4 Function(ffi.Pointer<objc.ObjCBlockImpl> block, Vec4 arg0)
-            >
-          >()
-          .asFunction<Vec4 Function(ffi.Pointer<objc.ObjCBlockImpl>, Vec4)>()(
-        ref.pointer,
-        arg0,
-      );
+  Vec4 call(Vec4 arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            Vec4 Function(ffi.Pointer<objc.ObjCBlockImpl> block, Vec4 arg0)
+          >
+        >()
+        .asFunction<Vec4 Function(ffi.Pointer<objc.ObjCBlockImpl>, Vec4)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Double Function(ffi.Double)>`.
@@ -1835,11 +1839,9 @@ abstract final class ObjCBlock_ffiDouble_ffiDouble {
     double Function(double) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Double Function(ffi.Double)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (double arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (double arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1869,18 +1871,21 @@ abstract final class ObjCBlock_ffiDouble_ffiDouble {
 /// Call operator for `objc.ObjCBlock<ffi.Double Function(ffi.Double)>`.
 extension ObjCBlock_ffiDouble_ffiDouble$CallExtension
     on objc.ObjCBlock<ffi.Double Function(ffi.Double)> {
-  double call(double arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Double Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Double arg0,
-          )
-        >
-      >()
-      .asFunction<
-        double Function(ffi.Pointer<objc.ObjCBlockImpl>, double)
-      >()(ref.pointer, arg0);
+  double call(double arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Double Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Double arg0,
+            )
+          >
+        >()
+        .asFunction<double Function(ffi.Pointer<objc.ObjCBlockImpl>, double)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Float Function(ffi.Float)>`.
@@ -1921,11 +1926,9 @@ abstract final class ObjCBlock_ffiFloat_ffiFloat {
     double Function(double) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Float Function(ffi.Float)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (double arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (double arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1955,18 +1958,21 @@ abstract final class ObjCBlock_ffiFloat_ffiFloat {
 /// Call operator for `objc.ObjCBlock<ffi.Float Function(ffi.Float)>`.
 extension ObjCBlock_ffiFloat_ffiFloat$CallExtension
     on objc.ObjCBlock<ffi.Float Function(ffi.Float)> {
-  double call(double arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Float Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Float arg0,
-          )
-        >
-      >()
-      .asFunction<
-        double Function(ffi.Pointer<objc.ObjCBlockImpl>, double)
-      >()(ref.pointer, arg0);
+  double call(double arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Float Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Float arg0,
+            )
+          >
+        >()
+        .asFunction<double Function(ffi.Pointer<objc.ObjCBlockImpl>, double)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function()>`.
@@ -2007,7 +2013,9 @@ abstract final class ObjCBlock_ffiVoid {
     void Function() fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function()>(
-    objc.newClosureBlock(_closureCallable, () => fn(), keepIsolateAlive),
+    objc.newClosureBlock(_closureCallable, () {
+      return fn();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -2027,7 +2035,9 @@ abstract final class ObjCBlock_ffiVoid {
   }) {
     final raw = objc.newClosureBlock(
       _listenerCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapListenerBlock_1pl9qdv(raw);
@@ -2055,12 +2065,16 @@ abstract final class ObjCBlock_ffiVoid {
   }) {
     final raw = objc.newClosureBlock(
       _blockingCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_1pl9qdv(
@@ -2145,16 +2159,17 @@ abstract final class ObjCBlock_ffiVoid {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function()>`.
 extension ObjCBlock_ffiVoid$CallExtension
     on objc.ObjCBlock<ffi.Void Function()> {
-  void call() =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<objc.ObjCBlockImpl> block)
-            >
-          >()
-          .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>)>()(
-        ref.pointer,
-      );
+  void call() {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(ffi.Pointer<objc.ObjCBlockImpl> block)
+          >
+        >()
+        .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>)>()(
+      ref.pointer,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(DummyObject)>`.
@@ -2200,12 +2215,11 @@ abstract final class ObjCBlock_ffiVoid_DummyObject {
     void Function(DummyObject) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(DummyObject)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(DummyObject.fromPointer(arg0, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(DummyObject.fromPointer(arg0, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -2223,12 +2237,11 @@ abstract final class ObjCBlock_ffiVoid_DummyObject {
     void Function(DummyObject) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(DummyObject.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(DummyObject.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_xtuoz7(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(DummyObject)>(
@@ -2252,16 +2265,16 @@ abstract final class ObjCBlock_ffiVoid_DummyObject {
     void Function(DummyObject) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(DummyObject.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(DummyObject.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(DummyObject.fromPointer(arg0, retain: false, release: true)),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0) {
+        return fn(DummyObject.fromPointer(arg0, retain: false, release: true));
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_xtuoz7(
@@ -2385,21 +2398,23 @@ abstract final class ObjCBlock_ffiVoid_DummyObject {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(DummyObject)>`.
 extension ObjCBlock_ffiVoid_DummyObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(DummyObject)> {
-  void call(DummyObject arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  void call(DummyObject arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, arg0.ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(DummyObject?)>`.
@@ -2445,15 +2460,15 @@ abstract final class ObjCBlock_ffiVoid_DummyObject$1 {
     void Function(DummyObject?) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(DummyObject?)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : DummyObject.fromPointer(arg0, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -2471,15 +2486,15 @@ abstract final class ObjCBlock_ffiVoid_DummyObject$1 {
     void Function(DummyObject?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : DummyObject.fromPointer(arg0, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_xtuoz7(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(DummyObject?)>(
@@ -2503,22 +2518,24 @@ abstract final class ObjCBlock_ffiVoid_DummyObject$1 {
     void Function(DummyObject?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : DummyObject.fromPointer(arg0, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
-        arg0.address == 0
-            ? null
-            : DummyObject.fromPointer(arg0, retain: false, release: true),
-      ),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0) {
+        return fn(
+          arg0.address == 0
+              ? null
+              : DummyObject.fromPointer(arg0, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_xtuoz7(
@@ -2642,21 +2659,23 @@ abstract final class ObjCBlock_ffiVoid_DummyObject$1 {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(DummyObject?)>`.
 extension ObjCBlock_ffiVoid_DummyObject$1$CallExtension
     on objc.ObjCBlock<ffi.Void Function(DummyObject?)> {
-  void call(DummyObject? arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  void call(DummyObject? arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr);
+        >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Int32)>`.
@@ -2697,11 +2716,9 @@ abstract final class ObjCBlock_ffiVoid_Int32 {
     void Function(int) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Int32)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (int arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -2719,11 +2736,11 @@ abstract final class ObjCBlock_ffiVoid_Int32 {
     void Function(int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      int arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_1bqef4y(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Int32)>(
@@ -2747,14 +2764,16 @@ abstract final class ObjCBlock_ffiVoid_Int32 {
     void Function(int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      int arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (int arg0) => fn(arg0),
+      (int arg0) {
+        return fn(arg0);
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_1bqef4y(
@@ -2858,20 +2877,21 @@ abstract final class ObjCBlock_ffiVoid_Int32 {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Int32)>`.
 extension ObjCBlock_ffiVoid_Int32$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Int32)> {
-  void call(int arg0) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Int32 arg0,
-              )
-            >
-          >()
-          .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
-        ref.pointer,
-        arg0,
-      );
+  void call(int arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Int32 arg0,
+            )
+          >
+        >()
+        .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Int32>)>`.
@@ -2916,11 +2936,9 @@ abstract final class ObjCBlock_ffiVoid_Int32$1 {
     void Function(ffi.Pointer<ffi.Int32>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Int32>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Int32> arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Int32> arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -2938,11 +2956,11 @@ abstract final class ObjCBlock_ffiVoid_Int32$1 {
     void Function(ffi.Pointer<ffi.Int32>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Int32> arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Int32> arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_yhkuco(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Int32>)>(
@@ -2966,14 +2984,16 @@ abstract final class ObjCBlock_ffiVoid_Int32$1 {
     void Function(ffi.Pointer<ffi.Int32>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Int32> arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Int32> arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Int32> arg0) => fn(arg0),
+      (ffi.Pointer<ffi.Int32> arg0) {
+        return fn(arg0);
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_yhkuco(
@@ -3094,18 +3114,20 @@ abstract final class ObjCBlock_ffiVoid_Int32$1 {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Int32>)>`.
 extension ObjCBlock_ffiVoid_Int32$1$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Int32>)> {
-  void call(ffi.Pointer<ffi.Int32> arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Int32> arg0,
-          )
-        >
-      >()
-      .asFunction<
-        void Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Int32>)
-      >()(ref.pointer, arg0);
+  void call(ffi.Pointer<ffi.Int32> arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Int32> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Int32>)
+        >()(ref.pointer, arg0);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Int32, Vec4, ffi.Pointer<ffi.Char>)>`.
@@ -3163,12 +3185,13 @@ abstract final class ObjCBlock_ffiVoid_Int32_Vec4_ffiChar {
     bool keepIsolateAlive = true,
   }) =>
       objc.ObjCBlock<ffi.Void Function(ffi.Int32, Vec4, ffi.Pointer<ffi.Char>)>(
-        objc.newClosureBlock(
-          _closureCallable,
-          (int arg0, Vec4 arg1, ffi.Pointer<ffi.Char> arg2) =>
-              fn(arg0, arg1, arg2),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          int arg0,
+          Vec4 arg1,
+          ffi.Pointer<ffi.Char> arg2,
+        ) {
+          return fn(arg0, arg1, arg2);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -3189,11 +3212,13 @@ abstract final class ObjCBlock_ffiVoid_Int32_Vec4_ffiChar {
     void Function(int, Vec4, ffi.Pointer<ffi.Char>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (int arg0, Vec4 arg1, ffi.Pointer<ffi.Char> arg2) => fn(arg0, arg1, arg2),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      int arg0,
+      Vec4 arg1,
+      ffi.Pointer<ffi.Char> arg2,
+    ) {
+      return fn(arg0, arg1, arg2);
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_li50va(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -3218,14 +3243,18 @@ abstract final class ObjCBlock_ffiVoid_Int32_Vec4_ffiChar {
     void Function(int, Vec4, ffi.Pointer<ffi.Char>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (int arg0, Vec4 arg1, ffi.Pointer<ffi.Char> arg2) => fn(arg0, arg1, arg2),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      int arg0,
+      Vec4 arg1,
+      ffi.Pointer<ffi.Char> arg2,
+    ) {
+      return fn(arg0, arg1, arg2);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (int arg0, Vec4 arg1, ffi.Pointer<ffi.Char> arg2) => fn(arg0, arg1, arg2),
+      (int arg0, Vec4 arg1, ffi.Pointer<ffi.Char> arg2) {
+        return fn(arg0, arg1, arg2);
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_li50va(
@@ -3383,28 +3412,27 @@ extension ObjCBlock_ffiVoid_Int32_Vec4_ffiChar$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Int32, Vec4, ffi.Pointer<ffi.Char>)
         > {
-  void call(int arg0, Vec4 arg1, ffi.Pointer<ffi.Char> arg2) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Int32 arg0,
-            Vec4 arg1,
-            ffi.Pointer<ffi.Char> arg2,
+  void call(int arg0, Vec4 arg1, ffi.Pointer<ffi.Char> arg2) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Int32 arg0,
+              Vec4 arg1,
+              ffi.Pointer<ffi.Char> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            int,
+            Vec4,
+            ffi.Pointer<ffi.Char>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          int,
-          Vec4,
-          ffi.Pointer<ffi.Char>,
-        )
-      >()(ref.pointer, arg0, arg1, arg2);
+        >()(ref.pointer, arg0, arg1, arg2);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>)>`.
@@ -3459,17 +3487,15 @@ abstract final class ObjCBlock_ffiVoid_IntBlock {
       objc.ObjCBlock<
         ffi.Void Function(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (IntBlock arg0) => fn(
+        objc.newClosureBlock(_closureCallable, (IntBlock arg0) {
+          return fn(
             ObjCBlock_Int32_Int32.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -3487,13 +3513,13 @@ abstract final class ObjCBlock_ffiVoid_IntBlock {
     ffi.Void Function(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>)
   >
   listener(void Function(DartIntBlock) fn, {bool keepIsolateAlive = true}) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (IntBlock arg0) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      IntBlock arg0,
+    ) {
+      return fn(
         ObjCBlock_Int32_Int32.fromPointer(arg0, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_f167m6(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -3515,18 +3541,20 @@ abstract final class ObjCBlock_ffiVoid_IntBlock {
     ffi.Void Function(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>)
   >
   blocking(void Function(DartIntBlock) fn, {bool keepIsolateAlive = true}) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (IntBlock arg0) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      IntBlock arg0,
+    ) {
+      return fn(
         ObjCBlock_Int32_Int32.fromPointer(arg0, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (IntBlock arg0) => fn(
-        ObjCBlock_Int32_Int32.fromPointer(arg0, retain: false, release: true),
-      ),
+      (IntBlock arg0) {
+        return fn(
+          ObjCBlock_Int32_Int32.fromPointer(arg0, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_f167m6(
@@ -3631,18 +3659,21 @@ extension ObjCBlock_ffiVoid_IntBlock$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>)
         > {
-  void call(DartIntBlock arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            IntBlock arg0,
-          )
-        >
-      >()
-      .asFunction<
-        void Function(ffi.Pointer<objc.ObjCBlockImpl>, IntBlock)
-      >()(ref.pointer, arg0.ref.pointer);
+  void call(DartIntBlock arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              IntBlock arg0,
+            )
+          >
+        >()
+        .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>, IntBlock)>()(
+      ref.pointer,
+      arg0.ref.pointer,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(objc.NSString)>`.
@@ -3688,12 +3719,11 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(objc.NSString)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -3711,12 +3741,11 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_xtuoz7(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(objc.NSString)>(
@@ -3740,16 +3769,18 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0) {
+        return fn(
+          objc.NSString.fromPointer(arg0, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_xtuoz7(
@@ -3873,21 +3904,23 @@ abstract final class ObjCBlock_ffiVoid_NSString {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(objc.NSString)>`.
 extension ObjCBlock_ffiVoid_NSString$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSString)> {
-  void call(objc.NSString arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  void call(objc.NSString arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, arg0.ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(Vec2, Vec4, objc.NSObject)>`.
@@ -3940,15 +3973,17 @@ abstract final class ObjCBlock_ffiVoid_Vec2_Vec4_NSObject {
     void Function(Vec2, Vec4, objc.NSObject) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(Vec2, Vec4, objc.NSObject)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (Vec2 arg0, Vec4 arg1, ffi.Pointer<objc.ObjCObjectImpl> arg2) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      Vec2 arg0,
+      Vec4 arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+    ) {
+      return fn(
         arg0,
         arg1,
         objc.NSObject.fromPointer(arg2, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -3966,15 +4001,17 @@ abstract final class ObjCBlock_ffiVoid_Vec2_Vec4_NSObject {
     void Function(Vec2, Vec4, objc.NSObject) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (Vec2 arg0, Vec4 arg1, ffi.Pointer<objc.ObjCObjectImpl> arg2) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      Vec2 arg0,
+      Vec4 arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+    ) {
+      return fn(
         arg0,
         arg1,
         objc.NSObject.fromPointer(arg2, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_ru30ue(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(Vec2, Vec4, objc.NSObject)>(
@@ -3998,22 +4035,26 @@ abstract final class ObjCBlock_ffiVoid_Vec2_Vec4_NSObject {
     void Function(Vec2, Vec4, objc.NSObject) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (Vec2 arg0, Vec4 arg1, ffi.Pointer<objc.ObjCObjectImpl> arg2) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      Vec2 arg0,
+      Vec4 arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+    ) {
+      return fn(
         arg0,
         arg1,
         objc.NSObject.fromPointer(arg2, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (Vec2 arg0, Vec4 arg1, ffi.Pointer<objc.ObjCObjectImpl> arg2) => fn(
-        arg0,
-        arg1,
-        objc.NSObject.fromPointer(arg2, retain: false, release: true),
-      ),
+      (Vec2 arg0, Vec4 arg1, ffi.Pointer<objc.ObjCObjectImpl> arg2) {
+        return fn(
+          arg0,
+          arg1,
+          objc.NSObject.fromPointer(arg2, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_ru30ue(
@@ -4179,25 +4220,27 @@ abstract final class ObjCBlock_ffiVoid_Vec2_Vec4_NSObject {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(Vec2, Vec4, objc.NSObject)>`.
 extension ObjCBlock_ffiVoid_Vec2_Vec4_NSObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(Vec2, Vec4, objc.NSObject)> {
-  void call(Vec2 arg0, Vec4 arg1, objc.NSObject arg2) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            Vec2 arg0,
-            Vec4 arg1,
-            ffi.Pointer<objc.ObjCObjectImpl> arg2,
+  void call(Vec2 arg0, Vec4 arg1, objc.NSObject arg2) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              Vec2 arg0,
+              Vec4 arg1,
+              ffi.Pointer<objc.ObjCObjectImpl> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            Vec2,
+            Vec4,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          Vec2,
-          Vec4,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0, arg1, arg2.ref.pointer);
+        >()(ref.pointer, arg0, arg1, arg2.ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCSelector>)>`.
@@ -4244,11 +4287,11 @@ abstract final class ObjCBlock_ffiVoid_objcObjCSelector {
     void Function(ffi.Pointer<objc.ObjCSelector>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCSelector>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCSelector> arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCSelector> arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -4267,11 +4310,11 @@ abstract final class ObjCBlock_ffiVoid_objcObjCSelector {
     void Function(ffi.Pointer<objc.ObjCSelector>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCSelector> arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCSelector> arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final wrapper = _18tji2r_wrapListenerBlock_1d9e4oe(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCSelector>)>(
@@ -4296,14 +4339,16 @@ abstract final class ObjCBlock_ffiVoid_objcObjCSelector {
     void Function(ffi.Pointer<objc.ObjCSelector>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCSelector> arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCSelector> arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCSelector> arg0) => fn(arg0),
+      (ffi.Pointer<objc.ObjCSelector> arg0) {
+        return fn(arg0);
+      },
       keepIsolateAlive,
     );
     final wrapper = _18tji2r_wrapBlockingBlock_1d9e4oe(
@@ -4427,21 +4472,23 @@ abstract final class ObjCBlock_ffiVoid_objcObjCSelector {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCSelector>)>`.
 extension ObjCBlock_ffiVoid_objcObjCSelector$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCSelector>)> {
-  void call(ffi.Pointer<objc.ObjCSelector> arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCSelector> arg0,
+  void call(ffi.Pointer<objc.ObjCSelector> arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCSelector> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCSelector>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCSelector>,
-        )
-      >()(ref.pointer, arg0);
+        >()(ref.pointer, arg0);
+  }
 }
 
 typedef ObjectBlock = ffi.Pointer<objc.ObjCBlockImpl>;

--- a/pkgs/ffigen/test/native_objc_test/block_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test_bindings.dart
@@ -1130,13 +1130,14 @@ abstract final class ObjCBlock_DummyObject_DummyObject {
     DummyObject Function(DummyObject) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<DummyObject Function(DummyObject)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      final _$obj = fn(
         DummyObject.fromPointer(arg0, retain: true, release: true),
-      ).ref.retainAndAutorelease(),
-      keepIsolateAlive,
-    ),
+      );
+      return _$obj.ref.retainAndAutorelease();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1253,17 +1254,16 @@ abstract final class ObjCBlock_DummyObject_DummyObject$1 {
     DummyObject? Function(DummyObject?) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<DummyObject? Function(DummyObject?)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(
-            arg0.address == 0
-                ? null
-                : DummyObject.fromPointer(arg0, retain: true, release: true),
-          )?.ref.retainAndAutorelease() ??
-          ffi.nullptr,
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      final _$nullableObj = fn(
+        arg0.address == 0
+            ? null
+            : DummyObject.fromPointer(arg0, retain: true, release: true),
+      );
+      return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1505,17 +1505,16 @@ abstract final class ObjCBlock_IntBlock_IntBlock {
           objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (IntBlock arg0) => fn(
+        objc.newClosureBlock(_closureCallable, (IntBlock arg0) {
+          final _$obj = fn(
             ObjCBlock_Int32_Int32.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
-          ).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+          );
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -1614,17 +1613,16 @@ abstract final class ObjCBlock_NSString_NSString {
     objc.NSString? Function(objc.NSString?) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<objc.NSString? Function(objc.NSString?)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(
-            arg0.address == 0
-                ? null
-                : objc.NSString.fromPointer(arg0, retain: true, release: true),
-          )?.ref.retainAndAutorelease() ??
-          ffi.nullptr,
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      final _$nullableObj = fn(
+        arg0.address == 0
+            ? null
+            : objc.NSString.fromPointer(arg0, retain: true, release: true),
+      );
+      return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );

--- a/pkgs/ffigen/test/native_objc_test/block_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test_bindings.dart
@@ -230,51 +230,52 @@ extension type BlockTester._(objc.ObjCObject object$)
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Int32>)> blockingBlock, {
     required objc.ObjCBlock<ffi.Void Function(ffi.Int32)> resultBlock,
   }) {
+    final _$$ = blockingBlock.ref;
+    final _$$$1 = resultBlock.ref;
     _objc_msgSend_18yul99(
       _class_BlockTester,
       _sel_blockingBlockTest_resultBlock_,
-      blockingBlock.ref.pointer,
-      resultBlock.ref.pointer,
+      _$$.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// callDoubleBlock:
   static double callDoubleBlock(DartDoubleBlock block) {
+    final _$$ = block.ref;
     return objc.useMsgSendVariants
         ? _objc_msgSend_8mj2fvFpret(
             _class_BlockTester,
             _sel_callDoubleBlock_,
-            block.ref.pointer,
+            _$$.pointer,
           )
         : _objc_msgSend_8mj2fv(
             _class_BlockTester,
             _sel_callDoubleBlock_,
-            block.ref.pointer,
+            _$$.pointer,
           );
   }
 
   /// callFloatBlock:
   static double callFloatBlock(DartFloatBlock block) {
+    final _$$ = block.ref;
     return objc.useMsgSendVariants
         ? _objc_msgSend_o8bnmsFpret(
             _class_BlockTester,
             _sel_callFloatBlock_,
-            block.ref.pointer,
+            _$$.pointer,
           )
         : _objc_msgSend_o8bnms(
             _class_BlockTester,
             _sel_callFloatBlock_,
-            block.ref.pointer,
+            _$$.pointer,
           );
   }
 
   /// callListener:
   static void callListener(DartListenerBlock block) {
-    _objc_msgSend_f167m6(
-      _class_BlockTester,
-      _sel_callListener_,
-      block.ref.pointer,
-    );
+    final _$$ = block.ref;
+    _objc_msgSend_f167m6(_class_BlockTester, _sel_callListener_, _$$.pointer);
   }
 
   /// callNSStringListener:x:
@@ -282,38 +283,42 @@ extension type BlockTester._(objc.ObjCObject object$)
     DartNSStringListenerBlock block, {
     required int x,
   }) {
+    final _$$ = block.ref;
     _objc_msgSend_po4t03(
       _class_BlockTester,
       _sel_callNSStringListener_x_,
-      block.ref.pointer,
+      _$$.pointer,
       x,
     );
   }
 
   /// callNoTrampolineListener:
   static void callNoTrampolineListener(DartNoTrampolineListenerBlock block) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callNoTrampolineListener_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// callNullableListener:
   static void callNullableListener(DartNullableListenerBlock block) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callNullableListener_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// callNullableObjectBlock:
   static DummyObject? callNullableObjectBlock(DartNullableObjectBlock block) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callNullableObjectBlock_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return $ret.address == 0
         ? null
@@ -324,10 +329,11 @@ extension type BlockTester._(objc.ObjCObject object$)
   static objc.NSString? callNullableStringBlock(
     objc.ObjCBlock<objc.NSString? Function(objc.NSString?)> block,
   ) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callNullableStringBlock_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return $ret.address == 0
         ? null
@@ -336,83 +342,91 @@ extension type BlockTester._(objc.ObjCObject object$)
 
   /// callObjectBlock:
   static DummyObject callObjectBlock(DartObjectBlock block) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callObjectBlock_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return DummyObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// callObjectListener:
   static void callObjectListener(DartObjectListenerBlock block) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callObjectListener_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// callOnNewThread:
   static NSThread callOnNewThread(DartVoidBlock block) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callOnNewThread_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
 
   /// callOnSameThread:
   static void callOnSameThread(DartVoidBlock block) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callOnSameThread_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// callOnSameThreadOutsideIsolate:
   static void callOnSameThreadOutsideIsolate(DartVoidBlock block) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callOnSameThreadOutsideIsolate_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// callSelectorBlock:
   static void callSelectorBlock(DartSelectorBlock block) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callSelectorBlock_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// callStructListener:
   static void callStructListener(DartStructListenerBlock block) {
+    final _$$ = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callStructListener_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// callVec4Block:
   static Vec4 callVec4Block(DartVec4Block block) {
+    final _$$ = block.ref;
     final $ptr = pkg_ffi.calloc<Vec4>();
     objc.useMsgSendVariants
         ? _objc_msgSend_1gew1vmStret(
             $ptr,
             _class_BlockTester,
             _sel_callVec4Block_,
-            block.ref.pointer,
+            _$$.pointer,
           )
         : $ptr.ref = _objc_msgSend_1gew1vm(
             _class_BlockTester,
             _sel_callVec4Block_,
-            block.ref.pointer,
+            _$$.pointer,
           );
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<Vec4>(),
@@ -423,10 +437,11 @@ extension type BlockTester._(objc.ObjCObject object$)
 
   /// callWithBlockOnNewThread:
   static NSThread callWithBlockOnNewThread(DartListenerBlock block) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callWithBlockOnNewThread_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
@@ -439,10 +454,11 @@ extension type BlockTester._(objc.ObjCObject object$)
 
   /// newBlock:withMult:
   static DartIntBlock newBlock(DartBlockBlock block, {required int withMult}) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_jevgay(
       _class_BlockTester,
       _sel_newBlock_withMult_,
-      block.ref.pointer,
+      _$$.pointer,
       withMult,
     );
     return ObjCBlock_Int32_Int32.fromPointer(
@@ -468,20 +484,22 @@ extension type BlockTester._(objc.ObjCObject object$)
 
   /// newFromBlock:
   static BlockTester newFromBlock(DartIntBlock block) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_newFromBlock_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return BlockTester.fromPointer($ret, retain: false, release: true);
   }
 
   /// newFromListener:
   static BlockTester newFromListener(DartObjectListenerBlock block) {
+    final _$$ = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_newFromListener_,
-      block.ref.pointer,
+      _$$.pointer,
     );
     return BlockTester.fromPointer($ret, retain: false, release: true);
   }
@@ -508,12 +526,14 @@ extension type BlockTester._(objc.ObjCObject object$)
 extension BlockTester$Methods on BlockTester {
   /// call:
   int call(int x) {
-    return _objc_msgSend_zo3bvx(object$.ref.pointer, _sel_call_, x);
+    final _$$ = object$.ref;
+    return _objc_msgSend_zo3bvx(_$$.pointer, _sel_call_, x);
   }
 
   /// getBlock
   DartIntBlock getBlock() {
-    final $ret = _objc_msgSend_uwvaik(object$.ref.pointer, _sel_getBlock);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getBlock);
     return ObjCBlock_Int32_Int32.fromPointer(
       $ret,
       retain: false,
@@ -523,38 +543,40 @@ extension BlockTester$Methods on BlockTester {
 
   /// init
   BlockTester init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'BlockTester.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return BlockTester.fromPointer($ret, retain: false, release: true);
   }
 
   /// invokeAndReleaseListener:
   void invokeAndReleaseListener(objc.ObjCObject? _$) {
+    final _$$ = object$.ref;
+    final _$$$1 = _$?.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_invokeAndReleaseListener_,
-      _$?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// invokeAndReleaseListenerOnNewThread
   void invokeAndReleaseListenerOnNewThread() {
+    final _$$ = object$.ref;
     _objc_msgSend_1pl9qdv(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_invokeAndReleaseListenerOnNewThread,
     );
   }
 
   /// pokeBlock
   void pokeBlock() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_pokeBlock);
+    final _$$ = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_pokeBlock);
   }
 }
 
@@ -626,18 +648,20 @@ extension type DummyObject._(objc.ObjCObject object$)
 extension DummyObject$Methods on DummyObject {
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_dealloc);
+    final _$$ = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
   }
 
   /// init
   DummyObject init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'DummyObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return DummyObject.fromPointer($ret, retain: false, release: true);
@@ -645,8 +669,9 @@ extension DummyObject$Methods on DummyObject {
 
   /// initWithCounter:
   DummyObject initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );
@@ -655,7 +680,8 @@ extension DummyObject$Methods on DummyObject {
 
   /// setCounter:
   void setCounter(ffi.Pointer<ffi.Int32> _counter) {
-    _objc_msgSend_yhkuco(object$.ref.pointer, _sel_setCounter_, _counter);
+    final _$$ = object$.ref;
+    _objc_msgSend_yhkuco(_$$.pointer, _sel_setCounter_, _counter);
   }
 }
 
@@ -751,12 +777,14 @@ extension type NSThread._(objc.ObjCObject object$)
     required objc.ObjCObject toTarget,
     objc.ObjCObject? withObject,
   }) {
+    final _$$ = toTarget.ref;
+    final _$$$1 = withObject?.ref;
     _objc_msgSend_lzbvjm(
       _class_NSThread,
       _sel_detachNewThreadSelector_toTarget_withObject_,
       selector,
-      toTarget.ref.pointer,
-      withObject?.ref.pointer ?? ffi.nullptr,
+      _$$.pointer,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -764,6 +792,7 @@ extension type NSThread._(objc.ObjCObject object$)
   static void detachNewThreadWithBlock(
     objc.ObjCBlock<ffi.Void Function()> block,
   ) {
+    final _$$ = block.ref;
     objc.checkOsVersionInternal(
       'NSThread.detachNewThreadWithBlock:',
       iOS: (false, (10, 0, 0)),
@@ -772,7 +801,7 @@ extension type NSThread._(objc.ObjCObject object$)
     _objc_msgSend_f167m6(
       _class_NSThread,
       _sel_detachNewThreadWithBlock_,
-      block.ref.pointer,
+      _$$.pointer,
     );
   }
 
@@ -825,11 +854,8 @@ extension type NSThread._(objc.ObjCObject object$)
 
   /// sleepUntilDate:
   static void sleepUntilDate(objc.NSDate date) {
-    _objc_msgSend_xtuoz7(
-      _class_NSThread,
-      _sel_sleepUntilDate_,
-      date.ref.pointer,
-    );
+    final _$$ = date.ref;
+    _objc_msgSend_xtuoz7(_class_NSThread, _sel_sleepUntilDate_, _$$.pointer);
   }
 
   /// threadPriority
@@ -846,23 +872,25 @@ extension type NSThread._(objc.ObjCObject object$)
 extension NSThread$Methods on NSThread {
   /// cancel
   void cancel() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.cancel',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_cancel);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_cancel);
   }
 
   /// init
   NSThread init() {
+    final _$$$2 = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_init,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
@@ -870,15 +898,17 @@ extension NSThread$Methods on NSThread {
 
   /// initWithBlock:
   NSThread initWithBlock(objc.ObjCBlock<ffi.Void Function()> block) {
+    final _$$ = object$.ref;
+    final _$$$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSThread.initWithBlock:',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithBlock_,
-      block.ref.pointer,
+      _$$$1.pointer,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
@@ -889,79 +919,88 @@ extension NSThread$Methods on NSThread {
     required ffi.Pointer<objc.ObjCSelector> selector,
     objc.ObjCObject? object,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = target.ref;
+    final _$$$2 = object?.ref;
     objc.checkOsVersionInternal(
       'NSThread.initWithTarget:selector:object:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_1eldwyi(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithTarget_selector_object_,
-      target.ref.pointer,
+      _$$$1.pointer,
       selector,
-      object?.ref.pointer ?? ffi.nullptr,
+      _$$$2?.pointer ?? ffi.nullptr,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
 
   /// isCancelled
   bool get isCancelled {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isCancelled',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isCancelled);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isCancelled);
   }
 
   /// isExecuting
   bool get isExecuting {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isExecuting',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isExecuting);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isExecuting);
   }
 
   /// isFinished
   bool get isFinished {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isFinished',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isFinished);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isFinished);
   }
 
   /// isMainThread
   bool get isMainThread {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isMainThread',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isMainThread);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isMainThread);
   }
 
   /// main
   void main() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.main',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_main);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_main);
   }
 
   /// name
   objc.NSString? get name {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.name',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_name);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -969,92 +1008,91 @@ extension NSThread$Methods on NSThread {
 
   /// qualityOfService
   objc.NSQualityOfService get qualityOfService {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.qualityOfService',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
-    final $ret = _objc_msgSend_oi8iq9(
-      object$.ref.pointer,
-      _sel_qualityOfService,
-    );
+    final $ret = _objc_msgSend_oi8iq9(_$$.pointer, _sel_qualityOfService);
     return objc.NSQualityOfService.fromValue($ret);
   }
 
   /// setName:
   set name(objc.NSString? value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSThread.setName:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setName_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setQualityOfService:
   set qualityOfService(objc.NSQualityOfService value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setQualityOfService:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
-    _objc_msgSend_n2da1l(
-      object$.ref.pointer,
-      _sel_setQualityOfService_,
-      value.value,
-    );
+    _objc_msgSend_n2da1l(_$$.pointer, _sel_setQualityOfService_, value.value);
   }
 
   /// setStackSize:
   set stackSize(int value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setStackSize:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1i9r4xy(object$.ref.pointer, _sel_setStackSize_, value);
+    _objc_msgSend_1i9r4xy(_$$.pointer, _sel_setStackSize_, value);
   }
 
   /// setThreadPriority:
   set threadPriority(double value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setThreadPriority:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    _objc_msgSend_hwm8nu(object$.ref.pointer, _sel_setThreadPriority_, value);
+    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setThreadPriority_, value);
   }
 
   /// stackSize
   int get stackSize {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.stackSize',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_stackSize);
+    return _objc_msgSend_xw2lbc(_$$.pointer, _sel_stackSize);
   }
 
   /// start
   void start() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.start',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_start);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_start);
   }
 
   /// threadDictionary
   objc.NSMutableDictionary get threadDictionary {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_threadDictionary,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_threadDictionary);
     return objc.NSMutableDictionary.fromPointer(
       $ret,
       retain: true,
@@ -1064,14 +1102,15 @@ extension NSThread$Methods on NSThread {
 
   /// threadPriority
   double get threadPriority {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.threadPriority',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_threadPriority)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_threadPriority);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_threadPriority)
+        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_threadPriority);
   }
 }
 
@@ -1133,10 +1172,10 @@ abstract final class ObjCBlock_DummyObject_DummyObject {
     objc.newClosureBlock(_closureCallable, (
       ffi.Pointer<objc.ObjCObjectImpl> arg0,
     ) {
-      final _$obj = fn(
+      final _$$ = fn(
         DummyObject.fromPointer(arg0, retain: true, release: true),
-      );
-      return _$obj.ref.retainAndAutorelease();
+      ).ref;
+      return _$$.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -1188,6 +1227,7 @@ abstract final class ObjCBlock_DummyObject_DummyObject {
 extension ObjCBlock_DummyObject_DummyObject$CallExtension
     on objc.ObjCBlock<DummyObject Function(DummyObject)> {
   DummyObject call(DummyObject arg0) {
+    final _$$$1 = arg0.ref;
     return DummyObject.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -1203,7 +1243,7 @@ extension ObjCBlock_DummyObject_DummyObject$CallExtension
               ffi.Pointer<objc.ObjCBlockImpl>,
               ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >()(ref.pointer, arg0.ref.pointer),
+          >()(ref.pointer, _$$$1.pointer),
       retain: true,
       release: true,
     );
@@ -1259,12 +1299,12 @@ abstract final class ObjCBlock_DummyObject_DummyObject$1 {
     objc.newClosureBlock(_closureCallable, (
       ffi.Pointer<objc.ObjCObjectImpl> arg0,
     ) {
-      final _$nullableObj = fn(
+      final _$$ = fn(
         arg0.address == 0
             ? null
             : DummyObject.fromPointer(arg0, retain: true, release: true),
-      );
-      return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+      )?.ref;
+      return _$$?.retainAndAutorelease() ?? ffi.nullptr;
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -1316,6 +1356,7 @@ abstract final class ObjCBlock_DummyObject_DummyObject$1 {
 extension ObjCBlock_DummyObject_DummyObject$1$CallExtension
     on objc.ObjCBlock<DummyObject? Function(DummyObject?)> {
   DummyObject? call(DummyObject? arg0) {
+    final _$$$1 = arg0?.ref;
     return ref.pointer.ref.invoke
                 .cast<
                   ffi.NativeFunction<
@@ -1330,7 +1371,7 @@ extension ObjCBlock_DummyObject_DummyObject$1$CallExtension
                     ffi.Pointer<objc.ObjCBlockImpl>,
                     ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr)
+                >()(ref.pointer, _$$$1?.pointer ?? ffi.nullptr)
                 .address ==
             0
         ? null
@@ -1349,7 +1390,7 @@ extension ObjCBlock_DummyObject_DummyObject$1$CallExtension
                     ffi.Pointer<objc.ObjCBlockImpl>,
                     ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr),
+                >()(ref.pointer, _$$$1?.pointer ?? ffi.nullptr),
             retain: true,
             release: true,
           );
@@ -1508,14 +1549,14 @@ abstract final class ObjCBlock_IntBlock_IntBlock {
         )
       >(
         objc.newClosureBlock(_closureCallable, (IntBlock arg0) {
-          final _$obj = fn(
+          final _$$ = fn(
             ObjCBlock_Int32_Int32.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
-          );
-          return _$obj.ref.retainAndAutorelease();
+          ).ref;
+          return _$$.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -1552,6 +1593,7 @@ extension ObjCBlock_IntBlock_IntBlock$CallExtension
           )
         > {
   DartIntBlock call(DartIntBlock arg0) {
+    final _$$$1 = arg0.ref;
     return ObjCBlock_Int32_Int32.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -1564,7 +1606,7 @@ extension ObjCBlock_IntBlock_IntBlock$CallExtension
           >()
           .asFunction<
             IntBlock Function(ffi.Pointer<objc.ObjCBlockImpl>, IntBlock)
-          >()(ref.pointer, arg0.ref.pointer),
+          >()(ref.pointer, _$$$1.pointer),
       retain: true,
       release: true,
     );
@@ -1620,12 +1662,12 @@ abstract final class ObjCBlock_NSString_NSString {
     objc.newClosureBlock(_closureCallable, (
       ffi.Pointer<objc.ObjCObjectImpl> arg0,
     ) {
-      final _$nullableObj = fn(
+      final _$$ = fn(
         arg0.address == 0
             ? null
             : objc.NSString.fromPointer(arg0, retain: true, release: true),
-      );
-      return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+      )?.ref;
+      return _$$?.retainAndAutorelease() ?? ffi.nullptr;
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -1677,6 +1719,7 @@ abstract final class ObjCBlock_NSString_NSString {
 extension ObjCBlock_NSString_NSString$CallExtension
     on objc.ObjCBlock<objc.NSString? Function(objc.NSString?)> {
   objc.NSString? call(objc.NSString? arg0) {
+    final _$$$1 = arg0?.ref;
     return ref.pointer.ref.invoke
                 .cast<
                   ffi.NativeFunction<
@@ -1691,7 +1734,7 @@ extension ObjCBlock_NSString_NSString$CallExtension
                     ffi.Pointer<objc.ObjCBlockImpl>,
                     ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr)
+                >()(ref.pointer, _$$$1?.pointer ?? ffi.nullptr)
                 .address ==
             0
         ? null
@@ -1710,7 +1753,7 @@ extension ObjCBlock_NSString_NSString$CallExtension
                     ffi.Pointer<objc.ObjCBlockImpl>,
                     ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr),
+                >()(ref.pointer, _$$$1?.pointer ?? ffi.nullptr),
             retain: true,
             release: true,
           );
@@ -2399,6 +2442,7 @@ abstract final class ObjCBlock_ffiVoid_DummyObject {
 extension ObjCBlock_ffiVoid_DummyObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(DummyObject)> {
   void call(DummyObject arg0) {
+    final _$$ = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -2413,7 +2457,7 @@ extension ObjCBlock_ffiVoid_DummyObject$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, _$$.pointer);
   }
 }
 
@@ -2660,6 +2704,7 @@ abstract final class ObjCBlock_ffiVoid_DummyObject$1 {
 extension ObjCBlock_ffiVoid_DummyObject$1$CallExtension
     on objc.ObjCBlock<ffi.Void Function(DummyObject?)> {
   void call(DummyObject? arg0) {
+    final _$$ = arg0?.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -2674,7 +2719,7 @@ extension ObjCBlock_ffiVoid_DummyObject$1$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr);
+        >()(ref.pointer, _$$?.pointer ?? ffi.nullptr);
   }
 }
 
@@ -3660,6 +3705,7 @@ extension ObjCBlock_ffiVoid_IntBlock$CallExtension
           ffi.Void Function(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>)
         > {
   void call(DartIntBlock arg0) {
+    final _$$ = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -3671,7 +3717,7 @@ extension ObjCBlock_ffiVoid_IntBlock$CallExtension
         >()
         .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>, IntBlock)>()(
       ref.pointer,
-      arg0.ref.pointer,
+      _$$.pointer,
     );
   }
 }
@@ -3905,6 +3951,7 @@ abstract final class ObjCBlock_ffiVoid_NSString {
 extension ObjCBlock_ffiVoid_NSString$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSString)> {
   void call(objc.NSString arg0) {
+    final _$$ = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -3919,7 +3966,7 @@ extension ObjCBlock_ffiVoid_NSString$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, _$$.pointer);
   }
 }
 
@@ -4221,6 +4268,7 @@ abstract final class ObjCBlock_ffiVoid_Vec2_Vec4_NSObject {
 extension ObjCBlock_ffiVoid_Vec2_Vec4_NSObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(Vec2, Vec4, objc.NSObject)> {
   void call(Vec2 arg0, Vec4 arg1, objc.NSObject arg2) {
+    final _$$ = arg2.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -4239,7 +4287,7 @@ extension ObjCBlock_ffiVoid_Vec2_Vec4_NSObject$CallExtension
             Vec4,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0, arg1, arg2.ref.pointer);
+        >()(ref.pointer, arg0, arg1, _$$.pointer);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/block_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test_bindings.dart
@@ -230,52 +230,56 @@ extension type BlockTester._(objc.ObjCObject object$)
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Int32>)> blockingBlock, {
     required objc.ObjCBlock<ffi.Void Function(ffi.Int32)> resultBlock,
   }) {
-    final _$$ = blockingBlock.ref;
-    final _$$$1 = resultBlock.ref;
+    final _$$ref = blockingBlock.ref;
+    final _$$ref$1 = resultBlock.ref;
     _objc_msgSend_18yul99(
       _class_BlockTester,
       _sel_blockingBlockTest_resultBlock_,
-      _$$.pointer,
-      _$$$1.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// callDoubleBlock:
   static double callDoubleBlock(DartDoubleBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     return objc.useMsgSendVariants
         ? _objc_msgSend_8mj2fvFpret(
             _class_BlockTester,
             _sel_callDoubleBlock_,
-            _$$.pointer,
+            _$$ref.pointer,
           )
         : _objc_msgSend_8mj2fv(
             _class_BlockTester,
             _sel_callDoubleBlock_,
-            _$$.pointer,
+            _$$ref.pointer,
           );
   }
 
   /// callFloatBlock:
   static double callFloatBlock(DartFloatBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     return objc.useMsgSendVariants
         ? _objc_msgSend_o8bnmsFpret(
             _class_BlockTester,
             _sel_callFloatBlock_,
-            _$$.pointer,
+            _$$ref.pointer,
           )
         : _objc_msgSend_o8bnms(
             _class_BlockTester,
             _sel_callFloatBlock_,
-            _$$.pointer,
+            _$$ref.pointer,
           );
   }
 
   /// callListener:
   static void callListener(DartListenerBlock block) {
-    final _$$ = block.ref;
-    _objc_msgSend_f167m6(_class_BlockTester, _sel_callListener_, _$$.pointer);
+    final _$$ref = block.ref;
+    _objc_msgSend_f167m6(
+      _class_BlockTester,
+      _sel_callListener_,
+      _$$ref.pointer,
+    );
   }
 
   /// callNSStringListener:x:
@@ -283,42 +287,42 @@ extension type BlockTester._(objc.ObjCObject object$)
     DartNSStringListenerBlock block, {
     required int x,
   }) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_po4t03(
       _class_BlockTester,
       _sel_callNSStringListener_x_,
-      _$$.pointer,
+      _$$ref.pointer,
       x,
     );
   }
 
   /// callNoTrampolineListener:
   static void callNoTrampolineListener(DartNoTrampolineListenerBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callNoTrampolineListener_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// callNullableListener:
   static void callNullableListener(DartNullableListenerBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callNullableListener_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// callNullableObjectBlock:
   static DummyObject? callNullableObjectBlock(DartNullableObjectBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callNullableObjectBlock_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -329,11 +333,11 @@ extension type BlockTester._(objc.ObjCObject object$)
   static objc.NSString? callNullableStringBlock(
     objc.ObjCBlock<objc.NSString? Function(objc.NSString?)> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callNullableStringBlock_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -342,91 +346,91 @@ extension type BlockTester._(objc.ObjCObject object$)
 
   /// callObjectBlock:
   static DummyObject callObjectBlock(DartObjectBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callObjectBlock_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return DummyObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// callObjectListener:
   static void callObjectListener(DartObjectListenerBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callObjectListener_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// callOnNewThread:
   static NSThread callOnNewThread(DartVoidBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callOnNewThread_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
 
   /// callOnSameThread:
   static void callOnSameThread(DartVoidBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callOnSameThread_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// callOnSameThreadOutsideIsolate:
   static void callOnSameThreadOutsideIsolate(DartVoidBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callOnSameThreadOutsideIsolate_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// callSelectorBlock:
   static void callSelectorBlock(DartSelectorBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callSelectorBlock_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// callStructListener:
   static void callStructListener(DartStructListenerBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     _objc_msgSend_f167m6(
       _class_BlockTester,
       _sel_callStructListener_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// callVec4Block:
   static Vec4 callVec4Block(DartVec4Block block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ptr = pkg_ffi.calloc<Vec4>();
     objc.useMsgSendVariants
         ? _objc_msgSend_1gew1vmStret(
             $ptr,
             _class_BlockTester,
             _sel_callVec4Block_,
-            _$$.pointer,
+            _$$ref.pointer,
           )
         : $ptr.ref = _objc_msgSend_1gew1vm(
             _class_BlockTester,
             _sel_callVec4Block_,
-            _$$.pointer,
+            _$$ref.pointer,
           );
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<Vec4>(),
@@ -437,11 +441,11 @@ extension type BlockTester._(objc.ObjCObject object$)
 
   /// callWithBlockOnNewThread:
   static NSThread callWithBlockOnNewThread(DartListenerBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_callWithBlockOnNewThread_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
@@ -454,11 +458,11 @@ extension type BlockTester._(objc.ObjCObject object$)
 
   /// newBlock:withMult:
   static DartIntBlock newBlock(DartBlockBlock block, {required int withMult}) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_jevgay(
       _class_BlockTester,
       _sel_newBlock_withMult_,
-      _$$.pointer,
+      _$$ref.pointer,
       withMult,
     );
     return ObjCBlock_Int32_Int32.fromPointer(
@@ -484,22 +488,22 @@ extension type BlockTester._(objc.ObjCObject object$)
 
   /// newFromBlock:
   static BlockTester newFromBlock(DartIntBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_newFromBlock_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return BlockTester.fromPointer($ret, retain: false, release: true);
   }
 
   /// newFromListener:
   static BlockTester newFromListener(DartObjectListenerBlock block) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     final $ret = _objc_msgSend_nnxkei(
       _class_BlockTester,
       _sel_newFromListener_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return BlockTester.fromPointer($ret, retain: false, release: true);
   }
@@ -526,14 +530,14 @@ extension type BlockTester._(objc.ObjCObject object$)
 extension BlockTester$Methods on BlockTester {
   /// call:
   int call(int x) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_zo3bvx(_$$.pointer, _sel_call_, x);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_zo3bvx(_$$ref.pointer, _sel_call_, x);
   }
 
   /// getBlock
   DartIntBlock getBlock() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_uwvaik(_$$.pointer, _sel_getBlock);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_getBlock);
     return ObjCBlock_Int32_Int32.fromPointer(
       $ret,
       retain: false,
@@ -543,40 +547,43 @@ extension BlockTester$Methods on BlockTester {
 
   /// init
   BlockTester init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'BlockTester.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return BlockTester.fromPointer($ret, retain: false, release: true);
   }
 
   /// invokeAndReleaseListener:
   void invokeAndReleaseListener(objc.ObjCObject? _$) {
-    final _$$ = object$.ref;
-    final _$$$1 = _$?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = _$?.ref;
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_invokeAndReleaseListener_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// invokeAndReleaseListenerOnNewThread
   void invokeAndReleaseListenerOnNewThread() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     _objc_msgSend_1pl9qdv(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_invokeAndReleaseListenerOnNewThread,
     );
   }
 
   /// pokeBlock
   void pokeBlock() {
-    final _$$ = object$.ref;
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_pokeBlock);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_pokeBlock);
   }
 }
 
@@ -648,20 +655,20 @@ extension type DummyObject._(objc.ObjCObject object$)
 extension DummyObject$Methods on DummyObject {
   /// dealloc
   void dealloc() {
-    final _$$ = object$.ref;
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_dealloc);
   }
 
   /// init
   DummyObject init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'DummyObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return DummyObject.fromPointer($ret, retain: false, release: true);
@@ -669,9 +676,9 @@ extension DummyObject$Methods on DummyObject {
 
   /// initWithCounter:
   DummyObject initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );
@@ -680,8 +687,8 @@ extension DummyObject$Methods on DummyObject {
 
   /// setCounter:
   void setCounter(ffi.Pointer<ffi.Int32> _counter) {
-    final _$$ = object$.ref;
-    _objc_msgSend_yhkuco(_$$.pointer, _sel_setCounter_, _counter);
+    final _$$ref = object$.ref;
+    _objc_msgSend_yhkuco(_$$ref.pointer, _sel_setCounter_, _counter);
   }
 }
 
@@ -777,14 +784,14 @@ extension type NSThread._(objc.ObjCObject object$)
     required objc.ObjCObject toTarget,
     objc.ObjCObject? withObject,
   }) {
-    final _$$ = toTarget.ref;
-    final _$$$1 = withObject?.ref;
+    final _$$ref = toTarget.ref;
+    final _$$ref$1 = withObject?.ref;
     _objc_msgSend_lzbvjm(
       _class_NSThread,
       _sel_detachNewThreadSelector_toTarget_withObject_,
       selector,
-      _$$.pointer,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -792,7 +799,7 @@ extension type NSThread._(objc.ObjCObject object$)
   static void detachNewThreadWithBlock(
     objc.ObjCBlock<ffi.Void Function()> block,
   ) {
-    final _$$ = block.ref;
+    final _$$ref = block.ref;
     objc.checkOsVersionInternal(
       'NSThread.detachNewThreadWithBlock:',
       iOS: (false, (10, 0, 0)),
@@ -801,7 +808,7 @@ extension type NSThread._(objc.ObjCObject object$)
     _objc_msgSend_f167m6(
       _class_NSThread,
       _sel_detachNewThreadWithBlock_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -854,8 +861,8 @@ extension type NSThread._(objc.ObjCObject object$)
 
   /// sleepUntilDate:
   static void sleepUntilDate(objc.NSDate date) {
-    final _$$ = date.ref;
-    _objc_msgSend_xtuoz7(_class_NSThread, _sel_sleepUntilDate_, _$$.pointer);
+    final _$$ref = date.ref;
+    _objc_msgSend_xtuoz7(_class_NSThread, _sel_sleepUntilDate_, _$$ref.pointer);
   }
 
   /// threadPriority
@@ -872,25 +879,25 @@ extension type NSThread._(objc.ObjCObject object$)
 extension NSThread$Methods on NSThread {
   /// cancel
   void cancel() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.cancel',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_cancel);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_cancel);
   }
 
   /// init
   NSThread init() {
-    final _$$$2 = object$.ref;
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
@@ -898,17 +905,17 @@ extension NSThread$Methods on NSThread {
 
   /// initWithBlock:
   NSThread initWithBlock(objc.ObjCBlock<ffi.Void Function()> block) {
-    final _$$ = object$.ref;
-    final _$$$1 = block.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSThread.initWithBlock:',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBlock_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
@@ -919,88 +926,88 @@ extension NSThread$Methods on NSThread {
     required ffi.Pointer<objc.ObjCSelector> selector,
     objc.ObjCObject? object,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = target.ref;
-    final _$$$2 = object?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = target.ref;
+    final _$$ref$2 = object?.ref;
     objc.checkOsVersionInternal(
       'NSThread.initWithTarget:selector:object:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_1eldwyi(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithTarget_selector_object_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
       selector,
-      _$$$2?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSThread.fromPointer($ret, retain: false, release: true);
   }
 
   /// isCancelled
   bool get isCancelled {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isCancelled',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isCancelled);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isCancelled);
   }
 
   /// isExecuting
   bool get isExecuting {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isExecuting',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isExecuting);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isExecuting);
   }
 
   /// isFinished
   bool get isFinished {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isFinished',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isFinished);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isFinished);
   }
 
   /// isMainThread
   bool get isMainThread {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.isMainThread',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isMainThread);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isMainThread);
   }
 
   /// main
   void main() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.main',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_main);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_main);
   }
 
   /// name
   objc.NSString? get name {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.name',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_name);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_name);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -1008,91 +1015,95 @@ extension NSThread$Methods on NSThread {
 
   /// qualityOfService
   objc.NSQualityOfService get qualityOfService {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.qualityOfService',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
-    final $ret = _objc_msgSend_oi8iq9(_$$.pointer, _sel_qualityOfService);
+    final $ret = _objc_msgSend_oi8iq9(_$$ref.pointer, _sel_qualityOfService);
     return objc.NSQualityOfService.fromValue($ret);
   }
 
   /// setName:
   set name(objc.NSString? value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSThread.setName:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setName_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setQualityOfService:
   set qualityOfService(objc.NSQualityOfService value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setQualityOfService:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
-    _objc_msgSend_n2da1l(_$$.pointer, _sel_setQualityOfService_, value.value);
+    _objc_msgSend_n2da1l(
+      _$$ref.pointer,
+      _sel_setQualityOfService_,
+      value.value,
+    );
   }
 
   /// setStackSize:
   set stackSize(int value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setStackSize:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1i9r4xy(_$$.pointer, _sel_setStackSize_, value);
+    _objc_msgSend_1i9r4xy(_$$ref.pointer, _sel_setStackSize_, value);
   }
 
   /// setThreadPriority:
   set threadPriority(double value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.setThreadPriority:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setThreadPriority_, value);
+    _objc_msgSend_hwm8nu(_$$ref.pointer, _sel_setThreadPriority_, value);
   }
 
   /// stackSize
   int get stackSize {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.stackSize',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_xw2lbc(_$$.pointer, _sel_stackSize);
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_stackSize);
   }
 
   /// start
   void start() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.start',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_start);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_start);
   }
 
   /// threadDictionary
   objc.NSMutableDictionary get threadDictionary {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_threadDictionary);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_threadDictionary);
     return objc.NSMutableDictionary.fromPointer(
       $ret,
       retain: true,
@@ -1102,15 +1113,15 @@ extension NSThread$Methods on NSThread {
 
   /// threadPriority
   double get threadPriority {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSThread.threadPriority',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_threadPriority)
-        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_threadPriority);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_threadPriority)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_threadPriority);
   }
 }
 
@@ -1172,10 +1183,10 @@ abstract final class ObjCBlock_DummyObject_DummyObject {
     objc.newClosureBlock(_closureCallable, (
       ffi.Pointer<objc.ObjCObjectImpl> arg0,
     ) {
-      final _$$ = fn(
+      final _$$ref = fn(
         DummyObject.fromPointer(arg0, retain: true, release: true),
       ).ref;
-      return _$$.retainAndAutorelease();
+      return _$$ref.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -1227,7 +1238,7 @@ abstract final class ObjCBlock_DummyObject_DummyObject {
 extension ObjCBlock_DummyObject_DummyObject$CallExtension
     on objc.ObjCBlock<DummyObject Function(DummyObject)> {
   DummyObject call(DummyObject arg0) {
-    final _$$$1 = arg0.ref;
+    final _$$ref$1 = arg0.ref;
     return DummyObject.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -1243,7 +1254,7 @@ extension ObjCBlock_DummyObject_DummyObject$CallExtension
               ffi.Pointer<objc.ObjCBlockImpl>,
               ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >()(ref.pointer, _$$$1.pointer),
+          >()(ref.pointer, _$$ref$1.pointer),
       retain: true,
       release: true,
     );
@@ -1299,12 +1310,12 @@ abstract final class ObjCBlock_DummyObject_DummyObject$1 {
     objc.newClosureBlock(_closureCallable, (
       ffi.Pointer<objc.ObjCObjectImpl> arg0,
     ) {
-      final _$$ = fn(
+      final _$$ref = fn(
         arg0.address == 0
             ? null
             : DummyObject.fromPointer(arg0, retain: true, release: true),
       )?.ref;
-      return _$$?.retainAndAutorelease() ?? ffi.nullptr;
+      return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -1356,7 +1367,7 @@ abstract final class ObjCBlock_DummyObject_DummyObject$1 {
 extension ObjCBlock_DummyObject_DummyObject$1$CallExtension
     on objc.ObjCBlock<DummyObject? Function(DummyObject?)> {
   DummyObject? call(DummyObject? arg0) {
-    final _$$$1 = arg0?.ref;
+    final _$$ref$1 = arg0?.ref;
     return ref.pointer.ref.invoke
                 .cast<
                   ffi.NativeFunction<
@@ -1371,7 +1382,7 @@ extension ObjCBlock_DummyObject_DummyObject$1$CallExtension
                     ffi.Pointer<objc.ObjCBlockImpl>,
                     ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >()(ref.pointer, _$$$1?.pointer ?? ffi.nullptr)
+                >()(ref.pointer, _$$ref$1?.pointer ?? ffi.nullptr)
                 .address ==
             0
         ? null
@@ -1390,7 +1401,7 @@ extension ObjCBlock_DummyObject_DummyObject$1$CallExtension
                     ffi.Pointer<objc.ObjCBlockImpl>,
                     ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >()(ref.pointer, _$$$1?.pointer ?? ffi.nullptr),
+                >()(ref.pointer, _$$ref$1?.pointer ?? ffi.nullptr),
             retain: true,
             release: true,
           );
@@ -1549,14 +1560,14 @@ abstract final class ObjCBlock_IntBlock_IntBlock {
         )
       >(
         objc.newClosureBlock(_closureCallable, (IntBlock arg0) {
-          final _$$ = fn(
+          final _$$ref = fn(
             ObjCBlock_Int32_Int32.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
           ).ref;
-          return _$$.retainAndAutorelease();
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -1593,7 +1604,7 @@ extension ObjCBlock_IntBlock_IntBlock$CallExtension
           )
         > {
   DartIntBlock call(DartIntBlock arg0) {
-    final _$$$1 = arg0.ref;
+    final _$$ref$1 = arg0.ref;
     return ObjCBlock_Int32_Int32.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -1606,7 +1617,7 @@ extension ObjCBlock_IntBlock_IntBlock$CallExtension
           >()
           .asFunction<
             IntBlock Function(ffi.Pointer<objc.ObjCBlockImpl>, IntBlock)
-          >()(ref.pointer, _$$$1.pointer),
+          >()(ref.pointer, _$$ref$1.pointer),
       retain: true,
       release: true,
     );
@@ -1662,12 +1673,12 @@ abstract final class ObjCBlock_NSString_NSString {
     objc.newClosureBlock(_closureCallable, (
       ffi.Pointer<objc.ObjCObjectImpl> arg0,
     ) {
-      final _$$ = fn(
+      final _$$ref = fn(
         arg0.address == 0
             ? null
             : objc.NSString.fromPointer(arg0, retain: true, release: true),
       )?.ref;
-      return _$$?.retainAndAutorelease() ?? ffi.nullptr;
+      return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -1719,7 +1730,7 @@ abstract final class ObjCBlock_NSString_NSString {
 extension ObjCBlock_NSString_NSString$CallExtension
     on objc.ObjCBlock<objc.NSString? Function(objc.NSString?)> {
   objc.NSString? call(objc.NSString? arg0) {
-    final _$$$1 = arg0?.ref;
+    final _$$ref$1 = arg0?.ref;
     return ref.pointer.ref.invoke
                 .cast<
                   ffi.NativeFunction<
@@ -1734,7 +1745,7 @@ extension ObjCBlock_NSString_NSString$CallExtension
                     ffi.Pointer<objc.ObjCBlockImpl>,
                     ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >()(ref.pointer, _$$$1?.pointer ?? ffi.nullptr)
+                >()(ref.pointer, _$$ref$1?.pointer ?? ffi.nullptr)
                 .address ==
             0
         ? null
@@ -1753,7 +1764,7 @@ extension ObjCBlock_NSString_NSString$CallExtension
                     ffi.Pointer<objc.ObjCBlockImpl>,
                     ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >()(ref.pointer, _$$$1?.pointer ?? ffi.nullptr),
+                >()(ref.pointer, _$$ref$1?.pointer ?? ffi.nullptr),
             retain: true,
             release: true,
           );
@@ -2442,7 +2453,7 @@ abstract final class ObjCBlock_ffiVoid_DummyObject {
 extension ObjCBlock_ffiVoid_DummyObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(DummyObject)> {
   void call(DummyObject arg0) {
-    final _$$ = arg0.ref;
+    final _$$ref = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -2457,7 +2468,7 @@ extension ObjCBlock_ffiVoid_DummyObject$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, _$$.pointer);
+        >()(ref.pointer, _$$ref.pointer);
   }
 }
 
@@ -2704,7 +2715,7 @@ abstract final class ObjCBlock_ffiVoid_DummyObject$1 {
 extension ObjCBlock_ffiVoid_DummyObject$1$CallExtension
     on objc.ObjCBlock<ffi.Void Function(DummyObject?)> {
   void call(DummyObject? arg0) {
-    final _$$ = arg0?.ref;
+    final _$$ref = arg0?.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -2719,7 +2730,7 @@ extension ObjCBlock_ffiVoid_DummyObject$1$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, _$$?.pointer ?? ffi.nullptr);
+        >()(ref.pointer, _$$ref?.pointer ?? ffi.nullptr);
   }
 }
 
@@ -3705,7 +3716,7 @@ extension ObjCBlock_ffiVoid_IntBlock$CallExtension
           ffi.Void Function(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>)
         > {
   void call(DartIntBlock arg0) {
-    final _$$ = arg0.ref;
+    final _$$ref = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -3717,7 +3728,7 @@ extension ObjCBlock_ffiVoid_IntBlock$CallExtension
         >()
         .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>, IntBlock)>()(
       ref.pointer,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 }
@@ -3951,7 +3962,7 @@ abstract final class ObjCBlock_ffiVoid_NSString {
 extension ObjCBlock_ffiVoid_NSString$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSString)> {
   void call(objc.NSString arg0) {
-    final _$$ = arg0.ref;
+    final _$$ref = arg0.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -3966,7 +3977,7 @@ extension ObjCBlock_ffiVoid_NSString$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, _$$.pointer);
+        >()(ref.pointer, _$$ref.pointer);
   }
 }
 
@@ -4268,7 +4279,7 @@ abstract final class ObjCBlock_ffiVoid_Vec2_Vec4_NSObject {
 extension ObjCBlock_ffiVoid_Vec2_Vec4_NSObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(Vec2, Vec4, objc.NSObject)> {
   void call(Vec2 arg0, Vec4 arg1, objc.NSObject arg2) {
-    final _$$ = arg2.ref;
+    final _$$ref = arg2.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -4287,7 +4298,7 @@ extension ObjCBlock_ffiVoid_Vec2_Vec4_NSObject$CallExtension
             Vec4,
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >()(ref.pointer, arg0, arg1, _$$.pointer);
+        >()(ref.pointer, arg0, arg1, _$$ref.pointer);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/cast_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/cast_test_bindings.dart
@@ -61,26 +61,29 @@ extension type Castaway._(objc.ObjCObject object$)
 extension Castaway$Methods on Castaway {
   /// init
   Castaway init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'Castaway.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return Castaway.fromPointer($ret, retain: false, release: true);
   }
 
   /// meAsInt
   int meAsInt() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_pysgoz(_$$.pointer, _sel_meAsInt);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_pysgoz(_$$ref.pointer, _sel_meAsInt);
   }
 
   /// meAsNSObject
   objc.NSObject meAsNSObject() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_meAsNSObject);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_meAsNSObject);
     return objc.NSObject.fromPointer($ret, retain: true, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/cast_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/cast_test_bindings.dart
@@ -61,26 +61,26 @@ extension type Castaway._(objc.ObjCObject object$)
 extension Castaway$Methods on Castaway {
   /// init
   Castaway init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'Castaway.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return Castaway.fromPointer($ret, retain: false, release: true);
   }
 
   /// meAsInt
   int meAsInt() {
-    return _objc_msgSend_pysgoz(object$.ref.pointer, _sel_meAsInt);
+    final _$$ = object$.ref;
+    return _objc_msgSend_pysgoz(_$$.pointer, _sel_meAsInt);
   }
 
   /// meAsNSObject
   objc.NSObject meAsNSObject() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_meAsNSObject);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_meAsNSObject);
     return objc.NSObject.fromPointer($ret, retain: true, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/category_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/category_test_bindings.dart
@@ -33,8 +33,8 @@ external ffi.Pointer<objc.ObjCBlockImpl> _l3cf7j_wrapListenerBlock_pfv6jd(
 extension CatImplementsProto on Thing {
   /// protoMethod
   int protoMethod() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_protoMethod);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_protoMethod);
   }
 
   /// staticProtoMethod
@@ -123,24 +123,27 @@ extension type ChildOfNSString._(objc.ObjCObject object$)
 extension ChildOfNSString$Methods on ChildOfNSString {
   /// init
   ChildOfNSString init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'ChildOfNSString.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return ChildOfNSString.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   ChildOfNSString? initWithCoder(objc.NSCoder coder) {
-    final _$$ = object$.ref;
-    final _$$$1 = coder.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -211,14 +214,14 @@ extension type ChildOfThing._(objc.ObjCObject object$)
 extension ChildOfThing$Methods on ChildOfThing {
   /// init
   ChildOfThing init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'ChildOfThing.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return ChildOfThing.fromPointer($ret, retain: false, release: true);
@@ -226,8 +229,8 @@ extension ChildOfThing$Methods on ChildOfThing {
 
   /// instancetypeMethod
   ChildOfThing instancetypeMethod() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_instancetypeMethod);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_instancetypeMethod);
     return ChildOfThing.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -239,15 +242,15 @@ extension InstanceTypeCategory on Thing {}
 extension InterfaceOnBuiltInType on objc.NSString {
   /// instancetypeMethod
   objc.NSString instancetypeMethod() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_instancetypeMethod);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_instancetypeMethod);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// method
   objc.NSString method() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_method);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_method);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
@@ -262,14 +265,14 @@ extension InterfaceOnBuiltInType on objc.NSString {
 extension Mul on Thing {
   /// mul:Y:
   int mul(int x, {required int Y}) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1q0lyci(_$$.pointer, _sel_mul_Y_, x, Y);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1q0lyci(_$$ref.pointer, _sel_mul_Y_, x, Y);
   }
 
   /// someProperty
   int get someProperty {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_someProperty);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_someProperty);
   }
 }
 
@@ -280,15 +283,15 @@ extension NSItemProvider on objc.NSURL {
   itemProviderVisibilityForRepresentationWithTypeIdentifier(
     objc.NSString typeIdentifier,
   ) {
-    final _$$ = object$.ref;
-    final _$$$1 = typeIdentifier.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSURL.itemProviderVisibilityForRepresentationWithTypeIdentifier:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     if (!objc.respondsToSelector(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_,
     )) {
       throw objc.UnimplementedOptionalMethodException(
@@ -297,9 +300,9 @@ extension NSItemProvider on objc.NSURL {
       );
     }
     final $ret = _objc_msgSend_16fy0up(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return objc.NSItemProviderRepresentationVisibility.fromValue($ret);
   }
@@ -310,19 +313,19 @@ extension NSItemProvider on objc.NSURL {
     required objc.ObjCBlock<ffi.Void Function(objc.NSData?, objc.NSError?)>
     forItemProviderCompletionHandler,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = typeIdentifier.ref;
-    final _$$$2 = forItemProviderCompletionHandler.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = forItemProviderCompletionHandler.ref;
     objc.checkOsVersionInternal(
       'NSURL.loadDataWithTypeIdentifier:forItemProviderCompletionHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_r0bo0s(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_loadDataWithTypeIdentifier_forItemProviderCompletionHandler_,
-      _$$$1.pointer,
-      _$$$2.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return $ret.address == 0
         ? null
@@ -331,14 +334,14 @@ extension NSItemProvider on objc.NSURL {
 
   /// writableTypeIdentifiersForItemProvider
   objc.NSArray get writableTypeIdentifiersForItemProvider {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.writableTypeIdentifiersForItemProvider',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     if (!objc.respondsToSelector(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_writableTypeIdentifiersForItemProvider,
     )) {
       throw objc.UnimplementedOptionalMethodException(
@@ -347,7 +350,7 @@ extension NSItemProvider on objc.NSURL {
       );
     }
     final $ret = _objc_msgSend_151sglz(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_writableTypeIdentifiersForItemProvider,
     );
     return objc.NSArray.fromPointer($ret, retain: true, release: true);
@@ -358,7 +361,7 @@ extension NSItemProvider on objc.NSURL {
   itemProviderVisibilityForRepresentationWithTypeIdentifier$1(
     objc.NSString typeIdentifier,
   ) {
-    final _$$ = typeIdentifier.ref;
+    final _$$ref = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSURL.itemProviderVisibilityForRepresentationWithTypeIdentifier:',
       iOS: (false, (11, 0, 0)),
@@ -376,7 +379,7 @@ extension NSItemProvider on objc.NSURL {
     final $ret = _objc_msgSend_16fy0up(
       _class_NSURL,
       _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return objc.NSItemProviderRepresentationVisibility.fromValue($ret);
   }
@@ -386,8 +389,8 @@ extension NSItemProvider on objc.NSURL {
     objc.NSData data, {
     required objc.NSString typeIdentifier,
   }) {
-    final _$$ = data.ref;
-    final _$$$1 = typeIdentifier.ref;
+    final _$$ref = data.ref;
+    final _$$ref$1 = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSURL.objectWithItemProviderData:typeIdentifier:error:',
       iOS: (false, (11, 0, 0)),
@@ -398,8 +401,8 @@ extension NSItemProvider on objc.NSURL {
       final $ret = _objc_msgSend_1pnyuds(
         _class_NSURL,
         _sel_objectWithItemProviderData_typeIdentifier_error_,
-        _$$.pointer,
-        _$$$1.pointer,
+        _$$ref.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -444,7 +447,7 @@ extension NSItemProvider on objc.NSURL {
 extension NSPromisedItems on objc.NSURL {
   /// checkPromisedItemIsReachableAndReturnError:
   bool checkPromisedItemIsReachableAndReturnError() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.checkPromisedItemIsReachableAndReturnError:',
       iOS: (false, (8, 0, 0)),
@@ -453,7 +456,7 @@ extension NSPromisedItems on objc.NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1dom33q(
-        _$$.pointer,
+        _$$ref.pointer,
         _sel_checkPromisedItemIsReachableAndReturnError_,
         $err,
       );
@@ -469,8 +472,8 @@ extension NSPromisedItems on objc.NSURL {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> value, {
     required objc.NSString forKey,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = forKey.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = forKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.getPromisedItemResourceValue:forKey:error:',
       iOS: (false, (8, 0, 0)),
@@ -479,10 +482,10 @@ extension NSPromisedItems on objc.NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1j9bhml(
-        _$$.pointer,
+        _$$ref.pointer,
         _sel_getPromisedItemResourceValue_forKey_error_,
         value,
-        _$$$1.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -494,8 +497,8 @@ extension NSPromisedItems on objc.NSURL {
 
   /// promisedItemResourceValuesForKeys:error:
   objc.NSDictionary? promisedItemResourceValuesForKeys(objc.NSArray keys) {
-    final _$$ = object$.ref;
-    final _$$$1 = keys.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = keys.ref;
     objc.checkOsVersionInternal(
       'NSURL.promisedItemResourceValuesForKeys:error:',
       iOS: (false, (8, 0, 0)),
@@ -504,9 +507,9 @@ extension NSPromisedItems on objc.NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1lhpu4m(
-        _$$.pointer,
+        _$$ref.pointer,
         _sel_promisedItemResourceValuesForKeys_error_,
-        _$$$1.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -523,8 +526,8 @@ extension NSPromisedItems on objc.NSURL {
 extension NSString on Thing {
   /// nsStringExtension
   int nsStringExtension() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_nsStringExtension);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_nsStringExtension);
   }
 }
 
@@ -532,8 +535,8 @@ extension NSString on Thing {
 extension NSURLCategory on objc.NSURL {
   /// extensionMethod
   int extensionMethod() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_extensionMethod);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_extensionMethod);
   }
 }
 
@@ -542,14 +545,14 @@ extension NSURLLoading on objc.NSURL {
   /// URLHandleUsingCache:
   @Deprecated('Use NSURLConnection instead')
   objc.NSURLHandle? URLHandleUsingCache(bool shouldUseCache) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLHandleUsingCache:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1t6aok9(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_URLHandleUsingCache_,
       shouldUseCache,
     );
@@ -564,17 +567,17 @@ extension NSURLLoading on objc.NSURL {
     objc.ObjCObject client, {
     required bool usingCache,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = client.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = client.ref;
     objc.checkOsVersionInternal(
       'NSURL.loadResourceDataNotifyingClient:usingCache:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     _objc_msgSend_6p7ndb(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_loadResourceDataNotifyingClient_usingCache_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
       usingCache,
     );
   }
@@ -582,17 +585,17 @@ extension NSURLLoading on objc.NSURL {
   /// propertyForKey:
   @Deprecated('Use NSURLConnection instead')
   objc.ObjCObject? propertyForKey(objc.NSString propertyKey) {
-    final _$$ = object$.ref;
-    final _$$$1 = propertyKey.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = propertyKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.propertyForKey:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_propertyForKey_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -602,14 +605,14 @@ extension NSURLLoading on objc.NSURL {
   /// resourceDataUsingCache:
   @Deprecated('Use NSURLConnection instead')
   objc.NSData? resourceDataUsingCache(bool shouldUseCache) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.resourceDataUsingCache:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1t6aok9(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_resourceDataUsingCache_,
       shouldUseCache,
     );
@@ -621,36 +624,36 @@ extension NSURLLoading on objc.NSURL {
   /// setProperty:forKey:
   @Deprecated('Use NSURLConnection instead')
   bool setProperty(objc.ObjCObject property, {required objc.NSString forKey}) {
-    final _$$ = object$.ref;
-    final _$$$1 = property.ref;
-    final _$$$2 = forKey.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = property.ref;
+    final _$$ref$2 = forKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.setProperty:forKey:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     return _objc_msgSend_1lsax7n(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setProperty_forKey_,
-      _$$$1.pointer,
-      _$$$2.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// setResourceData:
   @Deprecated('Use NSURLConnection instead')
   bool setResourceData(objc.NSData data) {
-    final _$$ = object$.ref;
-    final _$$$1 = data.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
     objc.checkOsVersionInternal(
       'NSURL.setResourceData:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     return _objc_msgSend_19nvye5(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setResourceData_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 }
@@ -659,17 +662,17 @@ extension NSURLLoading on objc.NSURL {
 extension NSURLPathUtilities on objc.NSURL {
   /// URLByAppendingPathComponent:
   objc.NSURL? URLByAppendingPathComponent(objc.NSString pathComponent) {
-    final _$$ = object$.ref;
-    final _$$$1 = pathComponent.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = pathComponent.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByAppendingPathComponent:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_URLByAppendingPathComponent_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -681,17 +684,17 @@ extension NSURLPathUtilities on objc.NSURL {
     objc.NSString pathComponent, {
     required bool isDirectory,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = pathComponent.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = pathComponent.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByAppendingPathComponent:isDirectory:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_URLByAppendingPathComponent_isDirectory_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
       isDirectory,
     );
     return $ret.address == 0
@@ -701,17 +704,17 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByAppendingPathExtension:
   objc.NSURL? URLByAppendingPathExtension(objc.NSString pathExtension) {
-    final _$$ = object$.ref;
-    final _$$$1 = pathExtension.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = pathExtension.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByAppendingPathExtension:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_URLByAppendingPathExtension_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -720,14 +723,14 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByDeletingLastPathComponent
   objc.NSURL? get URLByDeletingLastPathComponent {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByDeletingLastPathComponent',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_URLByDeletingLastPathComponent,
     );
     return $ret.address == 0
@@ -737,14 +740,14 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByDeletingPathExtension
   objc.NSURL? get URLByDeletingPathExtension {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByDeletingPathExtension',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_URLByDeletingPathExtension,
     );
     return $ret.address == 0
@@ -754,14 +757,14 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByResolvingSymlinksInPath
   objc.NSURL? get URLByResolvingSymlinksInPath {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByResolvingSymlinksInPath',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_URLByResolvingSymlinksInPath,
     );
     return $ret.address == 0
@@ -771,14 +774,14 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByStandardizingPath
   objc.NSURL? get URLByStandardizingPath {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByStandardizingPath',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_URLByStandardizingPath,
     );
     return $ret.address == 0
@@ -788,7 +791,7 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// checkResourceIsReachableAndReturnError:
   bool checkResourceIsReachableAndReturnError() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.checkResourceIsReachableAndReturnError:',
       iOS: (false, (4, 0, 0)),
@@ -797,7 +800,7 @@ extension NSURLPathUtilities on objc.NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1dom33q(
-        _$$.pointer,
+        _$$ref.pointer,
         _sel_checkResourceIsReachableAndReturnError_,
         $err,
       );
@@ -810,13 +813,13 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// lastPathComponent
   objc.NSString? get lastPathComponent {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.lastPathComponent',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_lastPathComponent);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_lastPathComponent);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -824,13 +827,13 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// pathComponents
   objc.NSArray? get pathComponents {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.pathComponents',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_pathComponents);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_pathComponents);
     return $ret.address == 0
         ? null
         : objc.NSArray.fromPointer($ret, retain: true, release: true);
@@ -838,13 +841,13 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// pathExtension
   objc.NSString? get pathExtension {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.pathExtension',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_pathExtension);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_pathExtension);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -852,7 +855,7 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// fileURLWithPathComponents:
   static objc.NSURL? fileURLWithPathComponents(objc.NSArray components) {
-    final _$$ = components.ref;
+    final _$$ref = components.ref;
     objc.checkOsVersionInternal(
       'NSURL.fileURLWithPathComponents:',
       iOS: (false, (4, 0, 0)),
@@ -861,7 +864,7 @@ extension NSURLPathUtilities on objc.NSURL {
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSURL,
       _sel_fileURLWithPathComponents_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -1167,8 +1170,8 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
 extension ObjCBlock_ffiVoid_NSData_NSError$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSData?, objc.NSError?)> {
   void call(objc.NSData? arg0, objc.NSError? arg1) {
-    final _$$ = arg0?.ref;
-    final _$$$1 = arg1?.ref;
+    final _$$ref = arg0?.ref;
+    final _$$ref$1 = arg1?.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -1187,8 +1190,8 @@ extension ObjCBlock_ffiVoid_NSData_NSError$CallExtension
           )
         >()(
       ref.pointer,
-      _$$?.pointer ?? ffi.nullptr,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 }
@@ -1197,8 +1200,8 @@ extension ObjCBlock_ffiVoid_NSData_NSError$CallExtension
 extension StaticAndInstanceMethodsWithSameNameCategory on Thing {
   /// sameNameMethod
   int sameNameMethod() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_sameNameMethod);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_sameNameMethod);
   }
 
   /// sameNameMethod
@@ -1211,8 +1214,8 @@ extension StaticAndInstanceMethodsWithSameNameCategory on Thing {
 extension Sub on Thing {
   /// sub:Y:
   int sub(int x, {required int Y}) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1q0lyci(_$$.pointer, _sel_sub_Y_, x, Y);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1q0lyci(_$$ref.pointer, _sel_sub_Y_, x, Y);
   }
 
   /// staticMethod
@@ -1280,26 +1283,26 @@ extension type Thing._(objc.ObjCObject object$)
 extension Thing$Methods on Thing {
   /// add:Y:
   int add(int x, {required int Y}) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1q0lyci(_$$.pointer, _sel_add_Y_, x, Y);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1q0lyci(_$$ref.pointer, _sel_add_Y_, x, Y);
   }
 
   /// anonymousCategoryMethod
   int anonymousCategoryMethod() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_anonymousCategoryMethod);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_anonymousCategoryMethod);
   }
 
   /// init
   Thing init() {
-    final _$$$2 = object$.ref;
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'Thing.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return Thing.fromPointer($ret, retain: false, release: true);
@@ -1307,8 +1310,11 @@ extension Thing$Methods on Thing {
 
   /// instancetypeMethod
   Thing instancetypeMethod() {
-    final _$$$1 = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$$1.pointer, _sel_instancetypeMethod);
+    final _$$ref$1 = object$.ref;
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref$1.pointer,
+      _sel_instancetypeMethod,
+    );
     return Thing.fromPointer($ret, retain: true, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/category_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/category_test_bindings.dart
@@ -881,21 +881,19 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
     void Function(objc.NSData?, objc.NSError?) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(objc.NSData?, objc.NSError?)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : objc.NSData.fromPointer(arg0, retain: true, release: true),
         arg1.address == 0
             ? null
             : objc.NSError.fromPointer(arg1, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -914,21 +912,19 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
     void Function(objc.NSData?, objc.NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : objc.NSData.fromPointer(arg0, retain: false, release: true),
         arg1.address == 0
             ? null
             : objc.NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _l3cf7j_wrapListenerBlock_pfv6jd(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(objc.NSData?, objc.NSError?)>(
@@ -953,34 +949,34 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
     void Function(objc.NSData?, objc.NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : objc.NSData.fromPointer(arg0, retain: false, release: true),
         arg1.address == 0
             ? null
             : objc.NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
       (
         ffi.Pointer<objc.ObjCObjectImpl> arg0,
         ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
-        arg0.address == 0
-            ? null
-            : objc.NSData.fromPointer(arg0, retain: false, release: true),
-        arg1.address == 0
-            ? null
-            : objc.NSError.fromPointer(arg1, retain: false, release: true),
-      ),
+      ) {
+        return fn(
+          arg0.address == 0
+              ? null
+              : objc.NSData.fromPointer(arg0, retain: false, release: true),
+          arg1.address == 0
+              ? null
+              : objc.NSError.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _l3cf7j_wrapBlockingBlock_pfv6jd(
@@ -1133,28 +1129,29 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(objc.NSData?, objc.NSError?)>`.
 extension ObjCBlock_ffiVoid_NSData_NSError$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSData?, objc.NSError?)> {
-  void call(objc.NSData? arg0, objc.NSError? arg1) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                ffi.Pointer<objc.ObjCObjectImpl> arg1,
-              )
-            >
-          >()
-          .asFunction<
-            void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
+  void call(objc.NSData? arg0, objc.NSError? arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
             )
-          >()(
-        ref.pointer,
-        arg0?.ref.pointer ?? ffi.nullptr,
-        arg1?.ref.pointer ?? ffi.nullptr,
-      );
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+          )
+        >()(
+      ref.pointer,
+      arg0?.ref.pointer ?? ffi.nullptr,
+      arg1?.ref.pointer ?? ffi.nullptr,
+    );
+  }
 }
 
 /// StaticAndInstanceMethodsWithSameNameCategory

--- a/pkgs/ffigen/test/native_objc_test/category_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/category_test_bindings.dart
@@ -33,7 +33,8 @@ external ffi.Pointer<objc.ObjCBlockImpl> _l3cf7j_wrapListenerBlock_pfv6jd(
 extension CatImplementsProto on Thing {
   /// protoMethod
   int protoMethod() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_protoMethod);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_protoMethod);
   }
 
   /// staticProtoMethod
@@ -122,24 +123,24 @@ extension type ChildOfNSString._(objc.ObjCObject object$)
 extension ChildOfNSString$Methods on ChildOfNSString {
   /// init
   ChildOfNSString init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'ChildOfNSString.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return ChildOfNSString.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   ChildOfNSString? initWithCoder(objc.NSCoder coder) {
+    final _$$ = object$.ref;
+    final _$$$1 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -210,13 +211,14 @@ extension type ChildOfThing._(objc.ObjCObject object$)
 extension ChildOfThing$Methods on ChildOfThing {
   /// init
   ChildOfThing init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'ChildOfThing.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return ChildOfThing.fromPointer($ret, retain: false, release: true);
@@ -224,10 +226,8 @@ extension ChildOfThing$Methods on ChildOfThing {
 
   /// instancetypeMethod
   ChildOfThing instancetypeMethod() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_instancetypeMethod,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_instancetypeMethod);
     return ChildOfThing.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -239,16 +239,15 @@ extension InstanceTypeCategory on Thing {}
 extension InterfaceOnBuiltInType on objc.NSString {
   /// instancetypeMethod
   objc.NSString instancetypeMethod() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_instancetypeMethod,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_instancetypeMethod);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// method
   objc.NSString method() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_method);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_method);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
@@ -263,12 +262,14 @@ extension InterfaceOnBuiltInType on objc.NSString {
 extension Mul on Thing {
   /// mul:Y:
   int mul(int x, {required int Y}) {
-    return _objc_msgSend_1q0lyci(object$.ref.pointer, _sel_mul_Y_, x, Y);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1q0lyci(_$$.pointer, _sel_mul_Y_, x, Y);
   }
 
   /// someProperty
   int get someProperty {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_someProperty);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_someProperty);
   }
 }
 
@@ -279,13 +280,15 @@ extension NSItemProvider on objc.NSURL {
   itemProviderVisibilityForRepresentationWithTypeIdentifier(
     objc.NSString typeIdentifier,
   ) {
+    final _$$ = object$.ref;
+    final _$$$1 = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSURL.itemProviderVisibilityForRepresentationWithTypeIdentifier:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     if (!objc.respondsToSelector(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_,
     )) {
       throw objc.UnimplementedOptionalMethodException(
@@ -294,9 +297,9 @@ extension NSItemProvider on objc.NSURL {
       );
     }
     final $ret = _objc_msgSend_16fy0up(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_,
-      typeIdentifier.ref.pointer,
+      _$$$1.pointer,
     );
     return objc.NSItemProviderRepresentationVisibility.fromValue($ret);
   }
@@ -307,16 +310,19 @@ extension NSItemProvider on objc.NSURL {
     required objc.ObjCBlock<ffi.Void Function(objc.NSData?, objc.NSError?)>
     forItemProviderCompletionHandler,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = typeIdentifier.ref;
+    final _$$$2 = forItemProviderCompletionHandler.ref;
     objc.checkOsVersionInternal(
       'NSURL.loadDataWithTypeIdentifier:forItemProviderCompletionHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_r0bo0s(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_loadDataWithTypeIdentifier_forItemProviderCompletionHandler_,
-      typeIdentifier.ref.pointer,
-      forItemProviderCompletionHandler.ref.pointer,
+      _$$$1.pointer,
+      _$$$2.pointer,
     );
     return $ret.address == 0
         ? null
@@ -325,13 +331,14 @@ extension NSItemProvider on objc.NSURL {
 
   /// writableTypeIdentifiersForItemProvider
   objc.NSArray get writableTypeIdentifiersForItemProvider {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.writableTypeIdentifiersForItemProvider',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     if (!objc.respondsToSelector(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_writableTypeIdentifiersForItemProvider,
     )) {
       throw objc.UnimplementedOptionalMethodException(
@@ -340,7 +347,7 @@ extension NSItemProvider on objc.NSURL {
       );
     }
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_writableTypeIdentifiersForItemProvider,
     );
     return objc.NSArray.fromPointer($ret, retain: true, release: true);
@@ -351,6 +358,7 @@ extension NSItemProvider on objc.NSURL {
   itemProviderVisibilityForRepresentationWithTypeIdentifier$1(
     objc.NSString typeIdentifier,
   ) {
+    final _$$ = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSURL.itemProviderVisibilityForRepresentationWithTypeIdentifier:',
       iOS: (false, (11, 0, 0)),
@@ -368,7 +376,7 @@ extension NSItemProvider on objc.NSURL {
     final $ret = _objc_msgSend_16fy0up(
       _class_NSURL,
       _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_,
-      typeIdentifier.ref.pointer,
+      _$$.pointer,
     );
     return objc.NSItemProviderRepresentationVisibility.fromValue($ret);
   }
@@ -378,6 +386,8 @@ extension NSItemProvider on objc.NSURL {
     objc.NSData data, {
     required objc.NSString typeIdentifier,
   }) {
+    final _$$ = data.ref;
+    final _$$$1 = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSURL.objectWithItemProviderData:typeIdentifier:error:',
       iOS: (false, (11, 0, 0)),
@@ -388,8 +398,8 @@ extension NSItemProvider on objc.NSURL {
       final $ret = _objc_msgSend_1pnyuds(
         _class_NSURL,
         _sel_objectWithItemProviderData_typeIdentifier_error_,
-        data.ref.pointer,
-        typeIdentifier.ref.pointer,
+        _$$.pointer,
+        _$$$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -434,6 +444,7 @@ extension NSItemProvider on objc.NSURL {
 extension NSPromisedItems on objc.NSURL {
   /// checkPromisedItemIsReachableAndReturnError:
   bool checkPromisedItemIsReachableAndReturnError() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.checkPromisedItemIsReachableAndReturnError:',
       iOS: (false, (8, 0, 0)),
@@ -442,7 +453,7 @@ extension NSPromisedItems on objc.NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1dom33q(
-        object$.ref.pointer,
+        _$$.pointer,
         _sel_checkPromisedItemIsReachableAndReturnError_,
         $err,
       );
@@ -458,6 +469,8 @@ extension NSPromisedItems on objc.NSURL {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> value, {
     required objc.NSString forKey,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = forKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.getPromisedItemResourceValue:forKey:error:',
       iOS: (false, (8, 0, 0)),
@@ -466,10 +479,10 @@ extension NSPromisedItems on objc.NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1j9bhml(
-        object$.ref.pointer,
+        _$$.pointer,
         _sel_getPromisedItemResourceValue_forKey_error_,
         value,
-        forKey.ref.pointer,
+        _$$$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -481,6 +494,8 @@ extension NSPromisedItems on objc.NSURL {
 
   /// promisedItemResourceValuesForKeys:error:
   objc.NSDictionary? promisedItemResourceValuesForKeys(objc.NSArray keys) {
+    final _$$ = object$.ref;
+    final _$$$1 = keys.ref;
     objc.checkOsVersionInternal(
       'NSURL.promisedItemResourceValuesForKeys:error:',
       iOS: (false, (8, 0, 0)),
@@ -489,9 +504,9 @@ extension NSPromisedItems on objc.NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1lhpu4m(
-        object$.ref.pointer,
+        _$$.pointer,
         _sel_promisedItemResourceValuesForKeys_error_,
-        keys.ref.pointer,
+        _$$$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -508,7 +523,8 @@ extension NSPromisedItems on objc.NSURL {
 extension NSString on Thing {
   /// nsStringExtension
   int nsStringExtension() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_nsStringExtension);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_nsStringExtension);
   }
 }
 
@@ -516,7 +532,8 @@ extension NSString on Thing {
 extension NSURLCategory on objc.NSURL {
   /// extensionMethod
   int extensionMethod() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_extensionMethod);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_extensionMethod);
   }
 }
 
@@ -525,13 +542,14 @@ extension NSURLLoading on objc.NSURL {
   /// URLHandleUsingCache:
   @Deprecated('Use NSURLConnection instead')
   objc.NSURLHandle? URLHandleUsingCache(bool shouldUseCache) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLHandleUsingCache:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1t6aok9(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_URLHandleUsingCache_,
       shouldUseCache,
     );
@@ -546,15 +564,17 @@ extension NSURLLoading on objc.NSURL {
     objc.ObjCObject client, {
     required bool usingCache,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = client.ref;
     objc.checkOsVersionInternal(
       'NSURL.loadResourceDataNotifyingClient:usingCache:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     _objc_msgSend_6p7ndb(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_loadResourceDataNotifyingClient_usingCache_,
-      client.ref.pointer,
+      _$$$1.pointer,
       usingCache,
     );
   }
@@ -562,15 +582,17 @@ extension NSURLLoading on objc.NSURL {
   /// propertyForKey:
   @Deprecated('Use NSURLConnection instead')
   objc.ObjCObject? propertyForKey(objc.NSString propertyKey) {
+    final _$$ = object$.ref;
+    final _$$$1 = propertyKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.propertyForKey:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_propertyForKey_,
-      propertyKey.ref.pointer,
+      _$$$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -580,13 +602,14 @@ extension NSURLLoading on objc.NSURL {
   /// resourceDataUsingCache:
   @Deprecated('Use NSURLConnection instead')
   objc.NSData? resourceDataUsingCache(bool shouldUseCache) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.resourceDataUsingCache:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1t6aok9(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_resourceDataUsingCache_,
       shouldUseCache,
     );
@@ -598,31 +621,36 @@ extension NSURLLoading on objc.NSURL {
   /// setProperty:forKey:
   @Deprecated('Use NSURLConnection instead')
   bool setProperty(objc.ObjCObject property, {required objc.NSString forKey}) {
+    final _$$ = object$.ref;
+    final _$$$1 = property.ref;
+    final _$$$2 = forKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.setProperty:forKey:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     return _objc_msgSend_1lsax7n(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setProperty_forKey_,
-      property.ref.pointer,
-      forKey.ref.pointer,
+      _$$$1.pointer,
+      _$$$2.pointer,
     );
   }
 
   /// setResourceData:
   @Deprecated('Use NSURLConnection instead')
   bool setResourceData(objc.NSData data) {
+    final _$$ = object$.ref;
+    final _$$$1 = data.ref;
     objc.checkOsVersionInternal(
       'NSURL.setResourceData:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setResourceData_,
-      data.ref.pointer,
+      _$$$1.pointer,
     );
   }
 }
@@ -631,15 +659,17 @@ extension NSURLLoading on objc.NSURL {
 extension NSURLPathUtilities on objc.NSURL {
   /// URLByAppendingPathComponent:
   objc.NSURL? URLByAppendingPathComponent(objc.NSString pathComponent) {
+    final _$$ = object$.ref;
+    final _$$$1 = pathComponent.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByAppendingPathComponent:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_URLByAppendingPathComponent_,
-      pathComponent.ref.pointer,
+      _$$$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -651,15 +681,17 @@ extension NSURLPathUtilities on objc.NSURL {
     objc.NSString pathComponent, {
     required bool isDirectory,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = pathComponent.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByAppendingPathComponent:isDirectory:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_URLByAppendingPathComponent_isDirectory_,
-      pathComponent.ref.pointer,
+      _$$$1.pointer,
       isDirectory,
     );
     return $ret.address == 0
@@ -669,15 +701,17 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByAppendingPathExtension:
   objc.NSURL? URLByAppendingPathExtension(objc.NSString pathExtension) {
+    final _$$ = object$.ref;
+    final _$$$1 = pathExtension.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByAppendingPathExtension:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_URLByAppendingPathExtension_,
-      pathExtension.ref.pointer,
+      _$$$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -686,13 +720,14 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByDeletingLastPathComponent
   objc.NSURL? get URLByDeletingLastPathComponent {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByDeletingLastPathComponent',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_URLByDeletingLastPathComponent,
     );
     return $ret.address == 0
@@ -702,13 +737,14 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByDeletingPathExtension
   objc.NSURL? get URLByDeletingPathExtension {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByDeletingPathExtension',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_URLByDeletingPathExtension,
     );
     return $ret.address == 0
@@ -718,13 +754,14 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByResolvingSymlinksInPath
   objc.NSURL? get URLByResolvingSymlinksInPath {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByResolvingSymlinksInPath',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_URLByResolvingSymlinksInPath,
     );
     return $ret.address == 0
@@ -734,13 +771,14 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// URLByStandardizingPath
   objc.NSURL? get URLByStandardizingPath {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByStandardizingPath',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_URLByStandardizingPath,
     );
     return $ret.address == 0
@@ -750,6 +788,7 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// checkResourceIsReachableAndReturnError:
   bool checkResourceIsReachableAndReturnError() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.checkResourceIsReachableAndReturnError:',
       iOS: (false, (4, 0, 0)),
@@ -758,7 +797,7 @@ extension NSURLPathUtilities on objc.NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1dom33q(
-        object$.ref.pointer,
+        _$$.pointer,
         _sel_checkResourceIsReachableAndReturnError_,
         $err,
       );
@@ -771,15 +810,13 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// lastPathComponent
   objc.NSString? get lastPathComponent {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.lastPathComponent',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_lastPathComponent,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_lastPathComponent);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -787,15 +824,13 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// pathComponents
   objc.NSArray? get pathComponents {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.pathComponents',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_pathComponents,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_pathComponents);
     return $ret.address == 0
         ? null
         : objc.NSArray.fromPointer($ret, retain: true, release: true);
@@ -803,12 +838,13 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// pathExtension
   objc.NSString? get pathExtension {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.pathExtension',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_pathExtension);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_pathExtension);
     return $ret.address == 0
         ? null
         : objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -816,6 +852,7 @@ extension NSURLPathUtilities on objc.NSURL {
 
   /// fileURLWithPathComponents:
   static objc.NSURL? fileURLWithPathComponents(objc.NSArray components) {
+    final _$$ = components.ref;
     objc.checkOsVersionInternal(
       'NSURL.fileURLWithPathComponents:',
       iOS: (false, (4, 0, 0)),
@@ -824,7 +861,7 @@ extension NSURLPathUtilities on objc.NSURL {
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSURL,
       _sel_fileURLWithPathComponents_,
-      components.ref.pointer,
+      _$$.pointer,
     );
     return $ret.address == 0
         ? null
@@ -1130,6 +1167,8 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
 extension ObjCBlock_ffiVoid_NSData_NSError$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSData?, objc.NSError?)> {
   void call(objc.NSData? arg0, objc.NSError? arg1) {
+    final _$$ = arg0?.ref;
+    final _$$$1 = arg1?.ref;
     return ref.pointer.ref.invoke
         .cast<
           ffi.NativeFunction<
@@ -1148,8 +1187,8 @@ extension ObjCBlock_ffiVoid_NSData_NSError$CallExtension
           )
         >()(
       ref.pointer,
-      arg0?.ref.pointer ?? ffi.nullptr,
-      arg1?.ref.pointer ?? ffi.nullptr,
+      _$$?.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 }
@@ -1158,7 +1197,8 @@ extension ObjCBlock_ffiVoid_NSData_NSError$CallExtension
 extension StaticAndInstanceMethodsWithSameNameCategory on Thing {
   /// sameNameMethod
   int sameNameMethod() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_sameNameMethod);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_sameNameMethod);
   }
 
   /// sameNameMethod
@@ -1171,7 +1211,8 @@ extension StaticAndInstanceMethodsWithSameNameCategory on Thing {
 extension Sub on Thing {
   /// sub:Y:
   int sub(int x, {required int Y}) {
-    return _objc_msgSend_1q0lyci(object$.ref.pointer, _sel_sub_Y_, x, Y);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1q0lyci(_$$.pointer, _sel_sub_Y_, x, Y);
   }
 
   /// staticMethod
@@ -1239,26 +1280,26 @@ extension type Thing._(objc.ObjCObject object$)
 extension Thing$Methods on Thing {
   /// add:Y:
   int add(int x, {required int Y}) {
-    return _objc_msgSend_1q0lyci(object$.ref.pointer, _sel_add_Y_, x, Y);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1q0lyci(_$$.pointer, _sel_add_Y_, x, Y);
   }
 
   /// anonymousCategoryMethod
   int anonymousCategoryMethod() {
-    return _objc_msgSend_1gcq84o(
-      object$.ref.pointer,
-      _sel_anonymousCategoryMethod,
-    );
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_anonymousCategoryMethod);
   }
 
   /// init
   Thing init() {
+    final _$$$2 = object$.ref;
     objc.checkOsVersionInternal(
       'Thing.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_init,
     );
     return Thing.fromPointer($ret, retain: false, release: true);
@@ -1266,10 +1307,8 @@ extension Thing$Methods on Thing {
 
   /// instancetypeMethod
   Thing instancetypeMethod() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_instancetypeMethod,
-    );
+    final _$$$1 = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$$1.pointer, _sel_instancetypeMethod);
     return Thing.fromPointer($ret, retain: true, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/enum_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/enum_test_bindings.dart
@@ -86,13 +86,16 @@ extension type EnumTestInterface._(objc.ObjCObject object$)
 extension EnumTestInterface$Methods on EnumTestInterface {
   /// init
   EnumTestInterface init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'EnumTestInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return EnumTestInterface.fromPointer($ret, retain: false, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/enum_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/enum_test_bindings.dart
@@ -86,15 +86,13 @@ extension type EnumTestInterface._(objc.ObjCObject object$)
 extension EnumTestInterface$Methods on EnumTestInterface {
   /// init
   EnumTestInterface init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'EnumTestInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return EnumTestInterface.fromPointer($ret, retain: false, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/error_method_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/error_method_test_bindings.dart
@@ -76,11 +76,11 @@ extension type ErrorMethodTestObject._(objc.ObjCObject object$)
 extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
   /// errorMethodReturningBool:error:
   bool errorMethodReturningBool(bool isOk) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_164wts2(
-        _$$.pointer,
+        _$$ref.pointer,
         _sel_errorMethodReturningBool_error_,
         isOk,
         $err,
@@ -94,11 +94,11 @@ extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
 
   /// errorMethodReturningNullable:error:
   objc.NSObject? errorMethodReturningNullable(bool isOk) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_28eabw(
-        _$$.pointer,
+        _$$ref.pointer,
         _sel_errorMethodReturningNullable_error_,
         isOk,
         $err,
@@ -114,13 +114,16 @@ extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
 
   /// init
   ErrorMethodTestObject init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'ErrorMethodTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return ErrorMethodTestObject.fromPointer(
       $ret,
       retain: false,
@@ -130,11 +133,11 @@ extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
 
   /// nullableErrorMethod:error:
   bool nullableErrorMethod(bool isOk) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_164wts2(
-        _$$.pointer,
+        _$$ref.pointer,
         _sel_nullableErrorMethod_error_,
         isOk,
         $err,
@@ -148,11 +151,11 @@ extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
 
   /// outErrorMethod:outError:
   bool outErrorMethod(bool isOk) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_164wts2(
-        _$$.pointer,
+        _$$ref.pointer,
         _sel_outErrorMethod_outError_,
         isOk,
         $err,

--- a/pkgs/ffigen/test/native_objc_test/error_method_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/error_method_test_bindings.dart
@@ -76,10 +76,11 @@ extension type ErrorMethodTestObject._(objc.ObjCObject object$)
 extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
   /// errorMethodReturningBool:error:
   bool errorMethodReturningBool(bool isOk) {
+    final _$$ = object$.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_164wts2(
-        object$.ref.pointer,
+        _$$.pointer,
         _sel_errorMethodReturningBool_error_,
         isOk,
         $err,
@@ -93,10 +94,11 @@ extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
 
   /// errorMethodReturningNullable:error:
   objc.NSObject? errorMethodReturningNullable(bool isOk) {
+    final _$$ = object$.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_28eabw(
-        object$.ref.pointer,
+        _$$.pointer,
         _sel_errorMethodReturningNullable_error_,
         isOk,
         $err,
@@ -112,15 +114,13 @@ extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
 
   /// init
   ErrorMethodTestObject init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'ErrorMethodTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return ErrorMethodTestObject.fromPointer(
       $ret,
       retain: false,
@@ -130,10 +130,11 @@ extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
 
   /// nullableErrorMethod:error:
   bool nullableErrorMethod(bool isOk) {
+    final _$$ = object$.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_164wts2(
-        object$.ref.pointer,
+        _$$.pointer,
         _sel_nullableErrorMethod_error_,
         isOk,
         $err,
@@ -147,10 +148,11 @@ extension ErrorMethodTestObject$Methods on ErrorMethodTestObject {
 
   /// outErrorMethod:outError:
   bool outErrorMethod(bool isOk) {
+    final _$$ = object$.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_164wts2(
-        object$.ref.pointer,
+        _$$.pointer,
         _sel_outErrorMethod_outError_,
         isOk,
         $err,

--- a/pkgs/ffigen/test/native_objc_test/failed_to_load_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/failed_to_load_test_bindings.dart
@@ -79,19 +79,22 @@ extension type ClassThatWillFailToLoad._(objc.ObjCObject object$)
 extension ClassThatWillFailToLoad$Methods on ClassThatWillFailToLoad {
   /// get123
   int get123() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_get123);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_get123);
   }
 
   /// init
   ClassThatWillFailToLoad init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'ClassThatWillFailToLoad.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return ClassThatWillFailToLoad.fromPointer(
       $ret,
       retain: false,

--- a/pkgs/ffigen/test/native_objc_test/failed_to_load_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/failed_to_load_test_bindings.dart
@@ -79,20 +79,19 @@ extension type ClassThatWillFailToLoad._(objc.ObjCObject object$)
 extension ClassThatWillFailToLoad$Methods on ClassThatWillFailToLoad {
   /// get123
   int get123() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_get123);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_get123);
   }
 
   /// init
   ClassThatWillFailToLoad init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'ClassThatWillFailToLoad.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return ClassThatWillFailToLoad.fromPointer(
       $ret,
       retain: false,

--- a/pkgs/ffigen/test/native_objc_test/forward_decl_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/forward_decl_test_bindings.dart
@@ -66,15 +66,13 @@ extension type ForwardDeclaredClass._(objc.ObjCObject object$)
 extension ForwardDeclaredClass$Methods on ForwardDeclaredClass {
   /// init
   ForwardDeclaredClass init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'ForwardDeclaredClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return ForwardDeclaredClass.fromPointer($ret, retain: false, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/forward_decl_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/forward_decl_test_bindings.dart
@@ -66,13 +66,16 @@ extension type ForwardDeclaredClass._(objc.ObjCObject object$)
 extension ForwardDeclaredClass$Methods on ForwardDeclaredClass {
   /// init
   ForwardDeclaredClass init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'ForwardDeclaredClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return ForwardDeclaredClass.fromPointer($ret, retain: false, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/global_native_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test_bindings.dart
@@ -103,11 +103,9 @@ abstract final class ObjCBlock_Int32_Int32 {
     int Function(int) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (int arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -137,18 +135,19 @@ abstract final class ObjCBlock_Int32_Int32 {
 /// Call operator for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.
 extension ObjCBlock_Int32_Int32$CallExtension
     on objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> {
-  int call(int arg0) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Int32 Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Int32 arg0,
-              )
-            >
-          >()
-          .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
-        ref.pointer,
-        arg0,
-      );
+  int call(int arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Int32 Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Int32 arg0,
+            )
+          >
+        >()
+        .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }

--- a/pkgs/ffigen/test/native_objc_test/global_native_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test_bindings.dart
@@ -29,7 +29,8 @@ set globalBlock(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>? value) {
           retain: false,
           release: true,
         ).ref.release();
-  _globalBlock = value?.ref.retainAndReturnPointer() ?? ffi.nullptr;
+  final _$$ = value?.ref;
+  _globalBlock = _$$?.retainAndReturnPointer() ?? ffi.nullptr;
 }
 
 @ffi.Native<ffi.Pointer<objc.ObjCObjectImpl>>(symbol: 'globalObject')
@@ -47,7 +48,8 @@ set globalObject(objc.NSObject? value) {
           retain: false,
           release: true,
         ).ref.release();
-  _globalObject = value?.ref.retainAndReturnPointer() ?? ffi.nullptr;
+  final _$$ = value?.ref;
+  _globalObject = _$$?.retainAndReturnPointer() ?? ffi.nullptr;
 }
 
 @ffi.Native<ffi.Pointer<objc.ObjCObjectImpl>>(symbol: 'globalString')
@@ -62,7 +64,8 @@ set globalString(objc.NSString value) {
     retain: false,
     release: true,
   ).ref.release();
-  _globalString = value.ref.retainAndReturnPointer();
+  final _$$ = value.ref;
+  _globalString = _$$.retainAndReturnPointer();
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.

--- a/pkgs/ffigen/test/native_objc_test/global_native_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test_bindings.dart
@@ -29,8 +29,8 @@ set globalBlock(objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>? value) {
           retain: false,
           release: true,
         ).ref.release();
-  final _$$ = value?.ref;
-  _globalBlock = _$$?.retainAndReturnPointer() ?? ffi.nullptr;
+  final _$$ref = value?.ref;
+  _globalBlock = _$$ref?.retainAndReturnPointer() ?? ffi.nullptr;
 }
 
 @ffi.Native<ffi.Pointer<objc.ObjCObjectImpl>>(symbol: 'globalObject')
@@ -48,8 +48,8 @@ set globalObject(objc.NSObject? value) {
           retain: false,
           release: true,
         ).ref.release();
-  final _$$ = value?.ref;
-  _globalObject = _$$?.retainAndReturnPointer() ?? ffi.nullptr;
+  final _$$ref = value?.ref;
+  _globalObject = _$$ref?.retainAndReturnPointer() ?? ffi.nullptr;
 }
 
 @ffi.Native<ffi.Pointer<objc.ObjCObjectImpl>>(symbol: 'globalString')
@@ -64,8 +64,8 @@ set globalString(objc.NSString value) {
     retain: false,
     release: true,
   ).ref.release();
-  final _$$ = value.ref;
-  _globalString = _$$.retainAndReturnPointer();
+  final _$$ref = value.ref;
+  _globalString = _$$ref.retainAndReturnPointer();
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.

--- a/pkgs/ffigen/test/native_objc_test/global_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_test_bindings.dart
@@ -41,8 +41,8 @@ class GlobalTestObjCLibrary {
             retain: false,
             release: true,
           ).ref.release();
-    final _$$ = value?.ref;
-    _globalBlock.value = _$$?.retainAndReturnPointer() ?? ffi.nullptr;
+    final _$$ref = value?.ref;
+    _globalBlock.value = _$$ref?.retainAndReturnPointer() ?? ffi.nullptr;
   }
 
   late final ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> _globalObject =
@@ -64,8 +64,8 @@ class GlobalTestObjCLibrary {
             retain: false,
             release: true,
           ).ref.release();
-    final _$$ = value?.ref;
-    _globalObject.value = _$$?.retainAndReturnPointer() ?? ffi.nullptr;
+    final _$$ref = value?.ref;
+    _globalObject.value = _$$ref?.retainAndReturnPointer() ?? ffi.nullptr;
   }
 
   late final ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> _globalString =
@@ -83,8 +83,8 @@ class GlobalTestObjCLibrary {
       retain: false,
       release: true,
     ).ref.release();
-    final _$$ = value.ref;
-    _globalString.value = _$$.retainAndReturnPointer();
+    final _$$ref = value.ref;
+    _globalString.value = _$$ref.retainAndReturnPointer();
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/global_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_test_bindings.dart
@@ -123,11 +123,9 @@ abstract final class ObjCBlock_Int32_Int32 {
     int Function(int) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (int arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -157,18 +155,19 @@ abstract final class ObjCBlock_Int32_Int32 {
 /// Call operator for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.
 extension ObjCBlock_Int32_Int32$CallExtension
     on objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> {
-  int call(int arg0) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Int32 Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Int32 arg0,
-              )
-            >
-          >()
-          .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
-        ref.pointer,
-        arg0,
-      );
+  int call(int arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Int32 Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Int32 arg0,
+            )
+          >
+        >()
+        .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }

--- a/pkgs/ffigen/test/native_objc_test/global_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_test_bindings.dart
@@ -41,7 +41,8 @@ class GlobalTestObjCLibrary {
             retain: false,
             release: true,
           ).ref.release();
-    _globalBlock.value = value?.ref.retainAndReturnPointer() ?? ffi.nullptr;
+    final _$$ = value?.ref;
+    _globalBlock.value = _$$?.retainAndReturnPointer() ?? ffi.nullptr;
   }
 
   late final ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> _globalObject =
@@ -63,7 +64,8 @@ class GlobalTestObjCLibrary {
             retain: false,
             release: true,
           ).ref.release();
-    _globalObject.value = value?.ref.retainAndReturnPointer() ?? ffi.nullptr;
+    final _$$ = value?.ref;
+    _globalObject.value = _$$?.retainAndReturnPointer() ?? ffi.nullptr;
   }
 
   late final ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> _globalString =
@@ -81,7 +83,8 @@ class GlobalTestObjCLibrary {
       retain: false,
       release: true,
     ).ref.release();
-    _globalString.value = value.ref.retainAndReturnPointer();
+    final _$$ = value.ref;
+    _globalString.value = _$$.retainAndReturnPointer();
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/inherited_instancetype_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/inherited_instancetype_test_bindings.dart
@@ -67,21 +67,20 @@ extension type BaseClass._(objc.ObjCObject object$)
 extension BaseClass$Methods on BaseClass {
   /// getSelf
   BaseClass getSelf() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_getSelf);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_getSelf);
     return BaseClass.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BaseClass init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'BaseClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return BaseClass.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -147,24 +146,27 @@ extension type ChildClass._(objc.ObjCObject object$)
 extension ChildClass$Methods on ChildClass {
   /// field
   int get field {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_field);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_field);
   }
 
   /// getSelf
   ChildClass getSelf() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_getSelf);
+    final _$$$1 = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$$1.pointer, _sel_getSelf);
     return ChildClass.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   ChildClass init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'ChildClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return ChildClass.fromPointer($ret, retain: false, release: true);
@@ -172,7 +174,8 @@ extension ChildClass$Methods on ChildClass {
 
   /// setField:
   set field(int value) {
-    _objc_msgSend_1bqef4y(object$.ref.pointer, _sel_setField_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setField_, value);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/inherited_instancetype_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/inherited_instancetype_test_bindings.dart
@@ -67,20 +67,23 @@ extension type BaseClass._(objc.ObjCObject object$)
 extension BaseClass$Methods on BaseClass {
   /// getSelf
   BaseClass getSelf() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_getSelf);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_getSelf);
     return BaseClass.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   BaseClass init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'BaseClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return BaseClass.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -146,27 +149,27 @@ extension type ChildClass._(objc.ObjCObject object$)
 extension ChildClass$Methods on ChildClass {
   /// field
   int get field {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_field);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_field);
   }
 
   /// getSelf
   ChildClass getSelf() {
-    final _$$$1 = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$$1.pointer, _sel_getSelf);
+    final _$$ref$1 = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref$1.pointer, _sel_getSelf);
     return ChildClass.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   ChildClass init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'ChildClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return ChildClass.fromPointer($ret, retain: false, release: true);
@@ -174,8 +177,8 @@ extension ChildClass$Methods on ChildClass {
 
   /// setField:
   set field(int value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setField_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1bqef4y(_$$ref.pointer, _sel_setField_, value);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/is_instance_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/is_instance_test_bindings.dart
@@ -61,13 +61,16 @@ extension type IsInstanceBaseClass._(objc.ObjCObject object$)
 extension IsInstanceBaseClass$Methods on IsInstanceBaseClass {
   /// init
   IsInstanceBaseClass init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'IsInstanceBaseClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return IsInstanceBaseClass.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -127,14 +130,14 @@ extension type IsInstanceChildClass._(objc.ObjCObject object$)
 extension IsInstanceChildClass$Methods on IsInstanceChildClass {
   /// init
   IsInstanceChildClass init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'IsInstanceChildClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return IsInstanceChildClass.fromPointer($ret, retain: false, release: true);
@@ -214,14 +217,14 @@ extension type IsInstanceUnrelatedClass._(objc.ObjCObject object$)
 extension IsInstanceUnrelatedClass$Methods on IsInstanceUnrelatedClass {
   /// init
   IsInstanceUnrelatedClass init() {
-    final _$$$2 = object$.ref;
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'IsInstanceUnrelatedClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return IsInstanceUnrelatedClass.fromPointer(

--- a/pkgs/ffigen/test/native_objc_test/is_instance_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/is_instance_test_bindings.dart
@@ -61,15 +61,13 @@ extension type IsInstanceBaseClass._(objc.ObjCObject object$)
 extension IsInstanceBaseClass$Methods on IsInstanceBaseClass {
   /// init
   IsInstanceBaseClass init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'IsInstanceBaseClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return IsInstanceBaseClass.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -129,13 +127,14 @@ extension type IsInstanceChildClass._(objc.ObjCObject object$)
 extension IsInstanceChildClass$Methods on IsInstanceChildClass {
   /// init
   IsInstanceChildClass init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'IsInstanceChildClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return IsInstanceChildClass.fromPointer($ret, retain: false, release: true);
@@ -215,13 +214,14 @@ extension type IsInstanceUnrelatedClass._(objc.ObjCObject object$)
 extension IsInstanceUnrelatedClass$Methods on IsInstanceUnrelatedClass {
   /// init
   IsInstanceUnrelatedClass init() {
+    final _$$$2 = object$.ref;
     objc.checkOsVersionInternal(
       'IsInstanceUnrelatedClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_init,
     );
     return IsInstanceUnrelatedClass.fromPointer(

--- a/pkgs/ffigen/test/native_objc_test/isolate_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/isolate_test_bindings.dart
@@ -314,26 +314,26 @@ extension type Sendable._(objc.ObjCObject object$)
 extension Sendable$Methods on Sendable {
   /// init
   Sendable init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'Sendable.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return Sendable.fromPointer($ret, retain: false, release: true);
   }
 
   /// setValue:
   set value(int value) {
-    _objc_msgSend_1bqef4y(object$.ref.pointer, _sel_setValue_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setValue_, value);
   }
 
   /// value
   int get value {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_value);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_value);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/isolate_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/isolate_test_bindings.dart
@@ -67,11 +67,9 @@ abstract final class ObjCBlock_ffiVoid_Int32 {
     void Function(int) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Int32)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (int arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -89,11 +87,11 @@ abstract final class ObjCBlock_ffiVoid_Int32 {
     void Function(int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      int arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final wrapper = _rdx59v_wrapListenerBlock_1bqef4y(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Int32)>(
@@ -117,14 +115,16 @@ abstract final class ObjCBlock_ffiVoid_Int32 {
     void Function(int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      int arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (int arg0) => fn(arg0),
+      (int arg0) {
+        return fn(arg0);
+      },
       keepIsolateAlive,
     );
     final wrapper = _rdx59v_wrapBlockingBlock_1bqef4y(
@@ -228,20 +228,21 @@ abstract final class ObjCBlock_ffiVoid_Int32 {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Int32)>`.
 extension ObjCBlock_ffiVoid_Int32$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Int32)> {
-  void call(int arg0) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Int32 arg0,
-              )
-            >
-          >()
-          .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
-        ref.pointer,
-        arg0,
-      );
+  void call(int arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Int32 arg0,
+            )
+          >
+        >()
+        .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }
 
 /// Sendable

--- a/pkgs/ffigen/test/native_objc_test/isolate_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/isolate_test_bindings.dart
@@ -314,26 +314,29 @@ extension type Sendable._(objc.ObjCObject object$)
 extension Sendable$Methods on Sendable {
   /// init
   Sendable init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'Sendable.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return Sendable.fromPointer($ret, retain: false, release: true);
   }
 
   /// setValue:
   set value(int value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setValue_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1bqef4y(_$$ref.pointer, _sel_setValue_, value);
   }
 
   /// value
   int get value {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_value);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_value);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/log_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/log_test_bindings.dart
@@ -75,15 +75,13 @@ extension type LogSpamBaseClass._(objc.ObjCObject object$)
 extension LogSpamBaseClass$Methods on LogSpamBaseClass {
   /// init
   LogSpamBaseClass init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'LogSpamBaseClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return LogSpamBaseClass.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -157,13 +155,14 @@ extension type LogSpamChildClass._(objc.ObjCObject object$)
 extension LogSpamChildClass$Methods on LogSpamChildClass {
   /// init
   LogSpamChildClass init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'LogSpamChildClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return LogSpamChildClass.fromPointer($ret, retain: false, release: true);

--- a/pkgs/ffigen/test/native_objc_test/log_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/log_test_bindings.dart
@@ -75,13 +75,16 @@ extension type LogSpamBaseClass._(objc.ObjCObject object$)
 extension LogSpamBaseClass$Methods on LogSpamBaseClass {
   /// init
   LogSpamBaseClass init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'LogSpamBaseClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return LogSpamBaseClass.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -155,14 +158,14 @@ extension type LogSpamChildClass._(objc.ObjCObject object$)
 extension LogSpamChildClass$Methods on LogSpamChildClass {
   /// init
   LogSpamChildClass init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'LogSpamChildClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return LogSpamChildClass.fromPointer($ret, retain: false, release: true);

--- a/pkgs/ffigen/test/native_objc_test/method_filtering_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_filtering_test_bindings.dart
@@ -295,25 +295,27 @@ extension ObjCBlock_instancetype_ffiVoid$CallExtension
         objc.ObjCBlock<
           ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
         > {
-  Dartinstancetype call(ffi.Pointer<ffi.Void> arg0) => objc.ObjCObject(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  Dartinstancetype call(ffi.Pointer<ffi.Void> arg0) {
+    return objc.ObjCObject(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              instancetype Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+              )
+            >
+          >()
+          .asFunction<
             instancetype Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
             )
-          >
-        >()
-        .asFunction<
-          instancetype Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >()(ref.pointer, arg0),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 late final _class_MethodFilteringTestInterface = objc.getClass(

--- a/pkgs/ffigen/test/native_objc_test/method_filtering_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_filtering_test_bindings.dart
@@ -249,11 +249,10 @@ abstract final class ObjCBlock_instancetype_ffiVoid {
       objc.ObjCBlock<
         ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+          final _$obj = fn(arg0);
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );

--- a/pkgs/ffigen/test/native_objc_test/method_filtering_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_filtering_test_bindings.dart
@@ -63,9 +63,9 @@ extension MethodFilteringTestInterface$Methods on MethodFilteringTestInterface {
     int arg, {
     required int with$,
   }) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_3hao97(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_includedInstanceMethod_with_,
       arg,
       with$,
@@ -79,8 +79,8 @@ extension MethodFilteringTestInterface$Methods on MethodFilteringTestInterface {
 
   /// includedProperty
   objc.NSObject get includedProperty {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_includedProperty);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_includedProperty);
     return objc.NSObject.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -111,9 +111,9 @@ extension type MethodFilteringTestProtocol._(objc.ObjCProtocol object$)
 extension MethodFilteringTestProtocol$Methods on MethodFilteringTestProtocol {
   /// includedProtocolMethod
   MethodFilteringTestProtocol includedProtocolMethod() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_includedProtocolMethod,
     );
     return MethodFilteringTestProtocol.fromPointer(
@@ -250,8 +250,8 @@ abstract final class ObjCBlock_instancetype_ffiVoid {
         ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$$ = fn(arg0).ref;
-          return _$$.retainAndAutorelease();
+          final _$$ref = fn(arg0).ref;
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,

--- a/pkgs/ffigen/test/native_objc_test/method_filtering_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_filtering_test_bindings.dart
@@ -63,8 +63,9 @@ extension MethodFilteringTestInterface$Methods on MethodFilteringTestInterface {
     int arg, {
     required int with$,
   }) {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_3hao97(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_includedInstanceMethod_with_,
       arg,
       with$,
@@ -78,10 +79,8 @@ extension MethodFilteringTestInterface$Methods on MethodFilteringTestInterface {
 
   /// includedProperty
   objc.NSObject get includedProperty {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_includedProperty,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_includedProperty);
     return objc.NSObject.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -112,8 +111,9 @@ extension type MethodFilteringTestProtocol._(objc.ObjCProtocol object$)
 extension MethodFilteringTestProtocol$Methods on MethodFilteringTestProtocol {
   /// includedProtocolMethod
   MethodFilteringTestProtocol includedProtocolMethod() {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_includedProtocolMethod,
     );
     return MethodFilteringTestProtocol.fromPointer(
@@ -250,8 +250,8 @@ abstract final class ObjCBlock_instancetype_ffiVoid {
         ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$obj = fn(arg0);
-          return _$obj.ref.retainAndAutorelease();
+          final _$$ = fn(arg0).ref;
+          return _$$.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,

--- a/pkgs/ffigen/test/native_objc_test/method_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_test_bindings.dart
@@ -89,11 +89,11 @@ extension type MethodInterface._(objc.ObjCObject object$)
 extension MethodInterface$Methods on MethodInterface {
   /// Vec4
   Vec4 Vec4$1() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ptr = pkg_ffi.calloc<Vec4>();
     objc.useMsgSendVariants
-        ? _objc_msgSend_o6r21bStret($ptr, _$$.pointer, _sel_Vec4)
-        : $ptr.ref = _objc_msgSend_o6r21b(_$$.pointer, _sel_Vec4);
+        ? _objc_msgSend_o6r21bStret($ptr, _$$ref.pointer, _sel_Vec4)
+        : $ptr.ref = _objc_msgSend_o6r21b(_$$ref.pointer, _sel_Vec4);
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<Vec4>(),
       finalizer: pkg_ffi.calloc.nativeFree,
@@ -103,75 +103,78 @@ extension MethodInterface$Methods on MethodInterface {
 
   /// add
   int add() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_add);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_add);
   }
 
   /// add:
   int add$1(int x) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_zo3bvx(_$$.pointer, _sel_add_, x);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_zo3bvx(_$$ref.pointer, _sel_add_, x);
   }
 
   /// add:Y:
   int add$2(int x, {required int Y}) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1q0lyci(_$$.pointer, _sel_add_Y_, x, Y);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1q0lyci(_$$ref.pointer, _sel_add_Y_, x, Y);
   }
 
   /// add:Y:Z:
   int add$3(int x, {required int Y, required int Z}) {
-    final _$$ = object$.ref;
-    return _objc_msgSend_b9kbqv(_$$.pointer, _sel_add_Y_Z_, x, Y, Z);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_b9kbqv(_$$ref.pointer, _sel_add_Y_Z_, x, Y, Z);
   }
 
   /// addDoubles:Y:
   double addDoubles(double x, {required double Y}) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_srsdcwFpret(_$$.pointer, _sel_addDoubles_Y_, x, Y)
-        : _objc_msgSend_srsdcw(_$$.pointer, _sel_addDoubles_Y_, x, Y);
+        ? _objc_msgSend_srsdcwFpret(_$$ref.pointer, _sel_addDoubles_Y_, x, Y)
+        : _objc_msgSend_srsdcw(_$$ref.pointer, _sel_addDoubles_Y_, x, Y);
   }
 
   /// addFloats:Y:
   double addFloats(double x, {required double Y}) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_sk7f6fFpret(_$$.pointer, _sel_addFloats_Y_, x, Y)
-        : _objc_msgSend_sk7f6f(_$$.pointer, _sel_addFloats_Y_, x, Y);
+        ? _objc_msgSend_sk7f6fFpret(_$$ref.pointer, _sel_addFloats_Y_, x, Y)
+        : _objc_msgSend_sk7f6f(_$$ref.pointer, _sel_addFloats_Y_, x, Y);
   }
 
   /// init
   MethodInterface init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'MethodInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return MethodInterface.fromPointer($ret, retain: false, release: true);
   }
 
   /// instStaticSameName
   int instStaticSameName() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_instStaticSameName);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_instStaticSameName);
   }
 
   /// twiddleVec4Components:
   Vec4 twiddleVec4Components(Vec4 v) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ptr = pkg_ffi.calloc<Vec4>();
     objc.useMsgSendVariants
         ? _objc_msgSend_ivr5s7Stret(
             $ptr,
-            _$$.pointer,
+            _$$ref.pointer,
             _sel_twiddleVec4Components_,
             v,
           )
         : $ptr.ref = _objc_msgSend_ivr5s7(
-            _$$.pointer,
+            _$$ref.pointer,
             _sel_twiddleVec4Components_,
             v,
           );

--- a/pkgs/ffigen/test/native_objc_test/method_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_test_bindings.dart
@@ -89,10 +89,11 @@ extension type MethodInterface._(objc.ObjCObject object$)
 extension MethodInterface$Methods on MethodInterface {
   /// Vec4
   Vec4 Vec4$1() {
+    final _$$ = object$.ref;
     final $ptr = pkg_ffi.calloc<Vec4>();
     objc.useMsgSendVariants
-        ? _objc_msgSend_o6r21bStret($ptr, object$.ref.pointer, _sel_Vec4)
-        : $ptr.ref = _objc_msgSend_o6r21b(object$.ref.pointer, _sel_Vec4);
+        ? _objc_msgSend_o6r21bStret($ptr, _$$.pointer, _sel_Vec4)
+        : $ptr.ref = _objc_msgSend_o6r21b(_$$.pointer, _sel_Vec4);
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<Vec4>(),
       finalizer: pkg_ffi.calloc.nativeFree,
@@ -102,79 +103,75 @@ extension MethodInterface$Methods on MethodInterface {
 
   /// add
   int add() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_add);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_add);
   }
 
   /// add:
   int add$1(int x) {
-    return _objc_msgSend_zo3bvx(object$.ref.pointer, _sel_add_, x);
+    final _$$ = object$.ref;
+    return _objc_msgSend_zo3bvx(_$$.pointer, _sel_add_, x);
   }
 
   /// add:Y:
   int add$2(int x, {required int Y}) {
-    return _objc_msgSend_1q0lyci(object$.ref.pointer, _sel_add_Y_, x, Y);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1q0lyci(_$$.pointer, _sel_add_Y_, x, Y);
   }
 
   /// add:Y:Z:
   int add$3(int x, {required int Y, required int Z}) {
-    return _objc_msgSend_b9kbqv(object$.ref.pointer, _sel_add_Y_Z_, x, Y, Z);
+    final _$$ = object$.ref;
+    return _objc_msgSend_b9kbqv(_$$.pointer, _sel_add_Y_Z_, x, Y, Z);
   }
 
   /// addDoubles:Y:
   double addDoubles(double x, {required double Y}) {
+    final _$$ = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_srsdcwFpret(
-            object$.ref.pointer,
-            _sel_addDoubles_Y_,
-            x,
-            Y,
-          )
-        : _objc_msgSend_srsdcw(object$.ref.pointer, _sel_addDoubles_Y_, x, Y);
+        ? _objc_msgSend_srsdcwFpret(_$$.pointer, _sel_addDoubles_Y_, x, Y)
+        : _objc_msgSend_srsdcw(_$$.pointer, _sel_addDoubles_Y_, x, Y);
   }
 
   /// addFloats:Y:
   double addFloats(double x, {required double Y}) {
+    final _$$ = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_sk7f6fFpret(
-            object$.ref.pointer,
-            _sel_addFloats_Y_,
-            x,
-            Y,
-          )
-        : _objc_msgSend_sk7f6f(object$.ref.pointer, _sel_addFloats_Y_, x, Y);
+        ? _objc_msgSend_sk7f6fFpret(_$$.pointer, _sel_addFloats_Y_, x, Y)
+        : _objc_msgSend_sk7f6f(_$$.pointer, _sel_addFloats_Y_, x, Y);
   }
 
   /// init
   MethodInterface init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'MethodInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return MethodInterface.fromPointer($ret, retain: false, release: true);
   }
 
   /// instStaticSameName
   int instStaticSameName() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_instStaticSameName);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_instStaticSameName);
   }
 
   /// twiddleVec4Components:
   Vec4 twiddleVec4Components(Vec4 v) {
+    final _$$ = object$.ref;
     final $ptr = pkg_ffi.calloc<Vec4>();
     objc.useMsgSendVariants
         ? _objc_msgSend_ivr5s7Stret(
             $ptr,
-            object$.ref.pointer,
+            _$$.pointer,
             _sel_twiddleVec4Components_,
             v,
           )
         : $ptr.ref = _objc_msgSend_ivr5s7(
-            object$.ref.pointer,
+            _$$.pointer,
             _sel_twiddleVec4Components_,
             v,
           );

--- a/pkgs/ffigen/test/native_objc_test/native_objc_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/native_objc_test_bindings.dart
@@ -59,106 +59,110 @@ extension type Foo._(objc.ObjCObject object$)
 extension Foo$Methods on Foo {
   /// boolVal
   bool get boolVal {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_boolVal);
+    final _$$ = object$.ref;
+    return _objc_msgSend_91o635(_$$.pointer, _sel_boolVal);
   }
 
   /// classVal
   objc.ObjCObject get classVal {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_classVal);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_classVal);
     return objc.ObjCObject($ret, retain: true, release: true);
   }
 
   /// idVal
   objc.ObjCObject get idVal {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_idVal);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_idVal);
     return objc.ObjCObject($ret, retain: true, release: true);
   }
 
   /// init
   Foo init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'Foo.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return Foo.fromPointer($ret, retain: false, release: true);
   }
 
   /// intVal
   int get intVal {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_intVal);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_intVal);
   }
 
   /// multiply:withOtherFoo:
   int multiply(bool useIntVals, {required Foo withOtherFoo}) {
+    final _$$ = object$.ref;
+    final _$$$1 = withOtherFoo.ref;
     return _objc_msgSend_1t47e0u(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_multiply_withOtherFoo_,
       useIntVals,
-      withOtherFoo.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// objVal
   objc.NSObject get objVal {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_objVal);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_objVal);
     return objc.NSObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// selVal
   ffi.Pointer<objc.ObjCSelector> get selVal {
-    return _objc_msgSend_1ovaulg(object$.ref.pointer, _sel_selVal);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1ovaulg(_$$.pointer, _sel_selVal);
   }
 
   /// setBoolVal:
   set boolVal(bool value) {
-    _objc_msgSend_1s56lr9(object$.ref.pointer, _sel_setBoolVal_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_1s56lr9(_$$.pointer, _sel_setBoolVal_, value);
   }
 
   /// setClassVal:
   set classVal(objc.ObjCObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setClassVal_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setClassVal_, _$$$1.pointer);
   }
 
   /// setDoubleVal:
   void setDoubleVal(double x) {
-    _objc_msgSend_hwm8nu(object$.ref.pointer, _sel_setDoubleVal_, x);
+    final _$$ = object$.ref;
+    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setDoubleVal_, x);
   }
 
   /// setIdVal:
   set idVal(objc.ObjCObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setIdVal_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setIdVal_, _$$$1.pointer);
   }
 
   /// setIntVal:
   set intVal(int value) {
-    _objc_msgSend_1bqef4y(object$.ref.pointer, _sel_setIntVal_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setIntVal_, value);
   }
 
   /// setObjVal:
   set objVal(objc.NSObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setObjVal_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setObjVal_, _$$$1.pointer);
   }
 
   /// setSelVal:
   set selVal(ffi.Pointer<objc.ObjCSelector> value) {
-    _objc_msgSend_1d9e4oe(object$.ref.pointer, _sel_setSelVal_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_1d9e4oe(_$$.pointer, _sel_setSelVal_, value);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/native_objc_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/native_objc_test_bindings.dart
@@ -59,110 +59,113 @@ extension type Foo._(objc.ObjCObject object$)
 extension Foo$Methods on Foo {
   /// boolVal
   bool get boolVal {
-    final _$$ = object$.ref;
-    return _objc_msgSend_91o635(_$$.pointer, _sel_boolVal);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_boolVal);
   }
 
   /// classVal
   objc.ObjCObject get classVal {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_classVal);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_classVal);
     return objc.ObjCObject($ret, retain: true, release: true);
   }
 
   /// idVal
   objc.ObjCObject get idVal {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_idVal);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_idVal);
     return objc.ObjCObject($ret, retain: true, release: true);
   }
 
   /// init
   Foo init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'Foo.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return Foo.fromPointer($ret, retain: false, release: true);
   }
 
   /// intVal
   int get intVal {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_intVal);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_intVal);
   }
 
   /// multiply:withOtherFoo:
   int multiply(bool useIntVals, {required Foo withOtherFoo}) {
-    final _$$ = object$.ref;
-    final _$$$1 = withOtherFoo.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withOtherFoo.ref;
     return _objc_msgSend_1t47e0u(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_multiply_withOtherFoo_,
       useIntVals,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// objVal
   objc.NSObject get objVal {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_objVal);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_objVal);
     return objc.NSObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// selVal
   ffi.Pointer<objc.ObjCSelector> get selVal {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1ovaulg(_$$.pointer, _sel_selVal);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1ovaulg(_$$ref.pointer, _sel_selVal);
   }
 
   /// setBoolVal:
   set boolVal(bool value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_1s56lr9(_$$.pointer, _sel_setBoolVal_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1s56lr9(_$$ref.pointer, _sel_setBoolVal_, value);
   }
 
   /// setClassVal:
   set classVal(objc.ObjCObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setClassVal_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setClassVal_, _$$ref$1.pointer);
   }
 
   /// setDoubleVal:
   void setDoubleVal(double x) {
-    final _$$ = object$.ref;
-    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setDoubleVal_, x);
+    final _$$ref = object$.ref;
+    _objc_msgSend_hwm8nu(_$$ref.pointer, _sel_setDoubleVal_, x);
   }
 
   /// setIdVal:
   set idVal(objc.ObjCObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setIdVal_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setIdVal_, _$$ref$1.pointer);
   }
 
   /// setIntVal:
   set intVal(int value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setIntVal_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1bqef4y(_$$ref.pointer, _sel_setIntVal_, value);
   }
 
   /// setObjVal:
   set objVal(objc.NSObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setObjVal_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setObjVal_, _$$ref$1.pointer);
   }
 
   /// setSelVal:
   set selVal(ffi.Pointer<objc.ObjCSelector> value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_1d9e4oe(_$$.pointer, _sel_setSelVal_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1d9e4oe(_$$ref.pointer, _sel_setSelVal_, value);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/nullable_inheritance_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/nullable_inheritance_test_bindings.dart
@@ -61,30 +61,27 @@ extension type NullableBase._(objc.ObjCObject object$)
 extension NullableBase$Methods on NullableBase {
   /// init
   NullableBase init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NullableBase.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return NullableBase.fromPointer($ret, retain: false, release: true);
   }
 
   /// nonNullArg:
   bool nonNullArg(objc.NSObject x) {
-    return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
-      _sel_nonNullArg_,
-      x.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = x.ref;
+    return _objc_msgSend_19nvye5(_$$.pointer, _sel_nonNullArg_, _$$$1.pointer);
   }
 
   /// nonNullReturn
   objc.NSObject? nonNullReturn() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_nonNullReturn);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_nonNullReturn);
     return $ret.address == 0
         ? null
         : objc.NSObject.fromPointer($ret, retain: true, release: true);
@@ -92,20 +89,19 @@ extension NullableBase$Methods on NullableBase {
 
   /// nullableArg:
   bool nullableArg(objc.NSObject? x) {
+    final _$$ = object$.ref;
+    final _$$$1 = x?.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_nullableArg_,
-      x?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// nullableReturn:
   objc.NSObject? nullableReturn(bool r) {
-    final $ret = _objc_msgSend_1t6aok9(
-      object$.ref.pointer,
-      _sel_nullableReturn_,
-      r,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_1t6aok9(_$$.pointer, _sel_nullableReturn_, r);
     return $ret.address == 0
         ? null
         : objc.NSObject.fromPointer($ret, retain: true, release: true);
@@ -167,13 +163,14 @@ extension type NullableChild._(objc.ObjCObject object$)
 extension NullableChild$Methods on NullableChild {
   /// init
   NullableChild init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'NullableChild.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return NullableChild.fromPointer($ret, retain: false, release: true);
@@ -181,16 +178,19 @@ extension NullableChild$Methods on NullableChild {
 
   /// nonNullArg:
   bool nonNullArg(objc.NSObject? x) {
+    final _$$ = object$.ref;
+    final _$$$1 = x?.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_nonNullArg_,
-      x?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// nonNullReturn
   objc.NSObject? nonNullReturn() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_nonNullReturn);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_nonNullReturn);
     return $ret.address == 0
         ? null
         : objc.NSObject.fromPointer($ret, retain: true, release: true);
@@ -198,20 +198,15 @@ extension NullableChild$Methods on NullableChild {
 
   /// nullableArg:
   bool nullableArg(objc.NSObject x) {
-    return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
-      _sel_nullableArg_,
-      x.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = x.ref;
+    return _objc_msgSend_19nvye5(_$$.pointer, _sel_nullableArg_, _$$$1.pointer);
   }
 
   /// nullableReturn:
   objc.NSObject nullableReturn(bool r) {
-    final $ret = _objc_msgSend_1t6aok9(
-      object$.ref.pointer,
-      _sel_nullableReturn_,
-      r,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_1t6aok9(_$$.pointer, _sel_nullableReturn_, r);
     return objc.NSObject.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -271,13 +266,14 @@ extension type NullableIntermediate._(objc.ObjCObject object$)
 extension NullableIntermediate$Methods on NullableIntermediate {
   /// init
   NullableIntermediate init() {
+    final _$$$2 = object$.ref;
     objc.checkOsVersionInternal(
       'NullableIntermediate.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_init,
     );
     return NullableIntermediate.fromPointer($ret, retain: false, release: true);

--- a/pkgs/ffigen/test/native_objc_test/nullable_inheritance_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/nullable_inheritance_test_bindings.dart
@@ -61,27 +61,34 @@ extension type NullableBase._(objc.ObjCObject object$)
 extension NullableBase$Methods on NullableBase {
   /// init
   NullableBase init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NullableBase.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return NullableBase.fromPointer($ret, retain: false, release: true);
   }
 
   /// nonNullArg:
   bool nonNullArg(objc.NSObject x) {
-    final _$$ = object$.ref;
-    final _$$$1 = x.ref;
-    return _objc_msgSend_19nvye5(_$$.pointer, _sel_nonNullArg_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = x.ref;
+    return _objc_msgSend_19nvye5(
+      _$$ref.pointer,
+      _sel_nonNullArg_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// nonNullReturn
   objc.NSObject? nonNullReturn() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_nonNullReturn);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_nonNullReturn);
     return $ret.address == 0
         ? null
         : objc.NSObject.fromPointer($ret, retain: true, release: true);
@@ -89,19 +96,19 @@ extension NullableBase$Methods on NullableBase {
 
   /// nullableArg:
   bool nullableArg(objc.NSObject? x) {
-    final _$$ = object$.ref;
-    final _$$$1 = x?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = x?.ref;
     return _objc_msgSend_19nvye5(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_nullableArg_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// nullableReturn:
   objc.NSObject? nullableReturn(bool r) {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_1t6aok9(_$$.pointer, _sel_nullableReturn_, r);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_1t6aok9(_$$ref.pointer, _sel_nullableReturn_, r);
     return $ret.address == 0
         ? null
         : objc.NSObject.fromPointer($ret, retain: true, release: true);
@@ -163,14 +170,14 @@ extension type NullableChild._(objc.ObjCObject object$)
 extension NullableChild$Methods on NullableChild {
   /// init
   NullableChild init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'NullableChild.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return NullableChild.fromPointer($ret, retain: false, release: true);
@@ -178,19 +185,19 @@ extension NullableChild$Methods on NullableChild {
 
   /// nonNullArg:
   bool nonNullArg(objc.NSObject? x) {
-    final _$$ = object$.ref;
-    final _$$$1 = x?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = x?.ref;
     return _objc_msgSend_19nvye5(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_nonNullArg_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// nonNullReturn
   objc.NSObject? nonNullReturn() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_nonNullReturn);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_nonNullReturn);
     return $ret.address == 0
         ? null
         : objc.NSObject.fromPointer($ret, retain: true, release: true);
@@ -198,15 +205,19 @@ extension NullableChild$Methods on NullableChild {
 
   /// nullableArg:
   bool nullableArg(objc.NSObject x) {
-    final _$$ = object$.ref;
-    final _$$$1 = x.ref;
-    return _objc_msgSend_19nvye5(_$$.pointer, _sel_nullableArg_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = x.ref;
+    return _objc_msgSend_19nvye5(
+      _$$ref.pointer,
+      _sel_nullableArg_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// nullableReturn:
   objc.NSObject nullableReturn(bool r) {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_1t6aok9(_$$.pointer, _sel_nullableReturn_, r);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_1t6aok9(_$$ref.pointer, _sel_nullableReturn_, r);
     return objc.NSObject.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -266,14 +277,14 @@ extension type NullableIntermediate._(objc.ObjCObject object$)
 extension NullableIntermediate$Methods on NullableIntermediate {
   /// init
   NullableIntermediate init() {
-    final _$$$2 = object$.ref;
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'NullableIntermediate.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return NullableIntermediate.fromPointer($ret, retain: false, release: true);

--- a/pkgs/ffigen/test/native_objc_test/nullable_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/nullable_test_bindings.dart
@@ -50,28 +50,31 @@ extension type NullableInterface._(objc.ObjCObject object$)
 
   /// isNullWithExplicitNonNullableNSObjectPtrArg:
   static bool isNullWithExplicitNonNullableNSObjectPtrArg(objc.NSObject x) {
+    final _$$ = x.ref;
     return _objc_msgSend_19nvye5(
       _class_NullableInterface,
       _sel_isNullWithExplicitNonNullableNSObjectPtrArg_,
-      x.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// isNullWithNotNullableNSObjectPtrArg:
   static bool isNullWithNotNullableNSObjectPtrArg(objc.NSObject x) {
+    final _$$ = x.ref;
     return _objc_msgSend_19nvye5(
       _class_NullableInterface,
       _sel_isNullWithNotNullableNSObjectPtrArg_,
-      x.ref.pointer,
+      _$$.pointer,
     );
   }
 
   /// isNullWithNullableNSObjectArg:
   static bool isNullWithNullableNSObjectArg(objc.NSObject? x) {
+    final _$$ = x?.ref;
     return _objc_msgSend_19nvye5(
       _class_NullableInterface,
       _sel_isNullWithNullableNSObjectArg_,
-      x?.ref.pointer ?? ffi.nullptr,
+      _$$?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -81,12 +84,15 @@ extension type NullableInterface._(objc.ObjCObject object$)
     objc.NSObject? y,
     objc.NSObject? z,
   }) {
+    final _$$ = x?.ref;
+    final _$$$1 = y?.ref;
+    final _$$$2 = z?.ref;
     final $ret = _objc_msgSend_11spmsz(
       _class_NullableInterface,
       _sel_multipleNullableArgs_y_z_,
-      x?.ref.pointer ?? ffi.nullptr,
-      y?.ref.pointer ?? ffi.nullptr,
-      z?.ref.pointer ?? ffi.nullptr,
+      _$$?.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
+      _$$$2?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -130,22 +136,21 @@ extension type NullableInterface._(objc.ObjCObject object$)
 extension NullableInterface$Methods on NullableInterface {
   /// init
   NullableInterface init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NullableInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return NullableInterface.fromPointer($ret, retain: false, release: true);
   }
 
   /// nullableObjectProperty
   objc.NSObject? get nullableObjectProperty {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_nullableObjectProperty,
     );
     return $ret.address == 0
@@ -155,10 +160,12 @@ extension NullableInterface$Methods on NullableInterface {
 
   /// setNullableObjectProperty:
   set nullableObjectProperty(objc.NSObject? value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value?.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setNullableObjectProperty_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/nullable_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/nullable_test_bindings.dart
@@ -50,31 +50,31 @@ extension type NullableInterface._(objc.ObjCObject object$)
 
   /// isNullWithExplicitNonNullableNSObjectPtrArg:
   static bool isNullWithExplicitNonNullableNSObjectPtrArg(objc.NSObject x) {
-    final _$$ = x.ref;
+    final _$$ref = x.ref;
     return _objc_msgSend_19nvye5(
       _class_NullableInterface,
       _sel_isNullWithExplicitNonNullableNSObjectPtrArg_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// isNullWithNotNullableNSObjectPtrArg:
   static bool isNullWithNotNullableNSObjectPtrArg(objc.NSObject x) {
-    final _$$ = x.ref;
+    final _$$ref = x.ref;
     return _objc_msgSend_19nvye5(
       _class_NullableInterface,
       _sel_isNullWithNotNullableNSObjectPtrArg_,
-      _$$.pointer,
+      _$$ref.pointer,
     );
   }
 
   /// isNullWithNullableNSObjectArg:
   static bool isNullWithNullableNSObjectArg(objc.NSObject? x) {
-    final _$$ = x?.ref;
+    final _$$ref = x?.ref;
     return _objc_msgSend_19nvye5(
       _class_NullableInterface,
       _sel_isNullWithNullableNSObjectArg_,
-      _$$?.pointer ?? ffi.nullptr,
+      _$$ref?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -84,15 +84,15 @@ extension type NullableInterface._(objc.ObjCObject object$)
     objc.NSObject? y,
     objc.NSObject? z,
   }) {
-    final _$$ = x?.ref;
-    final _$$$1 = y?.ref;
-    final _$$$2 = z?.ref;
+    final _$$ref = x?.ref;
+    final _$$ref$1 = y?.ref;
+    final _$$ref$2 = z?.ref;
     final $ret = _objc_msgSend_11spmsz(
       _class_NullableInterface,
       _sel_multipleNullableArgs_y_z_,
-      _$$?.pointer ?? ffi.nullptr,
-      _$$$1?.pointer ?? ffi.nullptr,
-      _$$$2?.pointer ?? ffi.nullptr,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -136,21 +136,24 @@ extension type NullableInterface._(objc.ObjCObject object$)
 extension NullableInterface$Methods on NullableInterface {
   /// init
   NullableInterface init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NullableInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return NullableInterface.fromPointer($ret, retain: false, release: true);
   }
 
   /// nullableObjectProperty
   objc.NSObject? get nullableObjectProperty {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_nullableObjectProperty,
     );
     return $ret.address == 0
@@ -160,12 +163,12 @@ extension NullableInterface$Methods on NullableInterface {
 
   /// setNullableObjectProperty:
   set nullableObjectProperty(objc.NSObject? value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setNullableObjectProperty_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/property_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/property_test_bindings.dart
@@ -112,81 +112,84 @@ extension type PropertyInterface._(objc.ObjCObject object$)
 extension PropertyInterface$Methods on PropertyInterface {
   /// doubleProperty
   double get doubleProperty {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_doubleProperty)
-        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_doubleProperty);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_doubleProperty)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_doubleProperty);
   }
 
   /// floatProperty
   double get floatProperty {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(_$$.pointer, _sel_floatProperty)
-        : _objc_msgSend_2cgrxl(_$$.pointer, _sel_floatProperty);
+        ? _objc_msgSend_2cgrxlFpret(_$$ref.pointer, _sel_floatProperty)
+        : _objc_msgSend_2cgrxl(_$$ref.pointer, _sel_floatProperty);
   }
 
   /// init
   PropertyInterface init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'PropertyInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return PropertyInterface.fromPointer($ret, retain: false, release: true);
   }
 
   /// instStaticSameName
   int get instStaticSameName {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_instStaticSameName);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_instStaticSameName);
   }
 
   /// readOnlyProperty
   int get readOnlyProperty {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_readOnlyProperty);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_readOnlyProperty);
   }
 
   /// readWriteProperty
   int get readWriteProperty {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_readWriteProperty);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_readWriteProperty);
   }
 
   /// setDoubleProperty:
   set doubleProperty(double value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setDoubleProperty_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_hwm8nu(_$$ref.pointer, _sel_setDoubleProperty_, value);
   }
 
   /// setFloatProperty:
   set floatProperty(double value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_v5hmet(_$$.pointer, _sel_setFloatProperty_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_v5hmet(_$$ref.pointer, _sel_setFloatProperty_, value);
   }
 
   /// setReadWriteProperty:
   set readWriteProperty(int value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setReadWriteProperty_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1bqef4y(_$$ref.pointer, _sel_setReadWriteProperty_, value);
   }
 
   /// setStructProperty:
   set structProperty(Vec4 value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_188ryij(_$$.pointer, _sel_setStructProperty_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_188ryij(_$$ref.pointer, _sel_setStructProperty_, value);
   }
 
   /// structProperty
   Vec4 get structProperty {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ptr = pkg_ffi.calloc<Vec4>();
     objc.useMsgSendVariants
-        ? _objc_msgSend_o6r21bStret($ptr, _$$.pointer, _sel_structProperty)
-        : $ptr.ref = _objc_msgSend_o6r21b(_$$.pointer, _sel_structProperty);
+        ? _objc_msgSend_o6r21bStret($ptr, _$$ref.pointer, _sel_structProperty)
+        : $ptr.ref = _objc_msgSend_o6r21b(_$$ref.pointer, _sel_structProperty);
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<Vec4>(),
       finalizer: pkg_ffi.calloc.nativeFree,

--- a/pkgs/ffigen/test/native_objc_test/property_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/property_test_bindings.dart
@@ -112,84 +112,81 @@ extension type PropertyInterface._(objc.ObjCObject object$)
 extension PropertyInterface$Methods on PropertyInterface {
   /// doubleProperty
   double get doubleProperty {
+    final _$$ = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_doubleProperty)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_doubleProperty);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$.pointer, _sel_doubleProperty)
+        : _objc_msgSend_1ukqyt8(_$$.pointer, _sel_doubleProperty);
   }
 
   /// floatProperty
   double get floatProperty {
+    final _$$ = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(object$.ref.pointer, _sel_floatProperty)
-        : _objc_msgSend_2cgrxl(object$.ref.pointer, _sel_floatProperty);
+        ? _objc_msgSend_2cgrxlFpret(_$$.pointer, _sel_floatProperty)
+        : _objc_msgSend_2cgrxl(_$$.pointer, _sel_floatProperty);
   }
 
   /// init
   PropertyInterface init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'PropertyInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return PropertyInterface.fromPointer($ret, retain: false, release: true);
   }
 
   /// instStaticSameName
   int get instStaticSameName {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_instStaticSameName);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_instStaticSameName);
   }
 
   /// readOnlyProperty
   int get readOnlyProperty {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_readOnlyProperty);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_readOnlyProperty);
   }
 
   /// readWriteProperty
   int get readWriteProperty {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_readWriteProperty);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_readWriteProperty);
   }
 
   /// setDoubleProperty:
   set doubleProperty(double value) {
-    _objc_msgSend_hwm8nu(object$.ref.pointer, _sel_setDoubleProperty_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_hwm8nu(_$$.pointer, _sel_setDoubleProperty_, value);
   }
 
   /// setFloatProperty:
   set floatProperty(double value) {
-    _objc_msgSend_v5hmet(object$.ref.pointer, _sel_setFloatProperty_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_v5hmet(_$$.pointer, _sel_setFloatProperty_, value);
   }
 
   /// setReadWriteProperty:
   set readWriteProperty(int value) {
-    _objc_msgSend_1bqef4y(
-      object$.ref.pointer,
-      _sel_setReadWriteProperty_,
-      value,
-    );
+    final _$$ = object$.ref;
+    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setReadWriteProperty_, value);
   }
 
   /// setStructProperty:
   set structProperty(Vec4 value) {
-    _objc_msgSend_188ryij(object$.ref.pointer, _sel_setStructProperty_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_188ryij(_$$.pointer, _sel_setStructProperty_, value);
   }
 
   /// structProperty
   Vec4 get structProperty {
+    final _$$ = object$.ref;
     final $ptr = pkg_ffi.calloc<Vec4>();
     objc.useMsgSendVariants
-        ? _objc_msgSend_o6r21bStret(
-            $ptr,
-            object$.ref.pointer,
-            _sel_structProperty,
-          )
-        : $ptr.ref = _objc_msgSend_o6r21b(
-            object$.ref.pointer,
-            _sel_structProperty,
-          );
+        ? _objc_msgSend_o6r21bStret($ptr, _$$.pointer, _sel_structProperty)
+        : $ptr.ref = _objc_msgSend_o6r21b(_$$.pointer, _sel_structProperty);
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<Vec4>(),
       finalizer: pkg_ffi.calloc.nativeFree,

--- a/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.dart
@@ -145,8 +145,9 @@ external ffi.Pointer<ffi.Void> _getClass(
   ffi.Pointer<objc.ObjCObjectImpl> object,
 );
 
-ffi.Pointer<ffi.Void> getClass(objc.ObjCObject object) =>
-    _getClass(object.ref.pointer);
+ffi.Pointer<ffi.Void> getClass(objc.ObjCObject object) {
+  return _getClass(object.ref.pointer);
+}
 
 @ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>)>()
 external ffi.Pointer<ffi.Char> getClassName(ffi.Pointer<ffi.Void> cls);
@@ -679,11 +680,9 @@ abstract final class ObjCBlock_Int32_ffiVoid {
     int Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Int32 Function(ffi.Pointer<ffi.Void>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -723,18 +722,20 @@ abstract final class ObjCBlock_Int32_ffiVoid {
 /// Call operator for `objc.ObjCBlock<ffi.Int32 Function(ffi.Pointer<ffi.Void>)>`.
 extension ObjCBlock_Int32_ffiVoid$CallExtension
     on objc.ObjCBlock<ffi.Int32 Function(ffi.Pointer<ffi.Void>)> {
-  int call(ffi.Pointer<ffi.Void> arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Int32 Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-          )
-        >
-      >()
-      .asFunction<
-        int Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)
-      >()(ref.pointer, arg0);
+  int call(ffi.Pointer<ffi.Void> arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Int32 Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          int Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)
+        >()(ref.pointer, arg0);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Int32 Function(ffi.Pointer<ffi.Void>, ffi.Int32, ffi.Int32, ffi.Int32, ffi.Int32)>`.
@@ -836,17 +837,15 @@ abstract final class ObjCBlock_Int32_ffiVoid_Int32_Int32_Int32_Int32 {
           ffi.Int32,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            int arg1,
-            int arg2,
-            int arg3,
-            int arg4,
-          ) => fn(arg0, arg1, arg2, arg3, arg4),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          int arg1,
+          int arg2,
+          int arg3,
+          int arg4,
+        ) {
+          return fn(arg0, arg1, arg2, arg3, arg4);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -927,35 +926,31 @@ extension ObjCBlock_Int32_ffiVoid_Int32_Int32_Int32_Int32$CallExtension
             ffi.Int32,
           )
         > {
-  int call(
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-    int arg2,
-    int arg3,
-    int arg4,
-  ) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Int32 Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Int32 arg1,
-            ffi.Int32 arg2,
-            ffi.Int32 arg3,
-            ffi.Int32 arg4,
+  int call(ffi.Pointer<ffi.Void> arg0, int arg1, int arg2, int arg3, int arg4) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Int32 Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Int32 arg1,
+              ffi.Int32 arg2,
+              ffi.Int32 arg3,
+              ffi.Int32 arg4,
+            )
+          >
+        >()
+        .asFunction<
+          int Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            int,
+            int,
+            int,
+            int,
           )
-        >
-      >()
-      .asFunction<
-        int Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          int,
-          int,
-          int,
-          int,
-        )
-      >()(ref.pointer, arg0, arg1, arg2, arg3, arg4);
+        >()(ref.pointer, arg0, arg1, arg2, arg3, arg4);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Int32 Function(ffi.Pointer<ffi.Void>, SomeStruct)>`.
@@ -1004,11 +999,12 @@ abstract final class ObjCBlock_Int32_ffiVoid_SomeStruct {
     int Function(ffi.Pointer<ffi.Void>, SomeStruct) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Int32 Function(ffi.Pointer<ffi.Void>, SomeStruct)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0, SomeStruct arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      SomeStruct arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1058,26 +1054,25 @@ abstract final class ObjCBlock_Int32_ffiVoid_SomeStruct {
 /// Call operator for `objc.ObjCBlock<ffi.Int32 Function(ffi.Pointer<ffi.Void>, SomeStruct)>`.
 extension ObjCBlock_Int32_ffiVoid_SomeStruct$CallExtension
     on objc.ObjCBlock<ffi.Int32 Function(ffi.Pointer<ffi.Void>, SomeStruct)> {
-  int call(ffi.Pointer<ffi.Void> arg0, SomeStruct arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Int32 Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            SomeStruct arg1,
+  int call(ffi.Pointer<ffi.Void> arg0, SomeStruct arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Int32 Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              SomeStruct arg1,
+            )
+          >
+        >()
+        .asFunction<
+          int Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            SomeStruct,
           )
-        >
-      >()
-      .asFunction<
-        int Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          SomeStruct,
-        )
-      >()(ref.pointer, arg0, arg1);
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<objc.NSString Function(ffi.Pointer<ffi.Void>, objc.NSString, ffi.Double)>`.
@@ -1227,29 +1222,31 @@ extension ObjCBlock_NSString_ffiVoid_NSString_ffiDouble$CallExtension
     ffi.Pointer<ffi.Void> arg0,
     objc.NSString arg1,
     double arg2,
-  ) => objc.NSString.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  ) {
+    return objc.NSString.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+                ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                ffi.Double arg2,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
-              ffi.Pointer<objc.ObjCObjectImpl> arg1,
-              ffi.Double arg2,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
+              double,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<objc.ObjCObjectImpl>,
-            double,
-          )
-        >()(ref.pointer, arg0, arg1.ref.pointer, arg2),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0, arg1.ref.pointer, arg2),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
@@ -1298,11 +1295,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32 {
     void Function(ffi.Pointer<ffi.Void>, int) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0, int arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -1321,11 +1319,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32 {
     void Function(ffi.Pointer<ffi.Void>, int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, int arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final wrapper = _13hhotk_wrapListenerBlock_1pbq496(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
@@ -1350,14 +1349,17 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32 {
     void Function(ffi.Pointer<ffi.Void>, int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, int arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, int arg1) => fn(arg0, arg1),
+      (ffi.Pointer<ffi.Void> arg0, int arg1) {
+        return fn(arg0, arg1);
+      },
       keepIsolateAlive,
     );
     final wrapper = _13hhotk_wrapBlockingBlock_1pbq496(
@@ -1495,23 +1497,25 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32 {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
 extension ObjCBlock_ffiVoid_ffiVoid_Int32$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)> {
-  void call(ffi.Pointer<ffi.Void> arg0, int arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Int32 arg1,
+  void call(ffi.Pointer<ffi.Void> arg0, int arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Int32 arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            int,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          int,
-        )
-      >()(ref.pointer, arg0, arg1);
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)>`.
@@ -1574,12 +1578,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32$1 {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<ffi.Int32> arg1) =>
-              fn(arg0, arg1),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<ffi.Int32> arg1,
+        ) {
+          return fn(arg0, arg1);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -1600,12 +1604,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32$1 {
     void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<ffi.Int32> arg1) =>
-          fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<ffi.Int32> arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final wrapper = _13hhotk_wrapListenerBlock_8r9qkg(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -1630,16 +1634,17 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32$1 {
     void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<ffi.Int32> arg1) =>
-          fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<ffi.Int32> arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<ffi.Int32> arg1) =>
-          fn(arg0, arg1),
+      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<ffi.Int32> arg1) {
+        return fn(arg0, arg1);
+      },
       keepIsolateAlive,
     );
     final wrapper = _13hhotk_wrapBlockingBlock_8r9qkg(
@@ -1790,26 +1795,25 @@ extension ObjCBlock_ffiVoid_ffiVoid_Int32$1$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)
         > {
-  void call(ffi.Pointer<ffi.Void> arg0, ffi.Pointer<ffi.Int32> arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<ffi.Int32> arg1,
+  void call(ffi.Pointer<ffi.Void> arg0, ffi.Pointer<ffi.Int32> arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<ffi.Int32> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Int32>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<ffi.Int32>,
-        )
-      >()(ref.pointer, arg0, arg1);
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)>`.
@@ -1921,25 +1925,27 @@ extension ObjCBlock_idMyProtocol_ffiVoid$CallExtension
         objc.ObjCBlock<
           ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
         > {
-  MyProtocol call(ffi.Pointer<ffi.Void> arg0) => MyProtocol.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  MyProtocol call(ffi.Pointer<ffi.Void> arg0) {
+    return MyProtocol.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >()(ref.pointer, arg0),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObjectImpl>? Function(ffi.Pointer<ffi.Void>)>`.
@@ -2043,44 +2049,45 @@ extension ObjCBlock_instancetype_ffiVoid$CallExtension
         objc.ObjCBlock<
           ffi.Pointer<objc.ObjCObjectImpl>? Function(ffi.Pointer<ffi.Void>)
         > {
-  Dartinstancetype? call(ffi.Pointer<ffi.Void> arg0) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  Dartinstancetype? call(ffi.Pointer<ffi.Void> arg0) {
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    instancetype Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<ffi.Void> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   instancetype Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<ffi.Void> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<ffi.Void>,
                   )
-                >
-              >()
-              .asFunction<
-                instancetype Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<ffi.Void>,
-                )
-              >()(ref.pointer, arg0)
-              .address ==
-          0
-      ? null
-      : objc.ObjCObject(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, arg0)
+                .address ==
+            0
+        ? null
+        : objc.ObjCObject(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    instancetype Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<ffi.Void> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   instancetype Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<ffi.Void> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<ffi.Void>,
                   )
-                >
-              >()
-              .asFunction<
-                instancetype Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<ffi.Void>,
-                )
-              >()(ref.pointer, arg0),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, arg0),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// ObjCProtocolImpl

--- a/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.dart
@@ -146,8 +146,8 @@ external ffi.Pointer<ffi.Void> _getClass(
 );
 
 ffi.Pointer<ffi.Void> getClass(objc.ObjCObject object) {
-  final _$$ = object.ref;
-  return _getClass(_$$.pointer);
+  final _$$ref = object.ref;
+  return _getClass(_$$ref.pointer);
 }
 
 @ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>)>()
@@ -256,24 +256,24 @@ extension type MyProtocol._(objc.ObjCProtocol object$)
 extension MyProtocol$Methods on MyProtocol {
   /// disabledMethod
   int disabledMethod() {
-    final _$$ = object$.ref;
-    if (!objc.respondsToSelector(_$$.pointer, _sel_disabledMethod)) {
+    final _$$ref = object$.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_disabledMethod)) {
       throw objc.UnimplementedOptionalMethodException(
         'MyProtocol',
         'disabledMethod',
       );
     }
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_disabledMethod);
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_disabledMethod);
   }
 
   /// instanceMethod:withDouble:
   objc.NSString instanceMethod(objc.NSString s, {required double withDouble}) {
-    final _$$ = object$.ref;
-    final _$$$1 = s.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = s.ref;
     final $ret = _objc_msgSend_6plvbo(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_instanceMethod_withDouble_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
       withDouble,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -281,38 +281,38 @@ extension MyProtocol$Methods on MyProtocol {
 
   /// intPtrMethod:
   void intPtrMethod(ffi.Pointer<ffi.Int32> ptr) {
-    final _$$ = object$.ref;
-    if (!objc.respondsToSelector(_$$.pointer, _sel_intPtrMethod_)) {
+    final _$$ref = object$.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_intPtrMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'MyProtocol',
         'intPtrMethod:',
       );
     }
-    _objc_msgSend_yhkuco(_$$.pointer, _sel_intPtrMethod_, ptr);
+    _objc_msgSend_yhkuco(_$$ref.pointer, _sel_intPtrMethod_, ptr);
   }
 
   /// optionalMethod:
   int optionalMethod(SomeStruct s) {
-    final _$$ = object$.ref;
-    if (!objc.respondsToSelector(_$$.pointer, _sel_optionalMethod_)) {
+    final _$$ref = object$.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_optionalMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'MyProtocol',
         'optionalMethod:',
       );
     }
-    return _objc_msgSend_lacj97(_$$.pointer, _sel_optionalMethod_, s);
+    return _objc_msgSend_lacj97(_$$ref.pointer, _sel_optionalMethod_, s);
   }
 
   /// voidMethod:
   void voidMethod(int x) {
-    final _$$ = object$.ref;
-    if (!objc.respondsToSelector(_$$.pointer, _sel_voidMethod_)) {
+    final _$$ref = object$.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_voidMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'MyProtocol',
         'voidMethod:',
       );
     }
-    _objc_msgSend_1bqef4y(_$$.pointer, _sel_voidMethod_, x);
+    _objc_msgSend_1bqef4y(_$$ref.pointer, _sel_voidMethod_, x);
   }
 }
 
@@ -568,17 +568,17 @@ interface class MyProtocol$Builder {
           isInstanceMethod: true,
         ),
         (void Function(ffi.Pointer<ffi.Int32>) func) =>
-            ObjCBlock_ffiVoid_ffiVoid_Int32.fromFunction(
+            ObjCBlock_ffiVoid_ffiVoid_Int32$1.fromFunction(
               (ffi.Pointer<ffi.Void> _, ffi.Pointer<ffi.Int32> arg1) =>
                   func(arg1),
             ),
         (void Function(ffi.Pointer<ffi.Int32>) func) =>
-            ObjCBlock_ffiVoid_ffiVoid_Int32.listener(
+            ObjCBlock_ffiVoid_ffiVoid_Int32$1.listener(
               (ffi.Pointer<ffi.Void> _, ffi.Pointer<ffi.Int32> arg1) =>
                   func(arg1),
             ),
         (void Function(ffi.Pointer<ffi.Int32>) func) =>
-            ObjCBlock_ffiVoid_ffiVoid_Int32.blocking(
+            ObjCBlock_ffiVoid_ffiVoid_Int32$1.blocking(
               (ffi.Pointer<ffi.Void> _, ffi.Pointer<ffi.Int32> arg1) =>
                   func(arg1),
             ),
@@ -633,13 +633,13 @@ interface class MyProtocol$Builder {
           isInstanceMethod: true,
         ),
         (void Function(int) func) =>
-            ObjCBlock_ffiVoid_ffiVoid_Int32$1.fromFunction(
+            ObjCBlock_ffiVoid_ffiVoid_Int32.fromFunction(
               (ffi.Pointer<ffi.Void> _, int arg1) => func(arg1),
             ),
-        (void Function(int) func) => ObjCBlock_ffiVoid_ffiVoid_Int32$1.listener(
+        (void Function(int) func) => ObjCBlock_ffiVoid_ffiVoid_Int32.listener(
           (ffi.Pointer<ffi.Void> _, int arg1) => func(arg1),
         ),
-        (void Function(int) func) => ObjCBlock_ffiVoid_ffiVoid_Int32$1.blocking(
+        (void Function(int) func) => ObjCBlock_ffiVoid_ffiVoid_Int32.blocking(
           (ffi.Pointer<ffi.Void> _, int arg1) => func(arg1),
         ),
       );
@@ -1148,12 +1148,12 @@ abstract final class ObjCBlock_NSString_ffiVoid_NSString_ffiDouble {
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
           double arg2,
         ) {
-          final _$$ = fn(
+          final _$$ref = fn(
             arg0,
             objc.NSString.fromPointer(arg1, retain: true, release: true),
             arg2,
           ).ref;
-          return _$$.retainAndAutorelease();
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -1230,7 +1230,7 @@ extension ObjCBlock_NSString_ffiVoid_NSString_ffiDouble$CallExtension
     objc.NSString arg1,
     double arg2,
   ) {
-    final _$$$1 = arg1.ref;
+    final _$$ref$1 = arg1.ref;
     return objc.NSString.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -1250,15 +1250,284 @@ extension ObjCBlock_NSString_ffiVoid_NSString_ffiDouble$CallExtension
               ffi.Pointer<objc.ObjCObjectImpl>,
               double,
             )
-          >()(ref.pointer, arg0, _$$$1.pointer, arg2),
+          >()(ref.pointer, arg0, _$$ref$1.pointer, arg2),
       retain: true,
       release: true,
     );
   }
 }
 
-/// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)>`.
+/// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
 abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32 {
+  /// Returns a block that wraps the given raw block pointer.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  fromPointer(
+    ffi.Pointer<objc.ObjCBlockImpl> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+    pointer,
+    retain: retain,
+    release: release,
+  );
+
+  /// Creates a block from a C function pointer.
+  ///
+  /// This block must be invoked by native code running on the same thread as
+  /// the isolate that registered it. Invoking the block on the wrong thread
+  /// will result in a crash.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  fromFunctionPointer(
+    ffi.Pointer<
+      ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> arg0, ffi.Int32 arg1)
+      >
+    >
+    ptr,
+  ) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+    objc.newPointerBlock(_fnPtrCallable, ptr.cast()),
+    retain: false,
+    release: true,
+  );
+
+  /// Creates a block from a Dart function.
+  ///
+  /// This block must be invoked by native code running on the same thread as
+  /// the isolate that registered it. Invoking the block on the wrong thread
+  /// will result in a crash.
+  ///
+  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
+  /// until it is garbage collected by both Dart and ObjC.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  fromFunction(
+    void Function(ffi.Pointer<ffi.Void>, int) fn, {
+    bool keepIsolateAlive = true,
+  }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive),
+    retain: false,
+    release: true,
+  );
+
+  /// Creates a listener block from a Dart function.
+  ///
+  /// This is based on FFI's NativeCallable.listener, and has the same
+  /// capabilities and limitations. This block can be invoked from any thread,
+  /// but only supports void functions, and is not run synchronously. See
+  /// NativeCallable.listener for more details.
+  ///
+  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
+  /// until it is garbage collected by both Dart and ObjC.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  listener(
+    void Function(ffi.Pointer<ffi.Void>, int) fn, {
+    bool keepIsolateAlive = true,
+  }) {
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
+    final wrapper = _13hhotk_wrapListenerBlock_1pbq496(raw);
+    objc.objectRelease(raw.cast());
+    return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+      wrapper,
+      retain: false,
+      release: true,
+    );
+  }
+
+  /// Creates a blocking block from a Dart function.
+  ///
+  /// This callback can be invoked from any native thread, and will block the
+  /// caller until the callback is handled by the Dart isolate that created
+  /// the block. Async functions are not supported.
+  ///
+  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
+  /// until it is garbage collected by both Dart and ObjC. If the owner isolate
+  /// has shut down, and the block is invoked by native code, it may block
+  /// indefinitely, or have other undefined behavior.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  blocking(
+    void Function(ffi.Pointer<ffi.Void>, int) fn, {
+    bool keepIsolateAlive = true,
+  }) {
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
+    final rawListener = objc.newClosureBlock(
+      _blockingListenerCallable.nativeFunction.cast(),
+      (ffi.Pointer<ffi.Void> arg0, int arg1) {
+        return fn(arg0, arg1);
+      },
+      keepIsolateAlive,
+    );
+    final wrapper = _13hhotk_wrapBlockingBlock_1pbq496(
+      raw,
+      rawListener,
+      objc.objCContext,
+    );
+    objc.objectRelease(raw.cast());
+    objc.objectRelease(rawListener.cast());
+    return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+      wrapper,
+      retain: false,
+      release: true,
+    );
+  }
+
+  static void _listenerTrampoline(
+    ffi.Pointer<objc.ObjCBlockImpl> block,
+    ffi.Pointer<ffi.Void> arg0,
+    int arg1,
+  ) {
+    (objc.getBlockClosure(block) as void Function(ffi.Pointer<ffi.Void>, int))(
+      arg0,
+      arg1,
+    );
+    objc.objectRelease(block.cast());
+  }
+
+  static ffi.NativeCallable<
+    ffi.Void Function(
+      ffi.Pointer<objc.ObjCBlockImpl>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Int32,
+    )
+  >
+  _listenerCallable =
+      ffi.NativeCallable<
+          ffi.Void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Int32,
+          )
+        >.listener(_listenerTrampoline)
+        ..keepIsolateAlive = false;
+  static void _blockingTrampoline(
+    ffi.Pointer<objc.ObjCBlockImpl> block,
+    ffi.Pointer<ffi.Void> waiter,
+    ffi.Pointer<ffi.Void> arg0,
+    int arg1,
+  ) {
+    try {
+      (objc.getBlockClosure(block)
+          as void Function(ffi.Pointer<ffi.Void>, int))(arg0, arg1);
+    } catch (e) {
+    } finally {
+      objc.signalWaiter(waiter);
+      objc.objectRelease(block.cast());
+    }
+  }
+
+  static ffi.NativeCallable<
+    ffi.Void Function(
+      ffi.Pointer<objc.ObjCBlockImpl>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Int32,
+    )
+  >
+  _blockingCallable =
+      ffi.NativeCallable<
+          ffi.Void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Int32,
+          )
+        >.isolateLocal(_blockingTrampoline)
+        ..keepIsolateAlive = false;
+  static ffi.NativeCallable<
+    ffi.Void Function(
+      ffi.Pointer<objc.ObjCBlockImpl>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Int32,
+    )
+  >
+  _blockingListenerCallable =
+      ffi.NativeCallable<
+          ffi.Void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Int32,
+          )
+        >.listener(_blockingTrampoline)
+        ..keepIsolateAlive = false;
+  static void _fnPtrTrampoline(
+    ffi.Pointer<objc.ObjCBlockImpl> block,
+    ffi.Pointer<ffi.Void> arg0,
+    int arg1,
+  ) => block.ref.target
+      .cast<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ffi.Void> arg0, ffi.Int32 arg1)
+        >
+      >()
+      .asFunction<void Function(ffi.Pointer<ffi.Void>, int)>()(arg0, arg1);
+  static ffi.Pointer<ffi.Void> _fnPtrCallable =
+      ffi.Pointer.fromFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Int32,
+            )
+          >(_fnPtrTrampoline)
+          .cast();
+  static void _closureTrampoline(
+    ffi.Pointer<objc.ObjCBlockImpl> block,
+    ffi.Pointer<ffi.Void> arg0,
+    int arg1,
+  ) =>
+      (objc.getBlockClosure(block)
+          as void Function(ffi.Pointer<ffi.Void>, int))(arg0, arg1);
+  static ffi.Pointer<ffi.Void> _closureCallable =
+      ffi.Pointer.fromFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Int32,
+            )
+          >(_closureTrampoline)
+          .cast();
+}
+
+/// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
+extension ObjCBlock_ffiVoid_ffiVoid_Int32$CallExtension
+    on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)> {
+  void call(ffi.Pointer<ffi.Void> arg0, int arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Int32 arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            int,
+          )
+        >()(ref.pointer, arg0, arg1);
+  }
+}
+
+/// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)>`.
+abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32$1 {
   /// Returns a block that wraps the given raw block pointer.
   static objc.ObjCBlock<
     ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)
@@ -1529,7 +1798,7 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32 {
 }
 
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)>`.
-extension ObjCBlock_ffiVoid_ffiVoid_Int32$CallExtension
+extension ObjCBlock_ffiVoid_ffiVoid_Int32$1$CallExtension
     on
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)
@@ -1550,275 +1819,6 @@ extension ObjCBlock_ffiVoid_ffiVoid_Int32$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<ffi.Void>,
             ffi.Pointer<ffi.Int32>,
-          )
-        >()(ref.pointer, arg0, arg1);
-  }
-}
-
-/// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
-abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32$1 {
-  /// Returns a block that wraps the given raw block pointer.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  fromPointer(
-    ffi.Pointer<objc.ObjCBlockImpl> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-    pointer,
-    retain: retain,
-    release: release,
-  );
-
-  /// Creates a block from a C function pointer.
-  ///
-  /// This block must be invoked by native code running on the same thread as
-  /// the isolate that registered it. Invoking the block on the wrong thread
-  /// will result in a crash.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  fromFunctionPointer(
-    ffi.Pointer<
-      ffi.NativeFunction<
-        ffi.Void Function(ffi.Pointer<ffi.Void> arg0, ffi.Int32 arg1)
-      >
-    >
-    ptr,
-  ) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-    objc.newPointerBlock(_fnPtrCallable, ptr.cast()),
-    retain: false,
-    release: true,
-  );
-
-  /// Creates a block from a Dart function.
-  ///
-  /// This block must be invoked by native code running on the same thread as
-  /// the isolate that registered it. Invoking the block on the wrong thread
-  /// will result in a crash.
-  ///
-  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
-  /// until it is garbage collected by both Dart and ObjC.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  fromFunction(
-    void Function(ffi.Pointer<ffi.Void>, int) fn, {
-    bool keepIsolateAlive = true,
-  }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-    objc.newClosureBlock(_closureCallable, (
-      ffi.Pointer<ffi.Void> arg0,
-      int arg1,
-    ) {
-      return fn(arg0, arg1);
-    }, keepIsolateAlive),
-    retain: false,
-    release: true,
-  );
-
-  /// Creates a listener block from a Dart function.
-  ///
-  /// This is based on FFI's NativeCallable.listener, and has the same
-  /// capabilities and limitations. This block can be invoked from any thread,
-  /// but only supports void functions, and is not run synchronously. See
-  /// NativeCallable.listener for more details.
-  ///
-  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
-  /// until it is garbage collected by both Dart and ObjC.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  listener(
-    void Function(ffi.Pointer<ffi.Void>, int) fn, {
-    bool keepIsolateAlive = true,
-  }) {
-    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
-      ffi.Pointer<ffi.Void> arg0,
-      int arg1,
-    ) {
-      return fn(arg0, arg1);
-    }, keepIsolateAlive);
-    final wrapper = _13hhotk_wrapListenerBlock_1pbq496(raw);
-    objc.objectRelease(raw.cast());
-    return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-      wrapper,
-      retain: false,
-      release: true,
-    );
-  }
-
-  /// Creates a blocking block from a Dart function.
-  ///
-  /// This callback can be invoked from any native thread, and will block the
-  /// caller until the callback is handled by the Dart isolate that created
-  /// the block. Async functions are not supported.
-  ///
-  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
-  /// until it is garbage collected by both Dart and ObjC. If the owner isolate
-  /// has shut down, and the block is invoked by native code, it may block
-  /// indefinitely, or have other undefined behavior.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  blocking(
-    void Function(ffi.Pointer<ffi.Void>, int) fn, {
-    bool keepIsolateAlive = true,
-  }) {
-    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
-      ffi.Pointer<ffi.Void> arg0,
-      int arg1,
-    ) {
-      return fn(arg0, arg1);
-    }, keepIsolateAlive);
-    final rawListener = objc.newClosureBlock(
-      _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, int arg1) {
-        return fn(arg0, arg1);
-      },
-      keepIsolateAlive,
-    );
-    final wrapper = _13hhotk_wrapBlockingBlock_1pbq496(
-      raw,
-      rawListener,
-      objc.objCContext,
-    );
-    objc.objectRelease(raw.cast());
-    objc.objectRelease(rawListener.cast());
-    return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-      wrapper,
-      retain: false,
-      release: true,
-    );
-  }
-
-  static void _listenerTrampoline(
-    ffi.Pointer<objc.ObjCBlockImpl> block,
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-  ) {
-    (objc.getBlockClosure(block) as void Function(ffi.Pointer<ffi.Void>, int))(
-      arg0,
-      arg1,
-    );
-    objc.objectRelease(block.cast());
-  }
-
-  static ffi.NativeCallable<
-    ffi.Void Function(
-      ffi.Pointer<objc.ObjCBlockImpl>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Int32,
-    )
-  >
-  _listenerCallable =
-      ffi.NativeCallable<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Int32,
-          )
-        >.listener(_listenerTrampoline)
-        ..keepIsolateAlive = false;
-  static void _blockingTrampoline(
-    ffi.Pointer<objc.ObjCBlockImpl> block,
-    ffi.Pointer<ffi.Void> waiter,
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-  ) {
-    try {
-      (objc.getBlockClosure(block)
-          as void Function(ffi.Pointer<ffi.Void>, int))(arg0, arg1);
-    } catch (e) {
-    } finally {
-      objc.signalWaiter(waiter);
-      objc.objectRelease(block.cast());
-    }
-  }
-
-  static ffi.NativeCallable<
-    ffi.Void Function(
-      ffi.Pointer<objc.ObjCBlockImpl>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Int32,
-    )
-  >
-  _blockingCallable =
-      ffi.NativeCallable<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Int32,
-          )
-        >.isolateLocal(_blockingTrampoline)
-        ..keepIsolateAlive = false;
-  static ffi.NativeCallable<
-    ffi.Void Function(
-      ffi.Pointer<objc.ObjCBlockImpl>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Int32,
-    )
-  >
-  _blockingListenerCallable =
-      ffi.NativeCallable<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Int32,
-          )
-        >.listener(_blockingTrampoline)
-        ..keepIsolateAlive = false;
-  static void _fnPtrTrampoline(
-    ffi.Pointer<objc.ObjCBlockImpl> block,
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-  ) => block.ref.target
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ffi.Void> arg0, ffi.Int32 arg1)
-        >
-      >()
-      .asFunction<void Function(ffi.Pointer<ffi.Void>, int)>()(arg0, arg1);
-  static ffi.Pointer<ffi.Void> _fnPtrCallable =
-      ffi.Pointer.fromFunction<
-            ffi.Void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<ffi.Void>,
-              ffi.Int32,
-            )
-          >(_fnPtrTrampoline)
-          .cast();
-  static void _closureTrampoline(
-    ffi.Pointer<objc.ObjCBlockImpl> block,
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-  ) =>
-      (objc.getBlockClosure(block)
-          as void Function(ffi.Pointer<ffi.Void>, int))(arg0, arg1);
-  static ffi.Pointer<ffi.Void> _closureCallable =
-      ffi.Pointer.fromFunction<
-            ffi.Void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<ffi.Void>,
-              ffi.Int32,
-            )
-          >(_closureTrampoline)
-          .cast();
-}
-
-/// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
-extension ObjCBlock_ffiVoid_ffiVoid_Int32$1$CallExtension
-    on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)> {
-  void call(ffi.Pointer<ffi.Void> arg0, int arg1) {
-    return ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
-            ffi.Void Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
-              ffi.Int32 arg1,
-            )
-          >
-        >()
-        .asFunction<
-          void Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            int,
           )
         >()(ref.pointer, arg0, arg1);
   }
@@ -1882,8 +1882,8 @@ abstract final class ObjCBlock_idMyProtocol_ffiVoid {
         ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$$ = fn(arg0).ref;
-          return _$$.retainAndAutorelease();
+          final _$$ref = fn(arg0).ref;
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2012,8 +2012,8 @@ abstract final class ObjCBlock_instancetype_ffiVoid {
         ffi.Pointer<objc.ObjCObjectImpl>? Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$$ = fn(arg0)?.ref;
-          return _$$?.retainAndAutorelease() ?? ffi.nullptr;
+          final _$$ref = fn(arg0)?.ref;
+          return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2200,42 +2200,45 @@ extension type ObjCProtocolImpl._(objc.ObjCObject object$)
 extension ObjCProtocolImpl$Methods on ObjCProtocolImpl {
   /// disabledMethod
   int disabledMethod() {
-    final _$$$1 = object$.ref;
-    if (!objc.respondsToSelector(_$$$1.pointer, _sel_disabledMethod)) {
+    final _$$ref$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$1.pointer, _sel_disabledMethod)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'disabledMethod',
       );
     }
-    return _objc_msgSend_1gcq84o(_$$$1.pointer, _sel_disabledMethod);
+    return _objc_msgSend_1gcq84o(_$$ref$1.pointer, _sel_disabledMethod);
   }
 
   /// fooMethod
   int fooMethod() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_fooMethod);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_fooMethod);
   }
 
   /// init
   ObjCProtocolImpl init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'ObjCProtocolImpl.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return ObjCProtocolImpl.fromPointer($ret, retain: false, release: true);
   }
 
   /// instanceMethod:withDouble:
   objc.NSString instanceMethod(objc.NSString s, {required double withDouble}) {
-    final _$$$2 = object$.ref;
-    final _$$$3 = s.ref;
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = s.ref;
     final $ret = _objc_msgSend_6plvbo(
-      _$$$2.pointer,
+      _$$ref$2.pointer,
       _sel_instanceMethod_withDouble_,
-      _$$$3.pointer,
+      _$$ref$3.pointer,
       withDouble,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -2243,33 +2246,33 @@ extension ObjCProtocolImpl$Methods on ObjCProtocolImpl {
 
   /// intPtrMethod:
   void intPtrMethod(ffi.Pointer<ffi.Int32> ptr) {
-    final _$$$1 = object$.ref;
-    if (!objc.respondsToSelector(_$$$1.pointer, _sel_intPtrMethod_)) {
+    final _$$ref$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$1.pointer, _sel_intPtrMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'intPtrMethod:',
       );
     }
-    _objc_msgSend_yhkuco(_$$$1.pointer, _sel_intPtrMethod_, ptr);
+    _objc_msgSend_yhkuco(_$$ref$1.pointer, _sel_intPtrMethod_, ptr);
   }
 
   /// optionalMethod:
   int optionalMethod(SomeStruct s) {
-    final _$$$1 = object$.ref;
-    if (!objc.respondsToSelector(_$$$1.pointer, _sel_optionalMethod_)) {
+    final _$$ref$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$1.pointer, _sel_optionalMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'optionalMethod:',
       );
     }
-    return _objc_msgSend_lacj97(_$$$1.pointer, _sel_optionalMethod_, s);
+    return _objc_msgSend_lacj97(_$$ref$1.pointer, _sel_optionalMethod_, s);
   }
 
   /// otherMethod:b:c:d:
   int otherMethod(int a, {required int b, required int c, required int d}) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     return _objc_msgSend_hv8ra8(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_otherMethod_b_c_d_,
       a,
       b,
@@ -2280,14 +2283,17 @@ extension ObjCProtocolImpl$Methods on ObjCProtocolImpl {
 
   /// returnsInstanceType
   ObjCProtocolImpl? returnsInstanceType() {
-    final _$$ = object$.ref;
-    if (!objc.respondsToSelector(_$$.pointer, _sel_returnsInstanceType)) {
+    final _$$ref = object$.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_returnsInstanceType)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'returnsInstanceType',
       );
     }
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_returnsInstanceType);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.pointer,
+      _sel_returnsInstanceType,
+    );
     return $ret.address == 0
         ? null
         : ObjCProtocolImpl.fromPointer($ret, retain: true, release: true);
@@ -2295,27 +2301,27 @@ extension ObjCProtocolImpl$Methods on ObjCProtocolImpl {
 
   /// returnsMyProtocol
   MyProtocol returnsMyProtocol() {
-    final _$$ = object$.ref;
-    if (!objc.respondsToSelector(_$$.pointer, _sel_returnsMyProtocol)) {
+    final _$$ref = object$.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_returnsMyProtocol)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'returnsMyProtocol',
       );
     }
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_returnsMyProtocol);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_returnsMyProtocol);
     return MyProtocol.fromPointer($ret, retain: true, release: true);
   }
 
   /// voidMethod:
   void voidMethod(int x) {
-    final _$$$1 = object$.ref;
-    if (!objc.respondsToSelector(_$$$1.pointer, _sel_voidMethod_)) {
+    final _$$ref$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$1.pointer, _sel_voidMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'voidMethod:',
       );
     }
-    _objc_msgSend_1bqef4y(_$$$1.pointer, _sel_voidMethod_, x);
+    _objc_msgSend_1bqef4y(_$$ref$1.pointer, _sel_voidMethod_, x);
   }
 }
 
@@ -2437,26 +2443,26 @@ extension ObjCProtocolImplMissingMethod$Methods
     on ObjCProtocolImplMissingMethod {
   /// disabledMethod
   int disabledMethod() {
-    final _$$$2 = object$.ref;
-    if (!objc.respondsToSelector(_$$$2.pointer, _sel_disabledMethod)) {
+    final _$$ref$2 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$2.pointer, _sel_disabledMethod)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImplMissingMethod',
         'disabledMethod',
       );
     }
-    return _objc_msgSend_1gcq84o(_$$$2.pointer, _sel_disabledMethod);
+    return _objc_msgSend_1gcq84o(_$$ref$2.pointer, _sel_disabledMethod);
   }
 
   /// init
   ObjCProtocolImplMissingMethod init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'ObjCProtocolImplMissingMethod.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return ObjCProtocolImplMissingMethod.fromPointer(
@@ -2468,12 +2474,12 @@ extension ObjCProtocolImplMissingMethod$Methods
 
   /// instanceMethod:withDouble:
   objc.NSString instanceMethod(objc.NSString s, {required double withDouble}) {
-    final _$$$4 = object$.ref;
-    final _$$$5 = s.ref;
+    final _$$ref$4 = object$.ref;
+    final _$$ref$5 = s.ref;
     final $ret = _objc_msgSend_6plvbo(
-      _$$$4.pointer,
+      _$$ref$4.pointer,
       _sel_instanceMethod_withDouble_,
-      _$$$5.pointer,
+      _$$ref$5.pointer,
       withDouble,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -2481,38 +2487,38 @@ extension ObjCProtocolImplMissingMethod$Methods
 
   /// intPtrMethod:
   void intPtrMethod(ffi.Pointer<ffi.Int32> ptr) {
-    final _$$$2 = object$.ref;
-    if (!objc.respondsToSelector(_$$$2.pointer, _sel_intPtrMethod_)) {
+    final _$$ref$2 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$2.pointer, _sel_intPtrMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImplMissingMethod',
         'intPtrMethod:',
       );
     }
-    _objc_msgSend_yhkuco(_$$$2.pointer, _sel_intPtrMethod_, ptr);
+    _objc_msgSend_yhkuco(_$$ref$2.pointer, _sel_intPtrMethod_, ptr);
   }
 
   /// optionalMethod:
   int optionalMethod(SomeStruct s) {
-    final _$$$2 = object$.ref;
-    if (!objc.respondsToSelector(_$$$2.pointer, _sel_optionalMethod_)) {
+    final _$$ref$2 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$2.pointer, _sel_optionalMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImplMissingMethod',
         'optionalMethod:',
       );
     }
-    return _objc_msgSend_lacj97(_$$$2.pointer, _sel_optionalMethod_, s);
+    return _objc_msgSend_lacj97(_$$ref$2.pointer, _sel_optionalMethod_, s);
   }
 
   /// voidMethod:
   void voidMethod(int x) {
-    final _$$$2 = object$.ref;
-    if (!objc.respondsToSelector(_$$$2.pointer, _sel_voidMethod_)) {
+    final _$$ref$2 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$2.pointer, _sel_voidMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImplMissingMethod',
         'voidMethod:',
       );
     }
-    _objc_msgSend_1bqef4y(_$$$2.pointer, _sel_voidMethod_, x);
+    _objc_msgSend_1bqef4y(_$$ref$2.pointer, _sel_voidMethod_, x);
   }
 }
 
@@ -2571,81 +2577,81 @@ extension type ProtocolConsumer._(objc.ObjCObject object$)
 extension ProtocolConsumer$Methods on ProtocolConsumer {
   /// callBlockingMethodOnRandomThread:
   void callBlockingMethodOnRandomThread(MyProtocol protocol) {
-    final _$$ = object$.ref;
-    final _$$$1 = protocol.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = protocol.ref;
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_callBlockingMethodOnRandomThread_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// callInstanceMethod:
   objc.NSString callInstanceMethod(SuperProtocol protocol) {
-    final _$$ = object$.ref;
-    final _$$$1 = protocol.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = protocol.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_callInstanceMethod_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// callMethodOnRandomThread:
   void callMethodOnRandomThread(MyProtocol protocol) {
-    final _$$ = object$.ref;
-    final _$$$1 = protocol.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = protocol.ref;
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_callMethodOnRandomThread_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// callOptionalMethod:
   int callOptionalMethod(MyProtocol protocol) {
-    final _$$ = object$.ref;
-    final _$$$1 = protocol.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = protocol.ref;
     return _objc_msgSend_fd28sq(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_callOptionalMethod_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// callOtherMethod:
   int callOtherMethod(SecondaryProtocol protocol) {
-    final _$$ = object$.ref;
-    final _$$$1 = protocol.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = protocol.ref;
     return _objc_msgSend_fd28sq(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_callOtherMethod_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// callTwoMethods:
   int callTwoMethods(MyProtocol protocol) {
-    final _$$ = object$.ref;
-    final _$$$1 = protocol.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = protocol.ref;
     return _objc_msgSend_fd28sq(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_callTwoMethods_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// init
   ProtocolConsumer init() {
-    final _$$$2 = object$.ref;
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'ProtocolConsumer.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return ProtocolConsumer.fromPointer($ret, retain: false, release: true);
@@ -2678,9 +2684,9 @@ extension type SecondaryProtocol._(objc.ObjCProtocol object$)
 extension SecondaryProtocol$Methods on SecondaryProtocol {
   /// otherMethod:b:c:d:
   int otherMethod(int a, {required int b, required int c, required int d}) {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     return _objc_msgSend_hv8ra8(
-      _$$$1.pointer,
+      _$$ref$1.pointer,
       _sel_otherMethod_b_c_d_,
       a,
       b,
@@ -2691,14 +2697,17 @@ extension SecondaryProtocol$Methods on SecondaryProtocol {
 
   /// returnsInstanceType
   SecondaryProtocol? returnsInstanceType() {
-    final _$$$1 = object$.ref;
-    if (!objc.respondsToSelector(_$$$1.pointer, _sel_returnsInstanceType)) {
+    final _$$ref$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$1.pointer, _sel_returnsInstanceType)) {
       throw objc.UnimplementedOptionalMethodException(
         'SecondaryProtocol',
         'returnsInstanceType',
       );
     }
-    final $ret = _objc_msgSend_151sglz(_$$$1.pointer, _sel_returnsInstanceType);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref$1.pointer,
+      _sel_returnsInstanceType,
+    );
     return $ret.address == 0
         ? null
         : SecondaryProtocol.fromPointer($ret, retain: true, release: true);
@@ -2706,14 +2715,17 @@ extension SecondaryProtocol$Methods on SecondaryProtocol {
 
   /// returnsMyProtocol
   MyProtocol returnsMyProtocol() {
-    final _$$$1 = object$.ref;
-    if (!objc.respondsToSelector(_$$$1.pointer, _sel_returnsMyProtocol)) {
+    final _$$ref$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$ref$1.pointer, _sel_returnsMyProtocol)) {
       throw objc.UnimplementedOptionalMethodException(
         'SecondaryProtocol',
         'returnsMyProtocol',
       );
     }
-    final $ret = _objc_msgSend_151sglz(_$$$1.pointer, _sel_returnsMyProtocol);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref$1.pointer,
+      _sel_returnsMyProtocol,
+    );
     return MyProtocol.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -2927,8 +2939,8 @@ extension type UnusedProtocol._(objc.ObjCProtocol object$)
 extension UnusedProtocol$Methods on UnusedProtocol {
   /// someMethod
   int someMethod() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_someMethod);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_someMethod);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.dart
@@ -146,7 +146,8 @@ external ffi.Pointer<ffi.Void> _getClass(
 );
 
 ffi.Pointer<ffi.Void> getClass(objc.ObjCObject object) {
-  return _getClass(object.ref.pointer);
+  final _$$ = object.ref;
+  return _getClass(_$$.pointer);
 }
 
 @ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>)>()
@@ -255,21 +256,24 @@ extension type MyProtocol._(objc.ObjCProtocol object$)
 extension MyProtocol$Methods on MyProtocol {
   /// disabledMethod
   int disabledMethod() {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_disabledMethod)) {
+    final _$$ = object$.ref;
+    if (!objc.respondsToSelector(_$$.pointer, _sel_disabledMethod)) {
       throw objc.UnimplementedOptionalMethodException(
         'MyProtocol',
         'disabledMethod',
       );
     }
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_disabledMethod);
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_disabledMethod);
   }
 
   /// instanceMethod:withDouble:
   objc.NSString instanceMethod(objc.NSString s, {required double withDouble}) {
+    final _$$ = object$.ref;
+    final _$$$1 = s.ref;
     final $ret = _objc_msgSend_6plvbo(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_instanceMethod_withDouble_,
-      s.ref.pointer,
+      _$$$1.pointer,
       withDouble,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -277,35 +281,38 @@ extension MyProtocol$Methods on MyProtocol {
 
   /// intPtrMethod:
   void intPtrMethod(ffi.Pointer<ffi.Int32> ptr) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_intPtrMethod_)) {
+    final _$$ = object$.ref;
+    if (!objc.respondsToSelector(_$$.pointer, _sel_intPtrMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'MyProtocol',
         'intPtrMethod:',
       );
     }
-    _objc_msgSend_yhkuco(object$.ref.pointer, _sel_intPtrMethod_, ptr);
+    _objc_msgSend_yhkuco(_$$.pointer, _sel_intPtrMethod_, ptr);
   }
 
   /// optionalMethod:
   int optionalMethod(SomeStruct s) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_optionalMethod_)) {
+    final _$$ = object$.ref;
+    if (!objc.respondsToSelector(_$$.pointer, _sel_optionalMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'MyProtocol',
         'optionalMethod:',
       );
     }
-    return _objc_msgSend_lacj97(object$.ref.pointer, _sel_optionalMethod_, s);
+    return _objc_msgSend_lacj97(_$$.pointer, _sel_optionalMethod_, s);
   }
 
   /// voidMethod:
   void voidMethod(int x) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_voidMethod_)) {
+    final _$$ = object$.ref;
+    if (!objc.respondsToSelector(_$$.pointer, _sel_voidMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'MyProtocol',
         'voidMethod:',
       );
     }
-    _objc_msgSend_1bqef4y(object$.ref.pointer, _sel_voidMethod_, x);
+    _objc_msgSend_1bqef4y(_$$.pointer, _sel_voidMethod_, x);
   }
 }
 
@@ -561,17 +568,17 @@ interface class MyProtocol$Builder {
           isInstanceMethod: true,
         ),
         (void Function(ffi.Pointer<ffi.Int32>) func) =>
-            ObjCBlock_ffiVoid_ffiVoid_Int32$1.fromFunction(
+            ObjCBlock_ffiVoid_ffiVoid_Int32.fromFunction(
               (ffi.Pointer<ffi.Void> _, ffi.Pointer<ffi.Int32> arg1) =>
                   func(arg1),
             ),
         (void Function(ffi.Pointer<ffi.Int32>) func) =>
-            ObjCBlock_ffiVoid_ffiVoid_Int32$1.listener(
+            ObjCBlock_ffiVoid_ffiVoid_Int32.listener(
               (ffi.Pointer<ffi.Void> _, ffi.Pointer<ffi.Int32> arg1) =>
                   func(arg1),
             ),
         (void Function(ffi.Pointer<ffi.Int32>) func) =>
-            ObjCBlock_ffiVoid_ffiVoid_Int32$1.blocking(
+            ObjCBlock_ffiVoid_ffiVoid_Int32.blocking(
               (ffi.Pointer<ffi.Void> _, ffi.Pointer<ffi.Int32> arg1) =>
                   func(arg1),
             ),
@@ -626,13 +633,13 @@ interface class MyProtocol$Builder {
           isInstanceMethod: true,
         ),
         (void Function(int) func) =>
-            ObjCBlock_ffiVoid_ffiVoid_Int32.fromFunction(
+            ObjCBlock_ffiVoid_ffiVoid_Int32$1.fromFunction(
               (ffi.Pointer<ffi.Void> _, int arg1) => func(arg1),
             ),
-        (void Function(int) func) => ObjCBlock_ffiVoid_ffiVoid_Int32.listener(
+        (void Function(int) func) => ObjCBlock_ffiVoid_ffiVoid_Int32$1.listener(
           (ffi.Pointer<ffi.Void> _, int arg1) => func(arg1),
         ),
-        (void Function(int) func) => ObjCBlock_ffiVoid_ffiVoid_Int32.blocking(
+        (void Function(int) func) => ObjCBlock_ffiVoid_ffiVoid_Int32$1.blocking(
           (ffi.Pointer<ffi.Void> _, int arg1) => func(arg1),
         ),
       );
@@ -1141,12 +1148,12 @@ abstract final class ObjCBlock_NSString_ffiVoid_NSString_ffiDouble {
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
           double arg2,
         ) {
-          final _$obj = fn(
+          final _$$ = fn(
             arg0,
             objc.NSString.fromPointer(arg1, retain: true, release: true),
             arg2,
-          );
-          return _$obj.ref.retainAndAutorelease();
+          ).ref;
+          return _$$.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -1223,6 +1230,7 @@ extension ObjCBlock_NSString_ffiVoid_NSString_ffiDouble$CallExtension
     objc.NSString arg1,
     double arg2,
   ) {
+    final _$$$1 = arg1.ref;
     return objc.NSString.fromPointer(
       ref.pointer.ref.invoke
           .cast<
@@ -1242,284 +1250,15 @@ extension ObjCBlock_NSString_ffiVoid_NSString_ffiDouble$CallExtension
               ffi.Pointer<objc.ObjCObjectImpl>,
               double,
             )
-          >()(ref.pointer, arg0, arg1.ref.pointer, arg2),
+          >()(ref.pointer, arg0, _$$$1.pointer, arg2),
       retain: true,
       release: true,
     );
   }
 }
 
-/// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
-abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32 {
-  /// Returns a block that wraps the given raw block pointer.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  fromPointer(
-    ffi.Pointer<objc.ObjCBlockImpl> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-    pointer,
-    retain: retain,
-    release: release,
-  );
-
-  /// Creates a block from a C function pointer.
-  ///
-  /// This block must be invoked by native code running on the same thread as
-  /// the isolate that registered it. Invoking the block on the wrong thread
-  /// will result in a crash.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  fromFunctionPointer(
-    ffi.Pointer<
-      ffi.NativeFunction<
-        ffi.Void Function(ffi.Pointer<ffi.Void> arg0, ffi.Int32 arg1)
-      >
-    >
-    ptr,
-  ) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-    objc.newPointerBlock(_fnPtrCallable, ptr.cast()),
-    retain: false,
-    release: true,
-  );
-
-  /// Creates a block from a Dart function.
-  ///
-  /// This block must be invoked by native code running on the same thread as
-  /// the isolate that registered it. Invoking the block on the wrong thread
-  /// will result in a crash.
-  ///
-  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
-  /// until it is garbage collected by both Dart and ObjC.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  fromFunction(
-    void Function(ffi.Pointer<ffi.Void>, int) fn, {
-    bool keepIsolateAlive = true,
-  }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-    objc.newClosureBlock(_closureCallable, (
-      ffi.Pointer<ffi.Void> arg0,
-      int arg1,
-    ) {
-      return fn(arg0, arg1);
-    }, keepIsolateAlive),
-    retain: false,
-    release: true,
-  );
-
-  /// Creates a listener block from a Dart function.
-  ///
-  /// This is based on FFI's NativeCallable.listener, and has the same
-  /// capabilities and limitations. This block can be invoked from any thread,
-  /// but only supports void functions, and is not run synchronously. See
-  /// NativeCallable.listener for more details.
-  ///
-  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
-  /// until it is garbage collected by both Dart and ObjC.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  listener(
-    void Function(ffi.Pointer<ffi.Void>, int) fn, {
-    bool keepIsolateAlive = true,
-  }) {
-    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
-      ffi.Pointer<ffi.Void> arg0,
-      int arg1,
-    ) {
-      return fn(arg0, arg1);
-    }, keepIsolateAlive);
-    final wrapper = _13hhotk_wrapListenerBlock_1pbq496(raw);
-    objc.objectRelease(raw.cast());
-    return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-      wrapper,
-      retain: false,
-      release: true,
-    );
-  }
-
-  /// Creates a blocking block from a Dart function.
-  ///
-  /// This callback can be invoked from any native thread, and will block the
-  /// caller until the callback is handled by the Dart isolate that created
-  /// the block. Async functions are not supported.
-  ///
-  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
-  /// until it is garbage collected by both Dart and ObjC. If the owner isolate
-  /// has shut down, and the block is invoked by native code, it may block
-  /// indefinitely, or have other undefined behavior.
-  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
-  blocking(
-    void Function(ffi.Pointer<ffi.Void>, int) fn, {
-    bool keepIsolateAlive = true,
-  }) {
-    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
-      ffi.Pointer<ffi.Void> arg0,
-      int arg1,
-    ) {
-      return fn(arg0, arg1);
-    }, keepIsolateAlive);
-    final rawListener = objc.newClosureBlock(
-      _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, int arg1) {
-        return fn(arg0, arg1);
-      },
-      keepIsolateAlive,
-    );
-    final wrapper = _13hhotk_wrapBlockingBlock_1pbq496(
-      raw,
-      rawListener,
-      objc.objCContext,
-    );
-    objc.objectRelease(raw.cast());
-    objc.objectRelease(rawListener.cast());
-    return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
-      wrapper,
-      retain: false,
-      release: true,
-    );
-  }
-
-  static void _listenerTrampoline(
-    ffi.Pointer<objc.ObjCBlockImpl> block,
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-  ) {
-    (objc.getBlockClosure(block) as void Function(ffi.Pointer<ffi.Void>, int))(
-      arg0,
-      arg1,
-    );
-    objc.objectRelease(block.cast());
-  }
-
-  static ffi.NativeCallable<
-    ffi.Void Function(
-      ffi.Pointer<objc.ObjCBlockImpl>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Int32,
-    )
-  >
-  _listenerCallable =
-      ffi.NativeCallable<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Int32,
-          )
-        >.listener(_listenerTrampoline)
-        ..keepIsolateAlive = false;
-  static void _blockingTrampoline(
-    ffi.Pointer<objc.ObjCBlockImpl> block,
-    ffi.Pointer<ffi.Void> waiter,
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-  ) {
-    try {
-      (objc.getBlockClosure(block)
-          as void Function(ffi.Pointer<ffi.Void>, int))(arg0, arg1);
-    } catch (e) {
-    } finally {
-      objc.signalWaiter(waiter);
-      objc.objectRelease(block.cast());
-    }
-  }
-
-  static ffi.NativeCallable<
-    ffi.Void Function(
-      ffi.Pointer<objc.ObjCBlockImpl>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Int32,
-    )
-  >
-  _blockingCallable =
-      ffi.NativeCallable<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Int32,
-          )
-        >.isolateLocal(_blockingTrampoline)
-        ..keepIsolateAlive = false;
-  static ffi.NativeCallable<
-    ffi.Void Function(
-      ffi.Pointer<objc.ObjCBlockImpl>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Pointer<ffi.Void>,
-      ffi.Int32,
-    )
-  >
-  _blockingListenerCallable =
-      ffi.NativeCallable<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Int32,
-          )
-        >.listener(_blockingTrampoline)
-        ..keepIsolateAlive = false;
-  static void _fnPtrTrampoline(
-    ffi.Pointer<objc.ObjCBlockImpl> block,
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-  ) => block.ref.target
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<ffi.Void> arg0, ffi.Int32 arg1)
-        >
-      >()
-      .asFunction<void Function(ffi.Pointer<ffi.Void>, int)>()(arg0, arg1);
-  static ffi.Pointer<ffi.Void> _fnPtrCallable =
-      ffi.Pointer.fromFunction<
-            ffi.Void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<ffi.Void>,
-              ffi.Int32,
-            )
-          >(_fnPtrTrampoline)
-          .cast();
-  static void _closureTrampoline(
-    ffi.Pointer<objc.ObjCBlockImpl> block,
-    ffi.Pointer<ffi.Void> arg0,
-    int arg1,
-  ) =>
-      (objc.getBlockClosure(block)
-          as void Function(ffi.Pointer<ffi.Void>, int))(arg0, arg1);
-  static ffi.Pointer<ffi.Void> _closureCallable =
-      ffi.Pointer.fromFunction<
-            ffi.Void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<ffi.Void>,
-              ffi.Int32,
-            )
-          >(_closureTrampoline)
-          .cast();
-}
-
-/// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
-extension ObjCBlock_ffiVoid_ffiVoid_Int32$CallExtension
-    on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)> {
-  void call(ffi.Pointer<ffi.Void> arg0, int arg1) {
-    return ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
-            ffi.Void Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
-              ffi.Int32 arg1,
-            )
-          >
-        >()
-        .asFunction<
-          void Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            int,
-          )
-        >()(ref.pointer, arg0, arg1);
-  }
-}
-
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)>`.
-abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32$1 {
+abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32 {
   /// Returns a block that wraps the given raw block pointer.
   static objc.ObjCBlock<
     ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)
@@ -1790,7 +1529,7 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32$1 {
 }
 
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)>`.
-extension ObjCBlock_ffiVoid_ffiVoid_Int32$1$CallExtension
+extension ObjCBlock_ffiVoid_ffiVoid_Int32$CallExtension
     on
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int32>)
@@ -1811,6 +1550,275 @@ extension ObjCBlock_ffiVoid_ffiVoid_Int32$1$CallExtension
             ffi.Pointer<objc.ObjCBlockImpl>,
             ffi.Pointer<ffi.Void>,
             ffi.Pointer<ffi.Int32>,
+          )
+        >()(ref.pointer, arg0, arg1);
+  }
+}
+
+/// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
+abstract final class ObjCBlock_ffiVoid_ffiVoid_Int32$1 {
+  /// Returns a block that wraps the given raw block pointer.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  fromPointer(
+    ffi.Pointer<objc.ObjCBlockImpl> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+    pointer,
+    retain: retain,
+    release: release,
+  );
+
+  /// Creates a block from a C function pointer.
+  ///
+  /// This block must be invoked by native code running on the same thread as
+  /// the isolate that registered it. Invoking the block on the wrong thread
+  /// will result in a crash.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  fromFunctionPointer(
+    ffi.Pointer<
+      ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> arg0, ffi.Int32 arg1)
+      >
+    >
+    ptr,
+  ) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+    objc.newPointerBlock(_fnPtrCallable, ptr.cast()),
+    retain: false,
+    release: true,
+  );
+
+  /// Creates a block from a Dart function.
+  ///
+  /// This block must be invoked by native code running on the same thread as
+  /// the isolate that registered it. Invoking the block on the wrong thread
+  /// will result in a crash.
+  ///
+  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
+  /// until it is garbage collected by both Dart and ObjC.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  fromFunction(
+    void Function(ffi.Pointer<ffi.Void>, int) fn, {
+    bool keepIsolateAlive = true,
+  }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive),
+    retain: false,
+    release: true,
+  );
+
+  /// Creates a listener block from a Dart function.
+  ///
+  /// This is based on FFI's NativeCallable.listener, and has the same
+  /// capabilities and limitations. This block can be invoked from any thread,
+  /// but only supports void functions, and is not run synchronously. See
+  /// NativeCallable.listener for more details.
+  ///
+  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
+  /// until it is garbage collected by both Dart and ObjC.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  listener(
+    void Function(ffi.Pointer<ffi.Void>, int) fn, {
+    bool keepIsolateAlive = true,
+  }) {
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
+    final wrapper = _13hhotk_wrapListenerBlock_1pbq496(raw);
+    objc.objectRelease(raw.cast());
+    return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+      wrapper,
+      retain: false,
+      release: true,
+    );
+  }
+
+  /// Creates a blocking block from a Dart function.
+  ///
+  /// This callback can be invoked from any native thread, and will block the
+  /// caller until the callback is handled by the Dart isolate that created
+  /// the block. Async functions are not supported.
+  ///
+  /// If `keepIsolateAlive` is true, this block will keep this isolate alive
+  /// until it is garbage collected by both Dart and ObjC. If the owner isolate
+  /// has shut down, and the block is invoked by native code, it may block
+  /// indefinitely, or have other undefined behavior.
+  static objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>
+  blocking(
+    void Function(ffi.Pointer<ffi.Void>, int) fn, {
+    bool keepIsolateAlive = true,
+  }) {
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
+    final rawListener = objc.newClosureBlock(
+      _blockingListenerCallable.nativeFunction.cast(),
+      (ffi.Pointer<ffi.Void> arg0, int arg1) {
+        return fn(arg0, arg1);
+      },
+      keepIsolateAlive,
+    );
+    final wrapper = _13hhotk_wrapBlockingBlock_1pbq496(
+      raw,
+      rawListener,
+      objc.objCContext,
+    );
+    objc.objectRelease(raw.cast());
+    objc.objectRelease(rawListener.cast());
+    return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>(
+      wrapper,
+      retain: false,
+      release: true,
+    );
+  }
+
+  static void _listenerTrampoline(
+    ffi.Pointer<objc.ObjCBlockImpl> block,
+    ffi.Pointer<ffi.Void> arg0,
+    int arg1,
+  ) {
+    (objc.getBlockClosure(block) as void Function(ffi.Pointer<ffi.Void>, int))(
+      arg0,
+      arg1,
+    );
+    objc.objectRelease(block.cast());
+  }
+
+  static ffi.NativeCallable<
+    ffi.Void Function(
+      ffi.Pointer<objc.ObjCBlockImpl>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Int32,
+    )
+  >
+  _listenerCallable =
+      ffi.NativeCallable<
+          ffi.Void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Int32,
+          )
+        >.listener(_listenerTrampoline)
+        ..keepIsolateAlive = false;
+  static void _blockingTrampoline(
+    ffi.Pointer<objc.ObjCBlockImpl> block,
+    ffi.Pointer<ffi.Void> waiter,
+    ffi.Pointer<ffi.Void> arg0,
+    int arg1,
+  ) {
+    try {
+      (objc.getBlockClosure(block)
+          as void Function(ffi.Pointer<ffi.Void>, int))(arg0, arg1);
+    } catch (e) {
+    } finally {
+      objc.signalWaiter(waiter);
+      objc.objectRelease(block.cast());
+    }
+  }
+
+  static ffi.NativeCallable<
+    ffi.Void Function(
+      ffi.Pointer<objc.ObjCBlockImpl>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Int32,
+    )
+  >
+  _blockingCallable =
+      ffi.NativeCallable<
+          ffi.Void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Int32,
+          )
+        >.isolateLocal(_blockingTrampoline)
+        ..keepIsolateAlive = false;
+  static ffi.NativeCallable<
+    ffi.Void Function(
+      ffi.Pointer<objc.ObjCBlockImpl>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Pointer<ffi.Void>,
+      ffi.Int32,
+    )
+  >
+  _blockingListenerCallable =
+      ffi.NativeCallable<
+          ffi.Void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Int32,
+          )
+        >.listener(_blockingTrampoline)
+        ..keepIsolateAlive = false;
+  static void _fnPtrTrampoline(
+    ffi.Pointer<objc.ObjCBlockImpl> block,
+    ffi.Pointer<ffi.Void> arg0,
+    int arg1,
+  ) => block.ref.target
+      .cast<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<ffi.Void> arg0, ffi.Int32 arg1)
+        >
+      >()
+      .asFunction<void Function(ffi.Pointer<ffi.Void>, int)>()(arg0, arg1);
+  static ffi.Pointer<ffi.Void> _fnPtrCallable =
+      ffi.Pointer.fromFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Int32,
+            )
+          >(_fnPtrTrampoline)
+          .cast();
+  static void _closureTrampoline(
+    ffi.Pointer<objc.ObjCBlockImpl> block,
+    ffi.Pointer<ffi.Void> arg0,
+    int arg1,
+  ) =>
+      (objc.getBlockClosure(block)
+          as void Function(ffi.Pointer<ffi.Void>, int))(arg0, arg1);
+  static ffi.Pointer<ffi.Void> _closureCallable =
+      ffi.Pointer.fromFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Int32,
+            )
+          >(_closureTrampoline)
+          .cast();
+}
+
+/// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)>`.
+extension ObjCBlock_ffiVoid_ffiVoid_Int32$1$CallExtension
+    on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int32)> {
+  void call(ffi.Pointer<ffi.Void> arg0, int arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Int32 arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            int,
           )
         >()(ref.pointer, arg0, arg1);
   }
@@ -1874,8 +1882,8 @@ abstract final class ObjCBlock_idMyProtocol_ffiVoid {
         ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$obj = fn(arg0);
-          return _$obj.ref.retainAndAutorelease();
+          final _$$ = fn(arg0).ref;
+          return _$$.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2004,8 +2012,8 @@ abstract final class ObjCBlock_instancetype_ffiVoid {
         ffi.Pointer<objc.ObjCObjectImpl>? Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$nullableObj = fn(arg0);
-          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+          final _$$ = fn(arg0)?.ref;
+          return _$$?.retainAndAutorelease() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -2192,40 +2200,42 @@ extension type ObjCProtocolImpl._(objc.ObjCObject object$)
 extension ObjCProtocolImpl$Methods on ObjCProtocolImpl {
   /// disabledMethod
   int disabledMethod() {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_disabledMethod)) {
+    final _$$$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$$1.pointer, _sel_disabledMethod)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'disabledMethod',
       );
     }
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_disabledMethod);
+    return _objc_msgSend_1gcq84o(_$$$1.pointer, _sel_disabledMethod);
   }
 
   /// fooMethod
   int fooMethod() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_fooMethod);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_fooMethod);
   }
 
   /// init
   ObjCProtocolImpl init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'ObjCProtocolImpl.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return ObjCProtocolImpl.fromPointer($ret, retain: false, release: true);
   }
 
   /// instanceMethod:withDouble:
   objc.NSString instanceMethod(objc.NSString s, {required double withDouble}) {
+    final _$$$2 = object$.ref;
+    final _$$$3 = s.ref;
     final $ret = _objc_msgSend_6plvbo(
-      object$.ref.pointer,
+      _$$$2.pointer,
       _sel_instanceMethod_withDouble_,
-      s.ref.pointer,
+      _$$$3.pointer,
       withDouble,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -2233,30 +2243,33 @@ extension ObjCProtocolImpl$Methods on ObjCProtocolImpl {
 
   /// intPtrMethod:
   void intPtrMethod(ffi.Pointer<ffi.Int32> ptr) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_intPtrMethod_)) {
+    final _$$$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$$1.pointer, _sel_intPtrMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'intPtrMethod:',
       );
     }
-    _objc_msgSend_yhkuco(object$.ref.pointer, _sel_intPtrMethod_, ptr);
+    _objc_msgSend_yhkuco(_$$$1.pointer, _sel_intPtrMethod_, ptr);
   }
 
   /// optionalMethod:
   int optionalMethod(SomeStruct s) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_optionalMethod_)) {
+    final _$$$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$$1.pointer, _sel_optionalMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'optionalMethod:',
       );
     }
-    return _objc_msgSend_lacj97(object$.ref.pointer, _sel_optionalMethod_, s);
+    return _objc_msgSend_lacj97(_$$$1.pointer, _sel_optionalMethod_, s);
   }
 
   /// otherMethod:b:c:d:
   int otherMethod(int a, {required int b, required int c, required int d}) {
+    final _$$ = object$.ref;
     return _objc_msgSend_hv8ra8(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_otherMethod_b_c_d_,
       a,
       b,
@@ -2267,19 +2280,14 @@ extension ObjCProtocolImpl$Methods on ObjCProtocolImpl {
 
   /// returnsInstanceType
   ObjCProtocolImpl? returnsInstanceType() {
-    if (!objc.respondsToSelector(
-      object$.ref.pointer,
-      _sel_returnsInstanceType,
-    )) {
+    final _$$ = object$.ref;
+    if (!objc.respondsToSelector(_$$.pointer, _sel_returnsInstanceType)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'returnsInstanceType',
       );
     }
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_returnsInstanceType,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_returnsInstanceType);
     return $ret.address == 0
         ? null
         : ObjCProtocolImpl.fromPointer($ret, retain: true, release: true);
@@ -2287,28 +2295,27 @@ extension ObjCProtocolImpl$Methods on ObjCProtocolImpl {
 
   /// returnsMyProtocol
   MyProtocol returnsMyProtocol() {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_returnsMyProtocol)) {
+    final _$$ = object$.ref;
+    if (!objc.respondsToSelector(_$$.pointer, _sel_returnsMyProtocol)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'returnsMyProtocol',
       );
     }
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_returnsMyProtocol,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_returnsMyProtocol);
     return MyProtocol.fromPointer($ret, retain: true, release: true);
   }
 
   /// voidMethod:
   void voidMethod(int x) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_voidMethod_)) {
+    final _$$$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$$1.pointer, _sel_voidMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImpl',
         'voidMethod:',
       );
     }
-    _objc_msgSend_1bqef4y(object$.ref.pointer, _sel_voidMethod_, x);
+    _objc_msgSend_1bqef4y(_$$$1.pointer, _sel_voidMethod_, x);
   }
 }
 
@@ -2430,24 +2437,26 @@ extension ObjCProtocolImplMissingMethod$Methods
     on ObjCProtocolImplMissingMethod {
   /// disabledMethod
   int disabledMethod() {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_disabledMethod)) {
+    final _$$$2 = object$.ref;
+    if (!objc.respondsToSelector(_$$$2.pointer, _sel_disabledMethod)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImplMissingMethod',
         'disabledMethod',
       );
     }
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_disabledMethod);
+    return _objc_msgSend_1gcq84o(_$$$2.pointer, _sel_disabledMethod);
   }
 
   /// init
   ObjCProtocolImplMissingMethod init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'ObjCProtocolImplMissingMethod.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return ObjCProtocolImplMissingMethod.fromPointer(
@@ -2459,10 +2468,12 @@ extension ObjCProtocolImplMissingMethod$Methods
 
   /// instanceMethod:withDouble:
   objc.NSString instanceMethod(objc.NSString s, {required double withDouble}) {
+    final _$$$4 = object$.ref;
+    final _$$$5 = s.ref;
     final $ret = _objc_msgSend_6plvbo(
-      object$.ref.pointer,
+      _$$$4.pointer,
       _sel_instanceMethod_withDouble_,
-      s.ref.pointer,
+      _$$$5.pointer,
       withDouble,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
@@ -2470,35 +2481,38 @@ extension ObjCProtocolImplMissingMethod$Methods
 
   /// intPtrMethod:
   void intPtrMethod(ffi.Pointer<ffi.Int32> ptr) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_intPtrMethod_)) {
+    final _$$$2 = object$.ref;
+    if (!objc.respondsToSelector(_$$$2.pointer, _sel_intPtrMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImplMissingMethod',
         'intPtrMethod:',
       );
     }
-    _objc_msgSend_yhkuco(object$.ref.pointer, _sel_intPtrMethod_, ptr);
+    _objc_msgSend_yhkuco(_$$$2.pointer, _sel_intPtrMethod_, ptr);
   }
 
   /// optionalMethod:
   int optionalMethod(SomeStruct s) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_optionalMethod_)) {
+    final _$$$2 = object$.ref;
+    if (!objc.respondsToSelector(_$$$2.pointer, _sel_optionalMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImplMissingMethod',
         'optionalMethod:',
       );
     }
-    return _objc_msgSend_lacj97(object$.ref.pointer, _sel_optionalMethod_, s);
+    return _objc_msgSend_lacj97(_$$$2.pointer, _sel_optionalMethod_, s);
   }
 
   /// voidMethod:
   void voidMethod(int x) {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_voidMethod_)) {
+    final _$$$2 = object$.ref;
+    if (!objc.respondsToSelector(_$$$2.pointer, _sel_voidMethod_)) {
       throw objc.UnimplementedOptionalMethodException(
         'ObjCProtocolImplMissingMethod',
         'voidMethod:',
       );
     }
-    _objc_msgSend_1bqef4y(object$.ref.pointer, _sel_voidMethod_, x);
+    _objc_msgSend_1bqef4y(_$$$2.pointer, _sel_voidMethod_, x);
   }
 }
 
@@ -2557,68 +2571,81 @@ extension type ProtocolConsumer._(objc.ObjCObject object$)
 extension ProtocolConsumer$Methods on ProtocolConsumer {
   /// callBlockingMethodOnRandomThread:
   void callBlockingMethodOnRandomThread(MyProtocol protocol) {
+    final _$$ = object$.ref;
+    final _$$$1 = protocol.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_callBlockingMethodOnRandomThread_,
-      protocol.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// callInstanceMethod:
   objc.NSString callInstanceMethod(SuperProtocol protocol) {
+    final _$$ = object$.ref;
+    final _$$$1 = protocol.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_callInstanceMethod_,
-      protocol.ref.pointer,
+      _$$$1.pointer,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// callMethodOnRandomThread:
   void callMethodOnRandomThread(MyProtocol protocol) {
+    final _$$ = object$.ref;
+    final _$$$1 = protocol.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_callMethodOnRandomThread_,
-      protocol.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// callOptionalMethod:
   int callOptionalMethod(MyProtocol protocol) {
+    final _$$ = object$.ref;
+    final _$$$1 = protocol.ref;
     return _objc_msgSend_fd28sq(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_callOptionalMethod_,
-      protocol.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// callOtherMethod:
   int callOtherMethod(SecondaryProtocol protocol) {
+    final _$$ = object$.ref;
+    final _$$$1 = protocol.ref;
     return _objc_msgSend_fd28sq(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_callOtherMethod_,
-      protocol.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// callTwoMethods:
   int callTwoMethods(MyProtocol protocol) {
+    final _$$ = object$.ref;
+    final _$$$1 = protocol.ref;
     return _objc_msgSend_fd28sq(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_callTwoMethods_,
-      protocol.ref.pointer,
+      _$$$1.pointer,
     );
   }
 
   /// init
   ProtocolConsumer init() {
+    final _$$$2 = object$.ref;
     objc.checkOsVersionInternal(
       'ProtocolConsumer.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_init,
     );
     return ProtocolConsumer.fromPointer($ret, retain: false, release: true);
@@ -2651,8 +2678,9 @@ extension type SecondaryProtocol._(objc.ObjCProtocol object$)
 extension SecondaryProtocol$Methods on SecondaryProtocol {
   /// otherMethod:b:c:d:
   int otherMethod(int a, {required int b, required int c, required int d}) {
+    final _$$$1 = object$.ref;
     return _objc_msgSend_hv8ra8(
-      object$.ref.pointer,
+      _$$$1.pointer,
       _sel_otherMethod_b_c_d_,
       a,
       b,
@@ -2663,19 +2691,14 @@ extension SecondaryProtocol$Methods on SecondaryProtocol {
 
   /// returnsInstanceType
   SecondaryProtocol? returnsInstanceType() {
-    if (!objc.respondsToSelector(
-      object$.ref.pointer,
-      _sel_returnsInstanceType,
-    )) {
+    final _$$$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$$1.pointer, _sel_returnsInstanceType)) {
       throw objc.UnimplementedOptionalMethodException(
         'SecondaryProtocol',
         'returnsInstanceType',
       );
     }
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_returnsInstanceType,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$$1.pointer, _sel_returnsInstanceType);
     return $ret.address == 0
         ? null
         : SecondaryProtocol.fromPointer($ret, retain: true, release: true);
@@ -2683,16 +2706,14 @@ extension SecondaryProtocol$Methods on SecondaryProtocol {
 
   /// returnsMyProtocol
   MyProtocol returnsMyProtocol() {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_returnsMyProtocol)) {
+    final _$$$1 = object$.ref;
+    if (!objc.respondsToSelector(_$$$1.pointer, _sel_returnsMyProtocol)) {
       throw objc.UnimplementedOptionalMethodException(
         'SecondaryProtocol',
         'returnsMyProtocol',
       );
     }
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_returnsMyProtocol,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$$1.pointer, _sel_returnsMyProtocol);
     return MyProtocol.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -2906,7 +2927,8 @@ extension type UnusedProtocol._(objc.ObjCProtocol object$)
 extension UnusedProtocol$Methods on UnusedProtocol {
   /// someMethod
   int someMethod() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_someMethod);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_someMethod);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.dart
@@ -1141,19 +1141,18 @@ abstract final class ObjCBlock_NSString_ffiVoid_NSString_ffiDouble {
       objc.ObjCBlock<
         objc.NSString Function(ffi.Pointer<ffi.Void>, objc.NSString, ffi.Double)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            double arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          double arg2,
+        ) {
+          final _$obj = fn(
             arg0,
             objc.NSString.fromPointer(arg1, retain: true, release: true),
             arg2,
-          ).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+          );
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -1870,11 +1869,10 @@ abstract final class ObjCBlock_idMyProtocol_ffiVoid {
       objc.ObjCBlock<
         ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+          final _$obj = fn(arg0);
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -1999,12 +1997,10 @@ abstract final class ObjCBlock_instancetype_ffiVoid {
       objc.ObjCBlock<
         ffi.Pointer<objc.ObjCObjectImpl>? Function(ffi.Pointer<ffi.Void>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0) =>
-              fn(arg0)?.ref.retainAndAutorelease() ?? ffi.nullptr,
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+          final _$nullableObj = fn(arg0);
+          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );

--- a/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.m
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.m
@@ -77,48 +77,19 @@ id  _13hhotk_protocolTrampoline_1s2pox8(id target, void * sel, id arg1, double a
   return ((_ProtocolTrampoline_3)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1, arg2);
 }
 
-typedef void  (^_ListenerTrampoline)(void * arg0, int32_t arg1);
+typedef void  (^_ListenerTrampoline)(void * arg0, int32_t * arg1);
 __attribute__((visibility("default"))) __attribute__((used))
-_ListenerTrampoline _13hhotk_wrapListenerBlock_1pbq496(_ListenerTrampoline block) NS_RETURNS_RETAINED {
-  return ^void(void * arg0, int32_t arg1) {
-    objc_retainBlock(block);
-    block(arg0, arg1);
-  };
-}
-
-typedef void  (^_BlockingTrampoline)(void * waiter, void * arg0, int32_t arg1);
-__attribute__((visibility("default"))) __attribute__((used))
-_ListenerTrampoline _13hhotk_wrapBlockingBlock_1pbq496(
-    _BlockingTrampoline block, _BlockingTrampoline listenerBlock,
-    DOBJC_Context* ctx) NS_RETURNS_RETAINED {
-  BLOCKING_BLOCK_IMPL(ctx, ^void(void * arg0, int32_t arg1), {
-    objc_retainBlock(block);
-    block(nil, arg0, arg1);
-  }, {
-    objc_retainBlock(listenerBlock);
-    listenerBlock(waiter, arg0, arg1);
-  });
-}
-
-typedef void  (^_ProtocolTrampoline_4)(void * sel, int32_t arg1);
-__attribute__((visibility("default"))) __attribute__((used))
-void  _13hhotk_protocolTrampoline_1pbq496(id target, void * sel, int32_t arg1) {
-  return ((_ProtocolTrampoline_4)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1);
-}
-
-typedef void  (^_ListenerTrampoline_1)(void * arg0, int32_t * arg1);
-__attribute__((visibility("default"))) __attribute__((used))
-_ListenerTrampoline_1 _13hhotk_wrapListenerBlock_8r9qkg(_ListenerTrampoline_1 block) NS_RETURNS_RETAINED {
+_ListenerTrampoline _13hhotk_wrapListenerBlock_8r9qkg(_ListenerTrampoline block) NS_RETURNS_RETAINED {
   return ^void(void * arg0, int32_t * arg1) {
     objc_retainBlock(block);
     block(arg0, arg1);
   };
 }
 
-typedef void  (^_BlockingTrampoline_1)(void * waiter, void * arg0, int32_t * arg1);
+typedef void  (^_BlockingTrampoline)(void * waiter, void * arg0, int32_t * arg1);
 __attribute__((visibility("default"))) __attribute__((used))
-_ListenerTrampoline_1 _13hhotk_wrapBlockingBlock_8r9qkg(
-    _BlockingTrampoline_1 block, _BlockingTrampoline_1 listenerBlock,
+_ListenerTrampoline _13hhotk_wrapBlockingBlock_8r9qkg(
+    _BlockingTrampoline block, _BlockingTrampoline listenerBlock,
     DOBJC_Context* ctx) NS_RETURNS_RETAINED {
   BLOCKING_BLOCK_IMPL(ctx, ^void(void * arg0, int32_t * arg1), {
     objc_retainBlock(block);
@@ -129,9 +100,38 @@ _ListenerTrampoline_1 _13hhotk_wrapBlockingBlock_8r9qkg(
   });
 }
 
-typedef void  (^_ProtocolTrampoline_5)(void * sel, int32_t * arg1);
+typedef void  (^_ProtocolTrampoline_4)(void * sel, int32_t * arg1);
 __attribute__((visibility("default"))) __attribute__((used))
 void  _13hhotk_protocolTrampoline_8r9qkg(id target, void * sel, int32_t * arg1) {
+  return ((_ProtocolTrampoline_4)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1);
+}
+
+typedef void  (^_ListenerTrampoline_1)(void * arg0, int32_t arg1);
+__attribute__((visibility("default"))) __attribute__((used))
+_ListenerTrampoline_1 _13hhotk_wrapListenerBlock_1pbq496(_ListenerTrampoline_1 block) NS_RETURNS_RETAINED {
+  return ^void(void * arg0, int32_t arg1) {
+    objc_retainBlock(block);
+    block(arg0, arg1);
+  };
+}
+
+typedef void  (^_BlockingTrampoline_1)(void * waiter, void * arg0, int32_t arg1);
+__attribute__((visibility("default"))) __attribute__((used))
+_ListenerTrampoline_1 _13hhotk_wrapBlockingBlock_1pbq496(
+    _BlockingTrampoline_1 block, _BlockingTrampoline_1 listenerBlock,
+    DOBJC_Context* ctx) NS_RETURNS_RETAINED {
+  BLOCKING_BLOCK_IMPL(ctx, ^void(void * arg0, int32_t arg1), {
+    objc_retainBlock(block);
+    block(nil, arg0, arg1);
+  }, {
+    objc_retainBlock(listenerBlock);
+    listenerBlock(waiter, arg0, arg1);
+  });
+}
+
+typedef void  (^_ProtocolTrampoline_5)(void * sel, int32_t arg1);
+__attribute__((visibility("default"))) __attribute__((used))
+void  _13hhotk_protocolTrampoline_1pbq496(id target, void * sel, int32_t arg1) {
   return ((_ProtocolTrampoline_5)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1);
 }
 

--- a/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.m
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test_bindings.m
@@ -77,48 +77,19 @@ id  _13hhotk_protocolTrampoline_1s2pox8(id target, void * sel, id arg1, double a
   return ((_ProtocolTrampoline_3)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1, arg2);
 }
 
-typedef void  (^_ListenerTrampoline)(void * arg0, int32_t * arg1);
+typedef void  (^_ListenerTrampoline)(void * arg0, int32_t arg1);
 __attribute__((visibility("default"))) __attribute__((used))
-_ListenerTrampoline _13hhotk_wrapListenerBlock_8r9qkg(_ListenerTrampoline block) NS_RETURNS_RETAINED {
-  return ^void(void * arg0, int32_t * arg1) {
-    objc_retainBlock(block);
-    block(arg0, arg1);
-  };
-}
-
-typedef void  (^_BlockingTrampoline)(void * waiter, void * arg0, int32_t * arg1);
-__attribute__((visibility("default"))) __attribute__((used))
-_ListenerTrampoline _13hhotk_wrapBlockingBlock_8r9qkg(
-    _BlockingTrampoline block, _BlockingTrampoline listenerBlock,
-    DOBJC_Context* ctx) NS_RETURNS_RETAINED {
-  BLOCKING_BLOCK_IMPL(ctx, ^void(void * arg0, int32_t * arg1), {
-    objc_retainBlock(block);
-    block(nil, arg0, arg1);
-  }, {
-    objc_retainBlock(listenerBlock);
-    listenerBlock(waiter, arg0, arg1);
-  });
-}
-
-typedef void  (^_ProtocolTrampoline_4)(void * sel, int32_t * arg1);
-__attribute__((visibility("default"))) __attribute__((used))
-void  _13hhotk_protocolTrampoline_8r9qkg(id target, void * sel, int32_t * arg1) {
-  return ((_ProtocolTrampoline_4)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1);
-}
-
-typedef void  (^_ListenerTrampoline_1)(void * arg0, int32_t arg1);
-__attribute__((visibility("default"))) __attribute__((used))
-_ListenerTrampoline_1 _13hhotk_wrapListenerBlock_1pbq496(_ListenerTrampoline_1 block) NS_RETURNS_RETAINED {
+_ListenerTrampoline _13hhotk_wrapListenerBlock_1pbq496(_ListenerTrampoline block) NS_RETURNS_RETAINED {
   return ^void(void * arg0, int32_t arg1) {
     objc_retainBlock(block);
     block(arg0, arg1);
   };
 }
 
-typedef void  (^_BlockingTrampoline_1)(void * waiter, void * arg0, int32_t arg1);
+typedef void  (^_BlockingTrampoline)(void * waiter, void * arg0, int32_t arg1);
 __attribute__((visibility("default"))) __attribute__((used))
-_ListenerTrampoline_1 _13hhotk_wrapBlockingBlock_1pbq496(
-    _BlockingTrampoline_1 block, _BlockingTrampoline_1 listenerBlock,
+_ListenerTrampoline _13hhotk_wrapBlockingBlock_1pbq496(
+    _BlockingTrampoline block, _BlockingTrampoline listenerBlock,
     DOBJC_Context* ctx) NS_RETURNS_RETAINED {
   BLOCKING_BLOCK_IMPL(ctx, ^void(void * arg0, int32_t arg1), {
     objc_retainBlock(block);
@@ -129,9 +100,38 @@ _ListenerTrampoline_1 _13hhotk_wrapBlockingBlock_1pbq496(
   });
 }
 
-typedef void  (^_ProtocolTrampoline_5)(void * sel, int32_t arg1);
+typedef void  (^_ProtocolTrampoline_4)(void * sel, int32_t arg1);
 __attribute__((visibility("default"))) __attribute__((used))
 void  _13hhotk_protocolTrampoline_1pbq496(id target, void * sel, int32_t arg1) {
+  return ((_ProtocolTrampoline_4)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1);
+}
+
+typedef void  (^_ListenerTrampoline_1)(void * arg0, int32_t * arg1);
+__attribute__((visibility("default"))) __attribute__((used))
+_ListenerTrampoline_1 _13hhotk_wrapListenerBlock_8r9qkg(_ListenerTrampoline_1 block) NS_RETURNS_RETAINED {
+  return ^void(void * arg0, int32_t * arg1) {
+    objc_retainBlock(block);
+    block(arg0, arg1);
+  };
+}
+
+typedef void  (^_BlockingTrampoline_1)(void * waiter, void * arg0, int32_t * arg1);
+__attribute__((visibility("default"))) __attribute__((used))
+_ListenerTrampoline_1 _13hhotk_wrapBlockingBlock_8r9qkg(
+    _BlockingTrampoline_1 block, _BlockingTrampoline_1 listenerBlock,
+    DOBJC_Context* ctx) NS_RETURNS_RETAINED {
+  BLOCKING_BLOCK_IMPL(ctx, ^void(void * arg0, int32_t * arg1), {
+    objc_retainBlock(block);
+    block(nil, arg0, arg1);
+  }, {
+    objc_retainBlock(listenerBlock);
+    listenerBlock(waiter, arg0, arg1);
+  });
+}
+
+typedef void  (^_ProtocolTrampoline_5)(void * sel, int32_t * arg1);
+__attribute__((visibility("default"))) __attribute__((used))
+void  _13hhotk_protocolTrampoline_8r9qkg(id target, void * sel, int32_t * arg1) {
   return ((_ProtocolTrampoline_5)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1);
 }
 

--- a/pkgs/ffigen/test/native_objc_test/ref_count_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/ref_count_test_bindings.dart
@@ -68,10 +68,11 @@ extension type RefCountTestObject._(objc.ObjCObject object$)
 
   /// consumeArg:
   static void consumeArg(RefCountTestObject arg) {
+    final _$$ = arg.ref;
     _objc_msgSend_4js6t(
       _class_RefCountTestObject,
       _sel_consumeArg_,
-      arg.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
     );
   }
 
@@ -110,41 +111,37 @@ extension type RefCountTestObject._(objc.ObjCObject object$)
 extension RefCountTestObject$Methods on RefCountTestObject {
   /// assignedProperty
   RefCountTestObject get assignedProperty {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_assignedProperty,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_assignedProperty);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copiedProperty
   RefCountTestObject get copiedProperty {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_copiedProperty,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copiedProperty);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyMe
   RefCountTestObject copyMe() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_copyMe);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMe);
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// copyMeAutorelease
   RefCountTestObject copyMeAutorelease() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_copyMeAutorelease,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMeAutorelease);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyMeConsumeSelf
   RefCountTestObject copyMeConsumeSelf() {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_copyMeConsumeSelf,
     );
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
@@ -152,46 +149,41 @@ extension RefCountTestObject$Methods on RefCountTestObject {
 
   /// copyMeNoRetain
   RefCountTestObject copyMeNoRetain() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_copyMeNoRetain,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMeNoRetain);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyWithZone:
   objc.ObjCObject copyWithZone$1(ffi.Pointer<objc.NSZone> zone) {
-    final $ret = _objc_msgSend_1cwp428(
-      object$.ref.pointer,
-      _sel_copyWithZone_,
-      zone,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_1cwp428(_$$.pointer, _sel_copyWithZone_, zone);
     return objc.ObjCObject($ret, retain: false, release: true);
   }
 
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_dealloc);
+    final _$$ = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
   }
 
   /// init
   RefCountTestObject init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'RefCountTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCounter:
   RefCountTestObject initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );
@@ -200,66 +192,56 @@ extension RefCountTestObject$Methods on RefCountTestObject {
 
   /// mutableCopyMe
   RefCountTestObject mutableCopyMe() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_mutableCopyMe);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_mutableCopyMe);
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// retainedProperty
   RefCountTestObject get retainedProperty {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_retainedProperty,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_retainedProperty);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// returnsRetained
   RefCountTestObject returnsRetained() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_returnsRetained,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_returnsRetained);
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// setAssignedProperty:
   set assignedProperty(RefCountTestObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setAssignedProperty_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setAssignedProperty_, _$$$1.pointer);
   }
 
   /// setCopiedProperty:
   set copiedProperty(RefCountTestObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setCopiedProperty_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setCopiedProperty_, _$$$1.pointer);
   }
 
   /// setCounter:
   void setCounter(ffi.Pointer<ffi.Int32> _counter) {
-    _objc_msgSend_yhkuco(object$.ref.pointer, _sel_setCounter_, _counter);
+    final _$$ = object$.ref;
+    _objc_msgSend_yhkuco(_$$.pointer, _sel_setCounter_, _counter);
   }
 
   /// setRetainedProperty:
   set retainedProperty(RefCountTestObject value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setRetainedProperty_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setRetainedProperty_, _$$$1.pointer);
   }
 
   /// unownedReference
   RefCountTestObject unownedReference() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_unownedReference,
-    );
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_unownedReference);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -319,13 +301,14 @@ extension type RefCounted._(objc.ObjCObject object$)
 extension RefCounted$Methods on RefCounted {
   /// init
   RefCounted init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'RefCounted.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return RefCounted.fromPointer($ret, retain: false, release: true);
@@ -333,12 +316,14 @@ extension RefCounted$Methods on RefCounted {
 
   /// meAsInt
   int meAsInt() {
-    return _objc_msgSend_pysgoz(object$.ref.pointer, _sel_meAsInt);
+    final _$$ = object$.ref;
+    return _objc_msgSend_pysgoz(_$$.pointer, _sel_meAsInt);
   }
 
   /// refCount
   int get refCount {
-    return _objc_msgSend_9qbz9w(object$.ref.pointer, _sel_refCount);
+    final _$$ = object$.ref;
+    return _objc_msgSend_9qbz9w(_$$.pointer, _sel_refCount);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/ref_count_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/ref_count_test_bindings.dart
@@ -68,11 +68,11 @@ extension type RefCountTestObject._(objc.ObjCObject object$)
 
   /// consumeArg:
   static void consumeArg(RefCountTestObject arg) {
-    final _$$ = arg.ref;
+    final _$$ref = arg.ref;
     _objc_msgSend_4js6t(
       _class_RefCountTestObject,
       _sel_consumeArg_,
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
     );
   }
 
@@ -111,37 +111,37 @@ extension type RefCountTestObject._(objc.ObjCObject object$)
 extension RefCountTestObject$Methods on RefCountTestObject {
   /// assignedProperty
   RefCountTestObject get assignedProperty {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_assignedProperty);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_assignedProperty);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copiedProperty
   RefCountTestObject get copiedProperty {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copiedProperty);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copiedProperty);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyMe
   RefCountTestObject copyMe() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMe);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copyMe);
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// copyMeAutorelease
   RefCountTestObject copyMeAutorelease() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMeAutorelease);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copyMeAutorelease);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyMeConsumeSelf
   RefCountTestObject copyMeConsumeSelf() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_copyMeConsumeSelf,
     );
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
@@ -149,41 +149,48 @@ extension RefCountTestObject$Methods on RefCountTestObject {
 
   /// copyMeNoRetain
   RefCountTestObject copyMeNoRetain() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_copyMeNoRetain);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copyMeNoRetain);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// copyWithZone:
   objc.ObjCObject copyWithZone$1(ffi.Pointer<objc.NSZone> zone) {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_1cwp428(_$$.pointer, _sel_copyWithZone_, zone);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_1cwp428(
+      _$$ref.pointer,
+      _sel_copyWithZone_,
+      zone,
+    );
     return objc.ObjCObject($ret, retain: false, release: true);
   }
 
   /// dealloc
   void dealloc() {
-    final _$$ = object$.ref;
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_dealloc);
   }
 
   /// init
   RefCountTestObject init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'RefCountTestObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCounter:
   RefCountTestObject initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );
@@ -192,56 +199,68 @@ extension RefCountTestObject$Methods on RefCountTestObject {
 
   /// mutableCopyMe
   RefCountTestObject mutableCopyMe() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_mutableCopyMe);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_mutableCopyMe);
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// retainedProperty
   RefCountTestObject get retainedProperty {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_retainedProperty);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_retainedProperty);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 
   /// returnsRetained
   RefCountTestObject returnsRetained() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_returnsRetained);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_returnsRetained);
     return RefCountTestObject.fromPointer($ret, retain: false, release: true);
   }
 
   /// setAssignedProperty:
   set assignedProperty(RefCountTestObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setAssignedProperty_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_setAssignedProperty_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// setCopiedProperty:
   set copiedProperty(RefCountTestObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setCopiedProperty_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_setCopiedProperty_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// setCounter:
   void setCounter(ffi.Pointer<ffi.Int32> _counter) {
-    final _$$ = object$.ref;
-    _objc_msgSend_yhkuco(_$$.pointer, _sel_setCounter_, _counter);
+    final _$$ref = object$.ref;
+    _objc_msgSend_yhkuco(_$$ref.pointer, _sel_setCounter_, _counter);
   }
 
   /// setRetainedProperty:
   set retainedProperty(RefCountTestObject value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setRetainedProperty_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_setRetainedProperty_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// unownedReference
   RefCountTestObject unownedReference() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_unownedReference);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_unownedReference);
     return RefCountTestObject.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -301,14 +320,14 @@ extension type RefCounted._(objc.ObjCObject object$)
 extension RefCounted$Methods on RefCounted {
   /// init
   RefCounted init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'RefCounted.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return RefCounted.fromPointer($ret, retain: false, release: true);
@@ -316,14 +335,14 @@ extension RefCounted$Methods on RefCounted {
 
   /// meAsInt
   int meAsInt() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_pysgoz(_$$.pointer, _sel_meAsInt);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_pysgoz(_$$ref.pointer, _sel_meAsInt);
   }
 
   /// refCount
   int get refCount {
-    final _$$ = object$.ref;
-    return _objc_msgSend_9qbz9w(_$$.pointer, _sel_refCount);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_9qbz9w(_$$ref.pointer, _sel_refCount);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/rename_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/rename_test_bindings.dart
@@ -63,32 +63,33 @@ extension type Renamed._(objc.ObjCObject object$)
 extension Renamed$Methods on Renamed {
   /// CollidingStructName
   int CollidingStructName$1() {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_CollidingStructName);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_CollidingStructName);
   }
 
   /// init
   Renamed init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       '_Renamed.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return Renamed.fromPointer($ret, retain: false, release: true);
   }
 
   /// property
   int get property {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_property);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_property);
   }
 
   /// renamedMethod:otherArg:
   int fooBarBaz(int x, {required int y}) {
+    final _$$ = object$.ref;
     return _objc_msgSend_1q0lyci(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_renamedMethod_otherArg_,
       x,
       y,
@@ -97,22 +98,26 @@ extension Renamed$Methods on Renamed {
 
   /// renamedProperty
   int get reProp {
-    return _objc_msgSend_1gcq84o(object$.ref.pointer, _sel_renamedProperty);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_renamedProperty);
   }
 
   /// setProperty:
   set property(int value) {
-    _objc_msgSend_1bqef4y(object$.ref.pointer, _sel_setProperty_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setProperty_, value);
   }
 
   /// setRenamedProperty:
   set reProp(int value) {
-    _objc_msgSend_1bqef4y(object$.ref.pointer, _sel_setRenamedProperty_, value);
+    final _$$ = object$.ref;
+    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setRenamedProperty_, value);
   }
 
   /// toString
   objc.NSString toString$1() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_toString);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_toString);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/rename_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/rename_test_bindings.dart
@@ -63,33 +63,36 @@ extension type Renamed._(objc.ObjCObject object$)
 extension Renamed$Methods on Renamed {
   /// CollidingStructName
   int CollidingStructName$1() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_CollidingStructName);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_CollidingStructName);
   }
 
   /// init
   Renamed init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       '_Renamed.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return Renamed.fromPointer($ret, retain: false, release: true);
   }
 
   /// property
   int get property {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_property);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_property);
   }
 
   /// renamedMethod:otherArg:
   int fooBarBaz(int x, {required int y}) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     return _objc_msgSend_1q0lyci(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_renamedMethod_otherArg_,
       x,
       y,
@@ -98,26 +101,26 @@ extension Renamed$Methods on Renamed {
 
   /// renamedProperty
   int get reProp {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1gcq84o(_$$.pointer, _sel_renamedProperty);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1gcq84o(_$$ref.pointer, _sel_renamedProperty);
   }
 
   /// setProperty:
   set property(int value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setProperty_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1bqef4y(_$$ref.pointer, _sel_setProperty_, value);
   }
 
   /// setRenamedProperty:
   set reProp(int value) {
-    final _$$ = object$.ref;
-    _objc_msgSend_1bqef4y(_$$.pointer, _sel_setRenamedProperty_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1bqef4y(_$$ref.pointer, _sel_setRenamedProperty_, value);
   }
 
   /// toString
   objc.NSString toString$1() {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_toString);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_toString);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/runtime_version_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/runtime_version_test_bindings.dart
@@ -13,66 +13,66 @@ extension FutureAPICategoryMethods on objc.NSObject {
   /// catFutureMethodBoth
   @Deprecated('test')
   int catFutureMethodBoth() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catFutureMethodBoth',
       iOS: (false, (1000, 0, 0)),
       macOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catFutureMethodBoth);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_catFutureMethodBoth);
   }
 
   /// catFutureMethodIos
   @Deprecated('test')
   int catFutureMethodIos() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catFutureMethodIos',
       iOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catFutureMethodIos);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_catFutureMethodIos);
   }
 
   /// catFutureMethodMac
   @Deprecated('test')
   int catFutureMethodMac() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catFutureMethodMac',
       macOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catFutureMethodMac);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_catFutureMethodMac);
   }
 
   /// catUnavailableBoth
   int catUnavailableBoth() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catUnavailableBoth',
       iOS: (true, null),
       macOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catUnavailableBoth);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_catUnavailableBoth);
   }
 
   /// catUnavailableIos
   int catUnavailableIos() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catUnavailableIos',
       iOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catUnavailableIos);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_catUnavailableIos);
   }
 
   /// catUnavailableMac
   int catUnavailableMac() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catUnavailableMac',
       macOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catUnavailableMac);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_catUnavailableMac);
   }
 }
 
@@ -142,13 +142,16 @@ extension type FutureAPIInterface._(objc.ObjCObject object$)
 extension FutureAPIInterface$Methods on FutureAPIInterface {
   /// init
   FutureAPIInterface init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return FutureAPIInterface.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -209,47 +212,47 @@ extension FutureAPIMethods$Methods on FutureAPIMethods {
   /// futureMethodBoth
   @Deprecated('test')
   int futureMethodBoth() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.futureMethodBoth',
       iOS: (false, (1000, 0, 0)),
       macOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_futureMethodBoth);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_futureMethodBoth);
   }
 
   /// futureMethodIos
   @Deprecated('test')
   int futureMethodIos() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.futureMethodIos',
       iOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_futureMethodIos);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_futureMethodIos);
   }
 
   /// futureMethodMac
   @Deprecated('test')
   int futureMethodMac() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.futureMethodMac',
       macOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_futureMethodMac);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_futureMethodMac);
   }
 
   /// init
   FutureAPIMethods init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return FutureAPIMethods.fromPointer($ret, retain: false, release: true);
@@ -257,33 +260,33 @@ extension FutureAPIMethods$Methods on FutureAPIMethods {
 
   /// unavailableBoth
   int unavailableBoth() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.unavailableBoth',
       iOS: (true, null),
       macOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_unavailableBoth);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_unavailableBoth);
   }
 
   /// unavailableIos
   int unavailableIos() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.unavailableIos',
       iOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_unavailableIos);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_unavailableIos);
   }
 
   /// unavailableMac
   int unavailableMac() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.unavailableMac',
       macOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_unavailableMac);
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_unavailableMac);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/runtime_version_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/runtime_version_test_bindings.dart
@@ -13,60 +13,66 @@ extension FutureAPICategoryMethods on objc.NSObject {
   /// catFutureMethodBoth
   @Deprecated('test')
   int catFutureMethodBoth() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catFutureMethodBoth',
       iOS: (false, (1000, 0, 0)),
       macOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_catFutureMethodBoth);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catFutureMethodBoth);
   }
 
   /// catFutureMethodIos
   @Deprecated('test')
   int catFutureMethodIos() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catFutureMethodIos',
       iOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_catFutureMethodIos);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catFutureMethodIos);
   }
 
   /// catFutureMethodMac
   @Deprecated('test')
   int catFutureMethodMac() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catFutureMethodMac',
       macOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_catFutureMethodMac);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catFutureMethodMac);
   }
 
   /// catUnavailableBoth
   int catUnavailableBoth() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catUnavailableBoth',
       iOS: (true, null),
       macOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_catUnavailableBoth);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catUnavailableBoth);
   }
 
   /// catUnavailableIos
   int catUnavailableIos() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catUnavailableIos',
       iOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_catUnavailableIos);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catUnavailableIos);
   }
 
   /// catUnavailableMac
   int catUnavailableMac() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.catUnavailableMac',
       macOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_catUnavailableMac);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_catUnavailableMac);
   }
 }
 
@@ -136,15 +142,13 @@ extension type FutureAPIInterface._(objc.ObjCObject object$)
 extension FutureAPIInterface$Methods on FutureAPIInterface {
   /// init
   FutureAPIInterface init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIInterface.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return FutureAPIInterface.fromPointer($ret, retain: false, release: true);
   }
 }
@@ -205,43 +209,47 @@ extension FutureAPIMethods$Methods on FutureAPIMethods {
   /// futureMethodBoth
   @Deprecated('test')
   int futureMethodBoth() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.futureMethodBoth',
       iOS: (false, (1000, 0, 0)),
       macOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_futureMethodBoth);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_futureMethodBoth);
   }
 
   /// futureMethodIos
   @Deprecated('test')
   int futureMethodIos() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.futureMethodIos',
       iOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_futureMethodIos);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_futureMethodIos);
   }
 
   /// futureMethodMac
   @Deprecated('test')
   int futureMethodMac() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.futureMethodMac',
       macOS: (false, (1000, 0, 0)),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_futureMethodMac);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_futureMethodMac);
   }
 
   /// init
   FutureAPIMethods init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return FutureAPIMethods.fromPointer($ret, retain: false, release: true);
@@ -249,30 +257,33 @@ extension FutureAPIMethods$Methods on FutureAPIMethods {
 
   /// unavailableBoth
   int unavailableBoth() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.unavailableBoth',
       iOS: (true, null),
       macOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_unavailableBoth);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_unavailableBoth);
   }
 
   /// unavailableIos
   int unavailableIos() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.unavailableIos',
       iOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_unavailableIos);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_unavailableIos);
   }
 
   /// unavailableMac
   int unavailableMac() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'FutureAPIMethods.unavailableMac',
       macOS: (true, null),
     );
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_unavailableMac);
+    return _objc_msgSend_13yqbb6(_$$.pointer, _sel_unavailableMac);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/sdk_variable_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/sdk_variable_test_bindings.dart
@@ -214,71 +214,69 @@ extension type NSColorPicker._(objc.ObjCObject object$)
 extension NSColorPicker$Methods on NSColorPicker {
   /// alphaControlAddedOrRemoved:
   void alphaControlAddedOrRemoved(objc.ObjCObject? sender) {
+    final _$$ = object$.ref;
+    final _$$$1 = sender?.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.alphaControlAddedOrRemoved:',
       iOS: (true, null),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_alphaControlAddedOrRemoved_,
-      sender?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// attachColorList:
   void attachColorList(NSColorList colorList) {
+    final _$$ = object$.ref;
+    final _$$$1 = colorList.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.attachColorList:',
       iOS: (true, null),
     );
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_attachColorList_,
-      colorList.ref.pointer,
-    );
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_attachColorList_, _$$$1.pointer);
   }
 
   /// buttonToolTip
   objc.NSString get buttonToolTip {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.buttonToolTip',
       iOS: (true, null),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_buttonToolTip);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_buttonToolTip);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// colorPanel
   NSColorPanel get colorPanel {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal('NSColorPicker.colorPanel', iOS: (true, null));
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_colorPanel);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_colorPanel);
     return NSColorPanel.fromPointer($ret, retain: true, release: true);
   }
 
   /// detachColorList:
   void detachColorList(NSColorList colorList) {
+    final _$$ = object$.ref;
+    final _$$$1 = colorList.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.detachColorList:',
       iOS: (true, null),
     );
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_detachColorList_,
-      colorList.ref.pointer,
-    );
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_detachColorList_, _$$$1.pointer);
   }
 
   /// init
   NSColorPicker init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return NSColorPicker.fromPointer($ret, retain: false, release: true);
   }
 
@@ -287,15 +285,17 @@ extension NSColorPicker$Methods on NSColorPicker {
     int mask, {
     required NSColorPanel colorPanel,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = colorPanel.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.initWithPickerMask:colorPanel:',
       iOS: (true, null),
     );
     final $ret = _objc_msgSend_vbc8p4(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithPickerMask_colorPanel_,
       mask,
-      colorPanel.ref.pointer,
+      _$$$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -307,35 +307,32 @@ extension NSColorPicker$Methods on NSColorPicker {
     NSImage newButtonImage, {
     required NSButtonCell in$,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = newButtonImage.ref;
+    final _$$$2 = in$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.insertNewButtonImage:in:',
       iOS: (true, null),
     );
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_insertNewButtonImage_in_,
-      newButtonImage.ref.pointer,
-      in$.ref.pointer,
+      _$$$1.pointer,
+      _$$$2.pointer,
     );
   }
 
   /// minContentSize
   objc.CGSize get minContentSize {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.minContentSize',
       iOS: (true, null),
     );
     final $ptr = pkg_ffi.calloc<objc.CGSize>();
     objc.useMsgSendVariants
-        ? _objc_msgSend_1vdfkenStret(
-            $ptr,
-            object$.ref.pointer,
-            _sel_minContentSize,
-          )
-        : $ptr.ref = _objc_msgSend_1vdfken(
-            object$.ref.pointer,
-            _sel_minContentSize,
-          );
+        ? _objc_msgSend_1vdfkenStret($ptr, _$$.pointer, _sel_minContentSize)
+        : $ptr.ref = _objc_msgSend_1vdfken(_$$.pointer, _sel_minContentSize);
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<objc.CGSize>(),
       finalizer: pkg_ffi.calloc.nativeFree,
@@ -345,33 +342,34 @@ extension NSColorPicker$Methods on NSColorPicker {
 
   /// provideNewButtonImage
   NSImage get provideNewButtonImage {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.provideNewButtonImage',
       iOS: (true, null),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_provideNewButtonImage,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_provideNewButtonImage);
     return NSImage.fromPointer($ret, retain: true, release: true);
   }
 
   /// setMode:
   void setMode(NSColorPanelMode mode) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal('NSColorPicker.setMode:', iOS: (true, null));
-    _objc_msgSend_190ea64(object$.ref.pointer, _sel_setMode_, mode.value);
+    _objc_msgSend_190ea64(_$$.pointer, _sel_setMode_, mode.value);
   }
 
   /// viewSizeChanged:
   void viewSizeChanged(objc.ObjCObject? sender) {
+    final _$$ = object$.ref;
+    final _$$$1 = sender?.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.viewSizeChanged:',
       iOS: (true, null),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_viewSizeChanged_,
-      sender?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 }
@@ -542,22 +540,21 @@ extension type NSTextList._(objc.ObjCObject object$)
 extension NSTextList$Methods on NSTextList {
   /// encodeWithCoder:
   void encodeWithCoder(objc.NSCoder coder) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_encodeWithCoder_,
-      coder.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = coder.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_encodeWithCoder_, _$$$1.pointer);
   }
 
   /// init
   NSTextList init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return NSTextList.fromPointer($ret, retain: false, release: true);
@@ -565,10 +562,12 @@ extension NSTextList$Methods on NSTextList {
 
   /// initWithCoder:
   NSTextList? initWithCoder(objc.NSCoder coder) {
+    final _$$ = object$.ref;
+    final _$$$1 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -580,15 +579,17 @@ extension NSTextList$Methods on NSTextList {
     objc.NSString markerFormat, {
     required int options,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = markerFormat.ref;
     objc.checkOsVersionInternal(
       'NSTextList.initWithMarkerFormat:options:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1k4kd9s(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithMarkerFormat_options_,
-      markerFormat.ref.pointer,
+      _$$$1.pointer,
       options,
     );
     return NSTextList.fromPointer($ret, retain: false, release: true);
@@ -600,15 +601,17 @@ extension NSTextList$Methods on NSTextList {
     required int options,
     required int startingItemNumber,
   }) {
+    final _$$ = object$.ref;
+    final _$$$1 = markerFormat.ref;
     objc.checkOsVersionInternal(
       'NSTextList.initWithMarkerFormat:options:startingItemNumber:',
       iOS: (false, (16, 0, 0)),
       macOS: (false, (13, 0, 0)),
     );
     final $ret = _objc_msgSend_1bh1vl9(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithMarkerFormat_options_startingItemNumber_,
-      markerFormat.ref.pointer,
+      _$$$1.pointer,
       options,
       startingItemNumber,
     );
@@ -617,33 +620,36 @@ extension NSTextList$Methods on NSTextList {
 
   /// isOrdered
   bool get isOrdered {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.isOrdered',
       iOS: (false, (16, 0, 0)),
       macOS: (false, (13, 0, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isOrdered);
+    return _objc_msgSend_91o635(_$$.pointer, _sel_isOrdered);
   }
 
   /// listOptions
   int get listOptions {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.listOptions',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    return _objc_msgSend_exovb9(object$.ref.pointer, _sel_listOptions);
+    return _objc_msgSend_exovb9(_$$.pointer, _sel_listOptions);
   }
 
   /// markerForItemNumber:
   objc.NSString markerForItemNumber(int itemNumber) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.markerForItemNumber:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_qugqlf(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_markerForItemNumber_,
       itemNumber,
     );
@@ -652,37 +658,36 @@ extension NSTextList$Methods on NSTextList {
 
   /// markerFormat
   objc.NSString get markerFormat {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.markerFormat',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_markerFormat);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_markerFormat);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// setStartingItemNumber:
   set startingItemNumber(int value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.setStartingItemNumber:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    _objc_msgSend_4sp4xj(
-      object$.ref.pointer,
-      _sel_setStartingItemNumber_,
-      value,
-    );
+    _objc_msgSend_4sp4xj(_$$.pointer, _sel_setStartingItemNumber_, value);
   }
 
   /// startingItemNumber
   int get startingItemNumber {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.startingItemNumber',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_startingItemNumber);
+    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_startingItemNumber);
   }
 }
 
@@ -786,11 +791,12 @@ extension type UIPickerView._(objc.ObjCObject object$)
 extension UIPickerView$Methods on UIPickerView {
   /// dataSource
   UIPickerViewDataSource? get dataSource {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.dataSource',
       iOS: (false, (2, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_dataSource);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_dataSource);
     return $ret.address == 0
         ? null
         : UIPickerViewDataSource.fromPointer($ret, retain: true, release: true);
@@ -798,11 +804,12 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// delegate
   UIPickerViewDelegate? get delegate {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.delegate',
       iOS: (false, (2, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_delegate);
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_delegate);
     return $ret.address == 0
         ? null
         : UIPickerViewDelegate.fromPointer($ret, retain: true, release: true);
@@ -810,19 +817,19 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// encodeWithCoder:
   void encodeWithCoder(objc.NSCoder coder) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_encodeWithCoder_,
-      coder.ref.pointer,
-    );
+    final _$$$2 = object$.ref;
+    final _$$$3 = coder.ref;
+    _objc_msgSend_xtuoz7(_$$$2.pointer, _sel_encodeWithCoder_, _$$$3.pointer);
   }
 
   /// initWithCoder:
   UIPickerView? initWithCoder(objc.NSCoder coder) {
+    final _$$$2 = object$.ref;
+    final _$$$3 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$$2.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$$3.pointer,
     );
     return $ret.address == 0
         ? null
@@ -831,21 +838,23 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// numberOfComponents
   int get numberOfComponents {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.numberOfComponents',
       iOS: (false, (2, 0, 0)),
     );
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_numberOfComponents);
+    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_numberOfComponents);
   }
 
   /// numberOfRowsInComponent:
   int numberOfRowsInComponent(int component) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.numberOfRowsInComponent:',
       iOS: (false, (2, 0, 0)),
     );
     return _objc_msgSend_12hwf9n(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_numberOfRowsInComponent_,
       component,
     );
@@ -853,24 +862,27 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// reloadAllComponents
   void reloadAllComponents() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.reloadAllComponents',
       iOS: (false, (2, 0, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_reloadAllComponents);
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_reloadAllComponents);
   }
 
   /// reloadComponent:
   void reloadComponent(int component) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.reloadComponent:',
       iOS: (false, (2, 0, 0)),
     );
-    _objc_msgSend_4sp4xj(object$.ref.pointer, _sel_reloadComponent_, component);
+    _objc_msgSend_4sp4xj(_$$.pointer, _sel_reloadComponent_, component);
   }
 
   /// rowSizeForComponent:
   objc.CGSize rowSizeForComponent(int component) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.rowSizeForComponent:',
       iOS: (false, (2, 0, 0)),
@@ -879,12 +891,12 @@ extension UIPickerView$Methods on UIPickerView {
     objc.useMsgSendVariants
         ? _objc_msgSend_17w0i2jStret(
             $ptr,
-            object$.ref.pointer,
+            _$$.pointer,
             _sel_rowSizeForComponent_,
             component,
           )
         : $ptr.ref = _objc_msgSend_17w0i2j(
-            object$.ref.pointer,
+            _$$.pointer,
             _sel_rowSizeForComponent_,
             component,
           );
@@ -897,12 +909,13 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// selectRow:inComponent:animated:
   void selectRow(int row, {required int inComponent, required bool animated}) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.selectRow:inComponent:animated:',
       iOS: (false, (2, 0, 0)),
     );
     _objc_msgSend_cy4jud(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_selectRow_inComponent_animated_,
       row,
       inComponent,
@@ -912,12 +925,13 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// selectedRowInComponent:
   int selectedRowInComponent(int component) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.selectedRowInComponent:',
       iOS: (false, (2, 0, 0)),
     );
     return _objc_msgSend_12hwf9n(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_selectedRowInComponent_,
       component,
     );
@@ -925,65 +939,65 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// setDataSource:
   set dataSource(UIPickerViewDataSource? value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value?.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.setDataSource:',
       iOS: (false, (2, 0, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setDataSource_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setDelegate:
   set delegate(UIPickerViewDelegate? value) {
+    final _$$ = object$.ref;
+    final _$$$1 = value?.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.setDelegate:',
       iOS: (false, (2, 0, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_setDelegate_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setShowsSelectionIndicator:
   @Deprecated('This property has no effect on iOS 7 and later.')
   set showsSelectionIndicator(bool value) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.setShowsSelectionIndicator:',
       iOS: (false, (2, 0, 0)),
     );
-    _objc_msgSend_1s56lr9(
-      object$.ref.pointer,
-      _sel_setShowsSelectionIndicator_,
-      value,
-    );
+    _objc_msgSend_1s56lr9(_$$.pointer, _sel_setShowsSelectionIndicator_, value);
   }
 
   /// showsSelectionIndicator
   @Deprecated('This property has no effect on iOS 7 and later.')
   bool get showsSelectionIndicator {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.showsSelectionIndicator',
       iOS: (false, (2, 0, 0)),
     );
-    return _objc_msgSend_91o635(
-      object$.ref.pointer,
-      _sel_showsSelectionIndicator,
-    );
+    return _objc_msgSend_91o635(_$$.pointer, _sel_showsSelectionIndicator);
   }
 
   /// viewForRow:forComponent:
   objc.ObjCObject viewForRow(int row, {required int forComponent}) {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.viewForRow:forComponent:',
       iOS: (false, (2, 0, 0)),
     );
     final $ret = _objc_msgSend_1nzyvs1(
-      object$.ref.pointer,
+      _$$.pointer,
       _sel_viewForRow_forComponent_,
       row,
       forComponent,

--- a/pkgs/ffigen/test/native_objc_test/sdk_variable_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/sdk_variable_test_bindings.dart
@@ -214,69 +214,80 @@ extension type NSColorPicker._(objc.ObjCObject object$)
 extension NSColorPicker$Methods on NSColorPicker {
   /// alphaControlAddedOrRemoved:
   void alphaControlAddedOrRemoved(objc.ObjCObject? sender) {
-    final _$$ = object$.ref;
-    final _$$$1 = sender?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = sender?.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.alphaControlAddedOrRemoved:',
       iOS: (true, null),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_alphaControlAddedOrRemoved_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// attachColorList:
   void attachColorList(NSColorList colorList) {
-    final _$$ = object$.ref;
-    final _$$$1 = colorList.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = colorList.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.attachColorList:',
       iOS: (true, null),
     );
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_attachColorList_, _$$$1.pointer);
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_attachColorList_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// buttonToolTip
   objc.NSString get buttonToolTip {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.buttonToolTip',
       iOS: (true, null),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_buttonToolTip);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_buttonToolTip);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// colorPanel
   NSColorPanel get colorPanel {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal('NSColorPicker.colorPanel', iOS: (true, null));
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_colorPanel);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_colorPanel);
     return NSColorPanel.fromPointer($ret, retain: true, release: true);
   }
 
   /// detachColorList:
   void detachColorList(NSColorList colorList) {
-    final _$$ = object$.ref;
-    final _$$$1 = colorList.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = colorList.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.detachColorList:',
       iOS: (true, null),
     );
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_detachColorList_, _$$$1.pointer);
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_detachColorList_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// init
   NSColorPicker init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return NSColorPicker.fromPointer($ret, retain: false, release: true);
   }
 
@@ -285,17 +296,17 @@ extension NSColorPicker$Methods on NSColorPicker {
     int mask, {
     required NSColorPanel colorPanel,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = colorPanel.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = colorPanel.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.initWithPickerMask:colorPanel:',
       iOS: (true, null),
     );
     final $ret = _objc_msgSend_vbc8p4(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithPickerMask_colorPanel_,
       mask,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -307,32 +318,32 @@ extension NSColorPicker$Methods on NSColorPicker {
     NSImage newButtonImage, {
     required NSButtonCell in$,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = newButtonImage.ref;
-    final _$$$2 = in$.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = newButtonImage.ref;
+    final _$$ref$2 = in$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.insertNewButtonImage:in:',
       iOS: (true, null),
     );
     _objc_msgSend_pfv6jd(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_insertNewButtonImage_in_,
-      _$$$1.pointer,
-      _$$$2.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// minContentSize
   objc.CGSize get minContentSize {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.minContentSize',
       iOS: (true, null),
     );
     final $ptr = pkg_ffi.calloc<objc.CGSize>();
     objc.useMsgSendVariants
-        ? _objc_msgSend_1vdfkenStret($ptr, _$$.pointer, _sel_minContentSize)
-        : $ptr.ref = _objc_msgSend_1vdfken(_$$.pointer, _sel_minContentSize);
+        ? _objc_msgSend_1vdfkenStret($ptr, _$$ref.pointer, _sel_minContentSize)
+        : $ptr.ref = _objc_msgSend_1vdfken(_$$ref.pointer, _sel_minContentSize);
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<objc.CGSize>(),
       finalizer: pkg_ffi.calloc.nativeFree,
@@ -342,34 +353,37 @@ extension NSColorPicker$Methods on NSColorPicker {
 
   /// provideNewButtonImage
   NSImage get provideNewButtonImage {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.provideNewButtonImage',
       iOS: (true, null),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_provideNewButtonImage);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.pointer,
+      _sel_provideNewButtonImage,
+    );
     return NSImage.fromPointer($ret, retain: true, release: true);
   }
 
   /// setMode:
   void setMode(NSColorPanelMode mode) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal('NSColorPicker.setMode:', iOS: (true, null));
-    _objc_msgSend_190ea64(_$$.pointer, _sel_setMode_, mode.value);
+    _objc_msgSend_190ea64(_$$ref.pointer, _sel_setMode_, mode.value);
   }
 
   /// viewSizeChanged:
   void viewSizeChanged(objc.ObjCObject? sender) {
-    final _$$ = object$.ref;
-    final _$$$1 = sender?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = sender?.ref;
     objc.checkOsVersionInternal(
       'NSColorPicker.viewSizeChanged:',
       iOS: (true, null),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_viewSizeChanged_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 }
@@ -540,21 +554,25 @@ extension type NSTextList._(objc.ObjCObject object$)
 extension NSTextList$Methods on NSTextList {
   /// encodeWithCoder:
   void encodeWithCoder(objc.NSCoder coder) {
-    final _$$ = object$.ref;
-    final _$$$1 = coder.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_encodeWithCoder_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = coder.ref;
+    _objc_msgSend_xtuoz7(
+      _$$ref.pointer,
+      _sel_encodeWithCoder_,
+      _$$ref$1.pointer,
+    );
   }
 
   /// init
   NSTextList init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return NSTextList.fromPointer($ret, retain: false, release: true);
@@ -562,12 +580,12 @@ extension NSTextList$Methods on NSTextList {
 
   /// initWithCoder:
   NSTextList? initWithCoder(objc.NSCoder coder) {
-    final _$$ = object$.ref;
-    final _$$$1 = coder.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -579,17 +597,17 @@ extension NSTextList$Methods on NSTextList {
     objc.NSString markerFormat, {
     required int options,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = markerFormat.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = markerFormat.ref;
     objc.checkOsVersionInternal(
       'NSTextList.initWithMarkerFormat:options:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1k4kd9s(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithMarkerFormat_options_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
       options,
     );
     return NSTextList.fromPointer($ret, retain: false, release: true);
@@ -601,17 +619,17 @@ extension NSTextList$Methods on NSTextList {
     required int options,
     required int startingItemNumber,
   }) {
-    final _$$ = object$.ref;
-    final _$$$1 = markerFormat.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = markerFormat.ref;
     objc.checkOsVersionInternal(
       'NSTextList.initWithMarkerFormat:options:startingItemNumber:',
       iOS: (false, (16, 0, 0)),
       macOS: (false, (13, 0, 0)),
     );
     final $ret = _objc_msgSend_1bh1vl9(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithMarkerFormat_options_startingItemNumber_,
-      _$$$1.pointer,
+      _$$ref$1.pointer,
       options,
       startingItemNumber,
     );
@@ -620,36 +638,36 @@ extension NSTextList$Methods on NSTextList {
 
   /// isOrdered
   bool get isOrdered {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.isOrdered',
       iOS: (false, (16, 0, 0)),
       macOS: (false, (13, 0, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_isOrdered);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isOrdered);
   }
 
   /// listOptions
   int get listOptions {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.listOptions',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    return _objc_msgSend_exovb9(_$$.pointer, _sel_listOptions);
+    return _objc_msgSend_exovb9(_$$ref.pointer, _sel_listOptions);
   }
 
   /// markerForItemNumber:
   objc.NSString markerForItemNumber(int itemNumber) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.markerForItemNumber:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_qugqlf(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_markerForItemNumber_,
       itemNumber,
     );
@@ -658,36 +676,36 @@ extension NSTextList$Methods on NSTextList {
 
   /// markerFormat
   objc.NSString get markerFormat {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.markerFormat',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_markerFormat);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_markerFormat);
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// setStartingItemNumber:
   set startingItemNumber(int value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.setStartingItemNumber:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    _objc_msgSend_4sp4xj(_$$.pointer, _sel_setStartingItemNumber_, value);
+    _objc_msgSend_4sp4xj(_$$ref.pointer, _sel_setStartingItemNumber_, value);
   }
 
   /// startingItemNumber
   int get startingItemNumber {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSTextList.startingItemNumber',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_startingItemNumber);
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_startingItemNumber);
   }
 }
 
@@ -791,12 +809,12 @@ extension type UIPickerView._(objc.ObjCObject object$)
 extension UIPickerView$Methods on UIPickerView {
   /// dataSource
   UIPickerViewDataSource? get dataSource {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.dataSource',
       iOS: (false, (2, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_dataSource);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_dataSource);
     return $ret.address == 0
         ? null
         : UIPickerViewDataSource.fromPointer($ret, retain: true, release: true);
@@ -804,12 +822,12 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// delegate
   UIPickerViewDelegate? get delegate {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.delegate',
       iOS: (false, (2, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_delegate);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_delegate);
     return $ret.address == 0
         ? null
         : UIPickerViewDelegate.fromPointer($ret, retain: true, release: true);
@@ -817,19 +835,23 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// encodeWithCoder:
   void encodeWithCoder(objc.NSCoder coder) {
-    final _$$$2 = object$.ref;
-    final _$$$3 = coder.ref;
-    _objc_msgSend_xtuoz7(_$$$2.pointer, _sel_encodeWithCoder_, _$$$3.pointer);
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = coder.ref;
+    _objc_msgSend_xtuoz7(
+      _$$ref$2.pointer,
+      _sel_encodeWithCoder_,
+      _$$ref$3.pointer,
+    );
   }
 
   /// initWithCoder:
   UIPickerView? initWithCoder(objc.NSCoder coder) {
-    final _$$$2 = object$.ref;
-    final _$$$3 = coder.ref;
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      _$$$2.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      _$$$3.pointer,
+      _$$ref$3.pointer,
     );
     return $ret.address == 0
         ? null
@@ -838,23 +860,23 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// numberOfComponents
   int get numberOfComponents {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.numberOfComponents',
       iOS: (false, (2, 0, 0)),
     );
-    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_numberOfComponents);
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_numberOfComponents);
   }
 
   /// numberOfRowsInComponent:
   int numberOfRowsInComponent(int component) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.numberOfRowsInComponent:',
       iOS: (false, (2, 0, 0)),
     );
     return _objc_msgSend_12hwf9n(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_numberOfRowsInComponent_,
       component,
     );
@@ -862,27 +884,27 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// reloadAllComponents
   void reloadAllComponents() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.reloadAllComponents',
       iOS: (false, (2, 0, 0)),
     );
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_reloadAllComponents);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_reloadAllComponents);
   }
 
   /// reloadComponent:
   void reloadComponent(int component) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.reloadComponent:',
       iOS: (false, (2, 0, 0)),
     );
-    _objc_msgSend_4sp4xj(_$$.pointer, _sel_reloadComponent_, component);
+    _objc_msgSend_4sp4xj(_$$ref.pointer, _sel_reloadComponent_, component);
   }
 
   /// rowSizeForComponent:
   objc.CGSize rowSizeForComponent(int component) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.rowSizeForComponent:',
       iOS: (false, (2, 0, 0)),
@@ -891,12 +913,12 @@ extension UIPickerView$Methods on UIPickerView {
     objc.useMsgSendVariants
         ? _objc_msgSend_17w0i2jStret(
             $ptr,
-            _$$.pointer,
+            _$$ref.pointer,
             _sel_rowSizeForComponent_,
             component,
           )
         : $ptr.ref = _objc_msgSend_17w0i2j(
-            _$$.pointer,
+            _$$ref.pointer,
             _sel_rowSizeForComponent_,
             component,
           );
@@ -909,13 +931,13 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// selectRow:inComponent:animated:
   void selectRow(int row, {required int inComponent, required bool animated}) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.selectRow:inComponent:animated:',
       iOS: (false, (2, 0, 0)),
     );
     _objc_msgSend_cy4jud(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_selectRow_inComponent_animated_,
       row,
       inComponent,
@@ -925,13 +947,13 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// selectedRowInComponent:
   int selectedRowInComponent(int component) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.selectedRowInComponent:',
       iOS: (false, (2, 0, 0)),
     );
     return _objc_msgSend_12hwf9n(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_selectedRowInComponent_,
       component,
     );
@@ -939,65 +961,69 @@ extension UIPickerView$Methods on UIPickerView {
 
   /// setDataSource:
   set dataSource(UIPickerViewDataSource? value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.setDataSource:',
       iOS: (false, (2, 0, 0)),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setDataSource_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setDelegate:
   set delegate(UIPickerViewDelegate? value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value?.ref;
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.setDelegate:',
       iOS: (false, (2, 0, 0)),
     );
     _objc_msgSend_xtuoz7(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_setDelegate_,
-      _$$$1?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setShowsSelectionIndicator:
   @Deprecated('This property has no effect on iOS 7 and later.')
   set showsSelectionIndicator(bool value) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.setShowsSelectionIndicator:',
       iOS: (false, (2, 0, 0)),
     );
-    _objc_msgSend_1s56lr9(_$$.pointer, _sel_setShowsSelectionIndicator_, value);
+    _objc_msgSend_1s56lr9(
+      _$$ref.pointer,
+      _sel_setShowsSelectionIndicator_,
+      value,
+    );
   }
 
   /// showsSelectionIndicator
   @Deprecated('This property has no effect on iOS 7 and later.')
   bool get showsSelectionIndicator {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.showsSelectionIndicator',
       iOS: (false, (2, 0, 0)),
     );
-    return _objc_msgSend_91o635(_$$.pointer, _sel_showsSelectionIndicator);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_showsSelectionIndicator);
   }
 
   /// viewForRow:forComponent:
   objc.ObjCObject viewForRow(int row, {required int forComponent}) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'UIPickerView.viewForRow:forComponent:',
       iOS: (false, (2, 0, 0)),
     );
     final $ret = _objc_msgSend_1nzyvs1(
-      _$$.pointer,
+      _$$ref.pointer,
       _sel_viewForRow_forComponent_,
       row,
       forComponent,

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test_bindings.dart
@@ -26,8 +26,9 @@ external ffi.Pointer<ffi.Void> objc_autoreleasePoolPush();
 )
 external void _staticFuncConsumesArg(ffi.Pointer<objc.ObjCObjectImpl> a);
 
-void staticFuncConsumesArg(StaticFuncTestObj a) =>
-    _staticFuncConsumesArg(a.ref.retainAndReturnPointer());
+void staticFuncConsumesArg(StaticFuncTestObj a) {
+  return _staticFuncConsumesArg(a.ref.retainAndReturnPointer());
+}
 
 @ffi.Native<
   ffi.Pointer<objc.ObjCBlockImpl> Function(ffi.Pointer<objc.ObjCBlockImpl>)
@@ -38,11 +39,13 @@ external ffi.Pointer<objc.ObjCBlockImpl> _staticFuncOfBlock(
 
 objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> staticFuncOfBlock(
   objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> a,
-) => ObjCBlock_Int32_Int32.fromPointer(
-  _staticFuncOfBlock(a.ref.pointer),
-  retain: true,
-  release: true,
-);
+) {
+  return ObjCBlock_Int32_Int32.fromPointer(
+    _staticFuncOfBlock(a.ref.pointer),
+    retain: true,
+    release: true,
+  );
+}
 
 @ffi.Native<
   ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<objc.ObjCObjectImpl>)
@@ -51,14 +54,15 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncOfNullableObject(
   ffi.Pointer<objc.ObjCObjectImpl> a,
 );
 
-StaticFuncTestObj? staticFuncOfNullableObject(StaticFuncTestObj? a) =>
-    _staticFuncOfNullableObject(a?.ref.pointer ?? ffi.nullptr).address == 0
-    ? null
-    : StaticFuncTestObj.fromPointer(
-        _staticFuncOfNullableObject(a?.ref.pointer ?? ffi.nullptr),
-        retain: true,
-        release: true,
-      );
+StaticFuncTestObj? staticFuncOfNullableObject(StaticFuncTestObj? a) {
+  return _staticFuncOfNullableObject(a?.ref.pointer ?? ffi.nullptr).address == 0
+      ? null
+      : StaticFuncTestObj.fromPointer(
+          _staticFuncOfNullableObject(a?.ref.pointer ?? ffi.nullptr),
+          retain: true,
+          release: true,
+        );
+}
 
 @ffi.Native<
   ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<objc.ObjCObjectImpl>)
@@ -67,12 +71,13 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncOfObject(
   ffi.Pointer<objc.ObjCObjectImpl> a,
 );
 
-StaticFuncTestObj staticFuncOfObject(StaticFuncTestObj a) =>
-    StaticFuncTestObj.fromPointer(
-      _staticFuncOfObject(a.ref.pointer),
-      retain: true,
-      release: true,
-    );
+StaticFuncTestObj staticFuncOfObject(StaticFuncTestObj a) {
+  return StaticFuncTestObj.fromPointer(
+    _staticFuncOfObject(a.ref.pointer),
+    retain: true,
+    release: true,
+  );
+}
 
 @ffi.Native<ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Int32>)>(
   symbol: 'staticFuncReturnsRetained',
@@ -81,12 +86,13 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncReturnsRetained(
   ffi.Pointer<ffi.Int32> counter,
 );
 
-StaticFuncTestObj staticFuncReturnsRetained(ffi.Pointer<ffi.Int32> counter) =>
-    StaticFuncTestObj.fromPointer(
-      _staticFuncReturnsRetained(counter),
-      retain: false,
-      release: true,
-    );
+StaticFuncTestObj staticFuncReturnsRetained(ffi.Pointer<ffi.Int32> counter) {
+  return StaticFuncTestObj.fromPointer(
+    _staticFuncReturnsRetained(counter),
+    retain: false,
+    release: true,
+  );
+}
 
 @ffi.Native<
   ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<objc.ObjCObjectImpl>)
@@ -95,12 +101,13 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncReturnsRetainedArg(
   ffi.Pointer<objc.ObjCObjectImpl> a,
 );
 
-StaticFuncTestObj staticFuncReturnsRetainedArg(StaticFuncTestObj a) =>
-    StaticFuncTestObj.fromPointer(
-      _staticFuncReturnsRetainedArg(a.ref.pointer),
-      retain: false,
-      release: true,
-    );
+StaticFuncTestObj staticFuncReturnsRetainedArg(StaticFuncTestObj a) {
+  return StaticFuncTestObj.fromPointer(
+    _staticFuncReturnsRetainedArg(a.ref.pointer),
+    retain: false,
+    release: true,
+  );
+}
 
 /// Construction methods for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.
 abstract final class ObjCBlock_Int32_Int32 {
@@ -140,11 +147,9 @@ abstract final class ObjCBlock_Int32_Int32 {
     int Function(int) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (int arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -174,20 +179,21 @@ abstract final class ObjCBlock_Int32_Int32 {
 /// Call operator for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.
 extension ObjCBlock_Int32_Int32$CallExtension
     on objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> {
-  int call(int arg0) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Int32 Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Int32 arg0,
-              )
-            >
-          >()
-          .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
-        ref.pointer,
-        arg0,
-      );
+  int call(int arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Int32 Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Int32 arg0,
+            )
+          >
+        >()
+        .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }
 
 /// StaticFuncTestObj

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test_bindings.dart
@@ -27,8 +27,8 @@ external ffi.Pointer<ffi.Void> objc_autoreleasePoolPush();
 external void _staticFuncConsumesArg(ffi.Pointer<objc.ObjCObjectImpl> a);
 
 void staticFuncConsumesArg(StaticFuncTestObj a) {
-  final _$$ = a.ref;
-  return _staticFuncConsumesArg(_$$.retainAndReturnPointer());
+  final _$$ref = a.ref;
+  return _staticFuncConsumesArg(_$$ref.retainAndReturnPointer());
 }
 
 @ffi.Native<
@@ -41,9 +41,9 @@ external ffi.Pointer<objc.ObjCBlockImpl> _staticFuncOfBlock(
 objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> staticFuncOfBlock(
   objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> a,
 ) {
-  final _$$ = a.ref;
+  final _$$ref = a.ref;
   return ObjCBlock_Int32_Int32.fromPointer(
-    _staticFuncOfBlock(_$$.pointer),
+    _staticFuncOfBlock(_$$ref.pointer),
     retain: true,
     release: true,
   );
@@ -57,11 +57,12 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncOfNullableObject(
 );
 
 StaticFuncTestObj? staticFuncOfNullableObject(StaticFuncTestObj? a) {
-  final _$$ = a?.ref;
-  return _staticFuncOfNullableObject(_$$?.pointer ?? ffi.nullptr).address == 0
+  final _$$ref = a?.ref;
+  return _staticFuncOfNullableObject(_$$ref?.pointer ?? ffi.nullptr).address ==
+          0
       ? null
       : StaticFuncTestObj.fromPointer(
-          _staticFuncOfNullableObject(_$$?.pointer ?? ffi.nullptr),
+          _staticFuncOfNullableObject(_$$ref?.pointer ?? ffi.nullptr),
           retain: true,
           release: true,
         );
@@ -75,9 +76,9 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncOfObject(
 );
 
 StaticFuncTestObj staticFuncOfObject(StaticFuncTestObj a) {
-  final _$$ = a.ref;
+  final _$$ref = a.ref;
   return StaticFuncTestObj.fromPointer(
-    _staticFuncOfObject(_$$.pointer),
+    _staticFuncOfObject(_$$ref.pointer),
     retain: true,
     release: true,
   );
@@ -106,9 +107,9 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncReturnsRetainedArg(
 );
 
 StaticFuncTestObj staticFuncReturnsRetainedArg(StaticFuncTestObj a) {
-  final _$$ = a.ref;
+  final _$$ref = a.ref;
   return StaticFuncTestObj.fromPointer(
-    _staticFuncReturnsRetainedArg(_$$.pointer),
+    _staticFuncReturnsRetainedArg(_$$ref.pointer),
     retain: false,
     release: true,
   );
@@ -266,27 +267,30 @@ extension type StaticFuncTestObj._(objc.ObjCObject object$)
 extension StaticFuncTestObj$Methods on StaticFuncTestObj {
   /// dealloc
   void dealloc() {
-    final _$$ = object$.ref;
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_dealloc);
   }
 
   /// init
   StaticFuncTestObj init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'StaticFuncTestObj.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return StaticFuncTestObj.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCounter:
   StaticFuncTestObj initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test_bindings.dart
@@ -27,7 +27,8 @@ external ffi.Pointer<ffi.Void> objc_autoreleasePoolPush();
 external void _staticFuncConsumesArg(ffi.Pointer<objc.ObjCObjectImpl> a);
 
 void staticFuncConsumesArg(StaticFuncTestObj a) {
-  return _staticFuncConsumesArg(a.ref.retainAndReturnPointer());
+  final _$$ = a.ref;
+  return _staticFuncConsumesArg(_$$.retainAndReturnPointer());
 }
 
 @ffi.Native<
@@ -40,8 +41,9 @@ external ffi.Pointer<objc.ObjCBlockImpl> _staticFuncOfBlock(
 objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> staticFuncOfBlock(
   objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> a,
 ) {
+  final _$$ = a.ref;
   return ObjCBlock_Int32_Int32.fromPointer(
-    _staticFuncOfBlock(a.ref.pointer),
+    _staticFuncOfBlock(_$$.pointer),
     retain: true,
     release: true,
   );
@@ -55,10 +57,11 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncOfNullableObject(
 );
 
 StaticFuncTestObj? staticFuncOfNullableObject(StaticFuncTestObj? a) {
-  return _staticFuncOfNullableObject(a?.ref.pointer ?? ffi.nullptr).address == 0
+  final _$$ = a?.ref;
+  return _staticFuncOfNullableObject(_$$?.pointer ?? ffi.nullptr).address == 0
       ? null
       : StaticFuncTestObj.fromPointer(
-          _staticFuncOfNullableObject(a?.ref.pointer ?? ffi.nullptr),
+          _staticFuncOfNullableObject(_$$?.pointer ?? ffi.nullptr),
           retain: true,
           release: true,
         );
@@ -72,8 +75,9 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncOfObject(
 );
 
 StaticFuncTestObj staticFuncOfObject(StaticFuncTestObj a) {
+  final _$$ = a.ref;
   return StaticFuncTestObj.fromPointer(
-    _staticFuncOfObject(a.ref.pointer),
+    _staticFuncOfObject(_$$.pointer),
     retain: true,
     release: true,
   );
@@ -102,8 +106,9 @@ external ffi.Pointer<objc.ObjCObjectImpl> _staticFuncReturnsRetainedArg(
 );
 
 StaticFuncTestObj staticFuncReturnsRetainedArg(StaticFuncTestObj a) {
+  final _$$ = a.ref;
   return StaticFuncTestObj.fromPointer(
-    _staticFuncReturnsRetainedArg(a.ref.pointer),
+    _staticFuncReturnsRetainedArg(_$$.pointer),
     retain: false,
     release: true,
   );
@@ -261,27 +266,27 @@ extension type StaticFuncTestObj._(objc.ObjCObject object$)
 extension StaticFuncTestObj$Methods on StaticFuncTestObj {
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_dealloc);
+    final _$$ = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
   }
 
   /// init
   StaticFuncTestObj init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'StaticFuncTestObj.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return StaticFuncTestObj.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCounter:
   StaticFuncTestObj initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );

--- a/pkgs/ffigen/test/native_objc_test/static_func_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_test_bindings.dart
@@ -226,11 +226,9 @@ abstract final class ObjCBlock_Int32_Int32 {
     int Function(int) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (int arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (int arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -260,20 +258,21 @@ abstract final class ObjCBlock_Int32_Int32 {
 /// Call operator for `objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)>`.
 extension ObjCBlock_Int32_Int32$CallExtension
     on objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> {
-  int call(int arg0) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Int32 Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Int32 arg0,
-              )
-            >
-          >()
-          .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
-        ref.pointer,
-        arg0,
-      );
+  int call(int arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Int32 Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Int32 arg0,
+            )
+          >
+        >()
+        .asFunction<int Function(ffi.Pointer<objc.ObjCBlockImpl>, int)>()(
+      ref.pointer,
+      arg0,
+    );
+  }
 }
 
 /// StaticFuncTestObj

--- a/pkgs/ffigen/test/native_objc_test/static_func_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_test_bindings.dart
@@ -61,7 +61,8 @@ class StaticFuncTestObjCLibrary {
       .asFunction<ffi.Pointer<ffi.Void> Function()>();
 
   void staticFuncConsumesArg(StaticFuncTestObj a) {
-    return _staticFuncConsumesArg(a.ref.retainAndReturnPointer());
+    final _$$ = a.ref;
+    return _staticFuncConsumesArg(_$$.retainAndReturnPointer());
   }
 
   late final _staticFuncConsumesArgPtr =
@@ -74,8 +75,9 @@ class StaticFuncTestObjCLibrary {
   objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> staticFuncOfBlock(
     objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> a,
   ) {
+    final _$$ = a.ref;
     return ObjCBlock_Int32_Int32.fromPointer(
-      _staticFuncOfBlock(a.ref.pointer),
+      _staticFuncOfBlock(_$$.pointer),
       retain: true,
       release: true,
     );
@@ -97,11 +99,11 @@ class StaticFuncTestObjCLibrary {
       >();
 
   StaticFuncTestObj? staticFuncOfNullableObject(StaticFuncTestObj? a) {
-    return _staticFuncOfNullableObject(a?.ref.pointer ?? ffi.nullptr).address ==
-            0
+    final _$$ = a?.ref;
+    return _staticFuncOfNullableObject(_$$?.pointer ?? ffi.nullptr).address == 0
         ? null
         : StaticFuncTestObj.fromPointer(
-            _staticFuncOfNullableObject(a?.ref.pointer ?? ffi.nullptr),
+            _staticFuncOfNullableObject(_$$?.pointer ?? ffi.nullptr),
             retain: true,
             release: true,
           );
@@ -123,8 +125,9 @@ class StaticFuncTestObjCLibrary {
       >();
 
   StaticFuncTestObj staticFuncOfObject(StaticFuncTestObj a) {
+    final _$$ = a.ref;
     return StaticFuncTestObj.fromPointer(
-      _staticFuncOfObject(a.ref.pointer),
+      _staticFuncOfObject(_$$.pointer),
       retain: true,
       release: true,
     );
@@ -165,8 +168,9 @@ class StaticFuncTestObjCLibrary {
       >();
 
   StaticFuncTestObj staticFuncReturnsRetainedArg(StaticFuncTestObj a) {
+    final _$$ = a.ref;
     return StaticFuncTestObj.fromPointer(
-      _staticFuncReturnsRetainedArg(a.ref.pointer),
+      _staticFuncReturnsRetainedArg(_$$.pointer),
       retain: false,
       release: true,
     );
@@ -340,27 +344,27 @@ extension type StaticFuncTestObj._(objc.ObjCObject object$)
 extension StaticFuncTestObj$Methods on StaticFuncTestObj {
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_dealloc);
+    final _$$ = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
   }
 
   /// init
   StaticFuncTestObj init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'StaticFuncTestObj.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return StaticFuncTestObj.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCounter:
   StaticFuncTestObj initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
+    final _$$ = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      object$.ref.retainAndReturnPointer(),
+      _$$.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );

--- a/pkgs/ffigen/test/native_objc_test/static_func_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_test_bindings.dart
@@ -61,8 +61,8 @@ class StaticFuncTestObjCLibrary {
       .asFunction<ffi.Pointer<ffi.Void> Function()>();
 
   void staticFuncConsumesArg(StaticFuncTestObj a) {
-    final _$$ = a.ref;
-    return _staticFuncConsumesArg(_$$.retainAndReturnPointer());
+    final _$$ref = a.ref;
+    return _staticFuncConsumesArg(_$$ref.retainAndReturnPointer());
   }
 
   late final _staticFuncConsumesArgPtr =
@@ -75,9 +75,9 @@ class StaticFuncTestObjCLibrary {
   objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> staticFuncOfBlock(
     objc.ObjCBlock<ffi.Int32 Function(ffi.Int32)> a,
   ) {
-    final _$$ = a.ref;
+    final _$$ref = a.ref;
     return ObjCBlock_Int32_Int32.fromPointer(
-      _staticFuncOfBlock(_$$.pointer),
+      _staticFuncOfBlock(_$$ref.pointer),
       retain: true,
       release: true,
     );
@@ -99,11 +99,14 @@ class StaticFuncTestObjCLibrary {
       >();
 
   StaticFuncTestObj? staticFuncOfNullableObject(StaticFuncTestObj? a) {
-    final _$$ = a?.ref;
-    return _staticFuncOfNullableObject(_$$?.pointer ?? ffi.nullptr).address == 0
+    final _$$ref = a?.ref;
+    return _staticFuncOfNullableObject(
+              _$$ref?.pointer ?? ffi.nullptr,
+            ).address ==
+            0
         ? null
         : StaticFuncTestObj.fromPointer(
-            _staticFuncOfNullableObject(_$$?.pointer ?? ffi.nullptr),
+            _staticFuncOfNullableObject(_$$ref?.pointer ?? ffi.nullptr),
             retain: true,
             release: true,
           );
@@ -125,9 +128,9 @@ class StaticFuncTestObjCLibrary {
       >();
 
   StaticFuncTestObj staticFuncOfObject(StaticFuncTestObj a) {
-    final _$$ = a.ref;
+    final _$$ref = a.ref;
     return StaticFuncTestObj.fromPointer(
-      _staticFuncOfObject(_$$.pointer),
+      _staticFuncOfObject(_$$ref.pointer),
       retain: true,
       release: true,
     );
@@ -168,9 +171,9 @@ class StaticFuncTestObjCLibrary {
       >();
 
   StaticFuncTestObj staticFuncReturnsRetainedArg(StaticFuncTestObj a) {
-    final _$$ = a.ref;
+    final _$$ref = a.ref;
     return StaticFuncTestObj.fromPointer(
-      _staticFuncReturnsRetainedArg(_$$.pointer),
+      _staticFuncReturnsRetainedArg(_$$ref.pointer),
       retain: false,
       release: true,
     );
@@ -344,27 +347,30 @@ extension type StaticFuncTestObj._(objc.ObjCObject object$)
 extension StaticFuncTestObj$Methods on StaticFuncTestObj {
   /// dealloc
   void dealloc() {
-    final _$$ = object$.ref;
-    _objc_msgSend_1pl9qdv(_$$.pointer, _sel_dealloc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_dealloc);
   }
 
   /// init
   StaticFuncTestObj init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'StaticFuncTestObj.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return StaticFuncTestObj.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCounter:
   StaticFuncTestObj initWithCounter(ffi.Pointer<ffi.Int32> _counter) {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_129vhbw(
-      _$$.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCounter_,
       _counter,
     );

--- a/pkgs/ffigen/test/native_objc_test/string_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/string_test_bindings.dart
@@ -59,13 +59,13 @@ extension type StringUtil._(objc.ObjCObject object$)
     objc.NSString a, {
     required objc.NSString with$,
   }) {
-    final _$$ = a.ref;
-    final _$$$1 = with$.ref;
+    final _$$ref = a.ref;
+    final _$$ref$1 = with$.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_StringUtil,
       _sel_strConcat_with_,
-      _$$.pointer,
-      _$$$1.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -77,13 +77,16 @@ extension type StringUtil._(objc.ObjCObject object$)
 extension StringUtil$Methods on StringUtil {
   /// init
   StringUtil init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'StringUtil.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return StringUtil.fromPointer($ret, retain: false, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/string_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/string_test_bindings.dart
@@ -59,11 +59,13 @@ extension type StringUtil._(objc.ObjCObject object$)
     objc.NSString a, {
     required objc.NSString with$,
   }) {
+    final _$$ = a.ref;
+    final _$$$1 = with$.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_StringUtil,
       _sel_strConcat_with_,
-      a.ref.pointer,
-      with$.ref.pointer,
+      _$$.pointer,
+      _$$$1.pointer,
     );
     return objc.NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -75,15 +77,13 @@ extension type StringUtil._(objc.ObjCObject object$)
 extension StringUtil$Methods on StringUtil {
   /// init
   StringUtil init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'StringUtil.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return StringUtil.fromPointer($ret, retain: false, release: true);
   }
 }

--- a/pkgs/ffigen/test/native_objc_test/swift_class_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/swift_class_test_bindings.dart
@@ -61,26 +61,26 @@ extension type MySwiftClass._(objc.ObjCObject object$)
 extension MySwiftClass$Methods on MySwiftClass {
   /// getValue
   int getValue() {
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_getValue);
+    final _$$ = object$.ref;
+    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_getValue);
   }
 
   /// init
   MySwiftClass init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'MySwiftClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return MySwiftClass.fromPointer($ret, retain: false, release: true);
   }
 
   /// setValueWithX:
   void setValueWithX(int x) {
-    _objc_msgSend_4sp4xj(object$.ref.pointer, _sel_setValueWithX_, x);
+    final _$$ = object$.ref;
+    _objc_msgSend_4sp4xj(_$$.pointer, _sel_setValueWithX_, x);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/swift_class_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/swift_class_test_bindings.dart
@@ -61,26 +61,29 @@ extension type MySwiftClass._(objc.ObjCObject object$)
 extension MySwiftClass$Methods on MySwiftClass {
   /// getValue
   int getValue() {
-    final _$$ = object$.ref;
-    return _objc_msgSend_1hz7y9r(_$$.pointer, _sel_getValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_getValue);
   }
 
   /// init
   MySwiftClass init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'MySwiftClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return MySwiftClass.fromPointer($ret, retain: false, release: true);
   }
 
   /// setValueWithX:
   void setValueWithX(int x) {
-    final _$$ = object$.ref;
-    _objc_msgSend_4sp4xj(_$$.pointer, _sel_setValueWithX_, x);
+    final _$$ref = object$.ref;
+    _objc_msgSend_4sp4xj(_$$ref.pointer, _sel_setValueWithX_, x);
   }
 }
 

--- a/pkgs/ffigen/test/native_objc_test/typedef_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/typedef_test_bindings.dart
@@ -61,31 +61,28 @@ extension type AnotherClass._(objc.ObjCObject object$)
 extension AnotherClass$Methods on AnotherClass {
   /// init
   AnotherClass init() {
+    final _$$ = object$.ref;
     objc.checkOsVersionInternal(
       'AnotherClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
     return AnotherClass.fromPointer($ret, retain: false, release: true);
   }
 
   /// property
   DartSomeClassPtr get property {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_property);
+    final _$$ = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_property);
     return SomeClass.fromPointer($ret, retain: true, release: true);
   }
 
   /// setProperty:
   set property(DartSomeClassPtr value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setProperty_,
-      value.ref.pointer,
-    );
+    final _$$ = object$.ref;
+    final _$$$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setProperty_, _$$$1.pointer);
   }
 }
 
@@ -144,13 +141,14 @@ extension type SomeClass._(objc.ObjCObject object$)
 extension SomeClass$Methods on SomeClass {
   /// init
   SomeClass init() {
+    final _$$$1 = object$.ref;
     objc.checkOsVersionInternal(
       'SomeClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$$1.retainAndReturnPointer(),
       _sel_init,
     );
     return SomeClass.fromPointer($ret, retain: false, release: true);

--- a/pkgs/ffigen/test/native_objc_test/typedef_test_bindings.dart
+++ b/pkgs/ffigen/test/native_objc_test/typedef_test_bindings.dart
@@ -61,28 +61,31 @@ extension type AnotherClass._(objc.ObjCObject object$)
 extension AnotherClass$Methods on AnotherClass {
   /// init
   AnotherClass init() {
-    final _$$ = object$.ref;
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'AnotherClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(_$$.retainAndReturnPointer(), _sel_init);
+    final $ret = _objc_msgSend_151sglz(
+      _$$ref.retainAndReturnPointer(),
+      _sel_init,
+    );
     return AnotherClass.fromPointer($ret, retain: false, release: true);
   }
 
   /// property
   DartSomeClassPtr get property {
-    final _$$ = object$.ref;
-    final $ret = _objc_msgSend_151sglz(_$$.pointer, _sel_property);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_property);
     return SomeClass.fromPointer($ret, retain: true, release: true);
   }
 
   /// setProperty:
   set property(DartSomeClassPtr value) {
-    final _$$ = object$.ref;
-    final _$$$1 = value.ref;
-    _objc_msgSend_xtuoz7(_$$.pointer, _sel_setProperty_, _$$$1.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setProperty_, _$$ref$1.pointer);
   }
 }
 
@@ -141,14 +144,14 @@ extension type SomeClass._(objc.ObjCObject object$)
 extension SomeClass$Methods on SomeClass {
   /// init
   SomeClass init() {
-    final _$$$1 = object$.ref;
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'SomeClass.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      _$$$1.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return SomeClass.fromPointer($ret, retain: false, release: true);

--- a/pkgs/ffigen/test/native_test/_expected_native_test_bindings.dart
+++ b/pkgs/ffigen/test/native_test/_expected_native_test_bindings.dart
@@ -55,8 +55,9 @@ external int Function1UintPtr(int x);
 @ffi.Native<ffi.UnsignedInt Function(ffi.UnsignedInt)>(symbol: 'funcWithEnum1')
 external int _funcWithEnum1(int value);
 
-Enum1 funcWithEnum1(Enum1 value) =>
-    Enum1.fromValue(_funcWithEnum1(value.value));
+Enum1 funcWithEnum1(Enum1 value) {
+  return Enum1.fromValue(_funcWithEnum1(value.value));
+}
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.UnsignedInt)>()
 external int funcWithEnum2(int value);

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -732,23 +732,26 @@ extension type DOBJCObservation._(objc.ObjCObject object$)
 extension DOBJCObservation$Methods on DOBJCObservation {
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_dealloc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_dealloc);
   }
 
   /// debugObserver
   ffi.Pointer<ffi.Void> debugObserver() {
-    return _objc_msgSend_6ex6p5(object$.ref.pointer, _sel_debugObserver);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_6ex6p5(_$$ref.pointer, _sel_debugObserver);
   }
 
   /// init
   DOBJCObservation init() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'DOBJCObservation.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_init,
     );
     return DOBJCObservation.fromPointer($ret, retain: false, release: true);
@@ -762,12 +765,16 @@ extension DOBJCObservation$Methods on DOBJCObservation {
     required int options,
     required ffi.Pointer<ffi.Void> context,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = keyPath.ref;
+    final _$$ref$2 = ofObject.ref;
+    final _$$ref$3 = withObserver.ref;
     final $ret = _objc_msgSend_1jiinfj(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initForKeyPath_ofObject_withObserver_options_context_,
-      keyPath.ref.pointer,
-      ofObject.ref.pointer,
-      withObserver.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
+      _$$ref$3.pointer,
       options,
       context,
     );
@@ -776,7 +783,8 @@ extension DOBJCObservation$Methods on DOBJCObservation {
 
   /// remove
   void remove() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_remove);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_remove);
   }
 }
 
@@ -835,10 +843,11 @@ extension type DartInputStreamAdapter._(objc.ObjCObject object$)
 
   /// inputStreamWithData:
   static DartInputStreamAdapter? inputStreamWithData(NSData data) {
+    final _$$ref = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_DOBJCDartInputStreamAdapter,
       _sel_inputStreamWithData_,
-      data.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -847,10 +856,11 @@ extension type DartInputStreamAdapter._(objc.ObjCObject object$)
 
   /// inputStreamWithFileAtPath:
   static DartInputStreamAdapter? inputStreamWithFileAtPath(NSString path) {
+    final _$$ref = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_DOBJCDartInputStreamAdapter,
       _sel_inputStreamWithFileAtPath_,
-      path.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -876,6 +886,7 @@ extension type DartInputStreamAdapter._(objc.ObjCObject object$)
 
   /// inputStreamWithURL:
   static DartInputStreamAdapter? inputStreamWithURL(NSURL url) {
+    final _$$ref = url.ref;
     objc.checkOsVersionInternal(
       'DOBJCDartInputStreamAdapter.inputStreamWithURL:',
       iOS: (false, (4, 0, 0)),
@@ -884,7 +895,7 @@ extension type DartInputStreamAdapter._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_DOBJCDartInputStreamAdapter,
       _sel_inputStreamWithURL_,
-      url.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -911,22 +922,25 @@ extension type DartInputStreamAdapter._(objc.ObjCObject object$)
 extension DartInputStreamAdapter$Methods on DartInputStreamAdapter {
   /// addData:
   int addData(NSData data) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
     return _objc_msgSend_1vd1c5m(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addData_,
-      data.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// init
   DartInputStreamAdapter init() {
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'DOBJCDartInputStreamAdapter.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return DartInputStreamAdapter.fromPointer(
@@ -938,10 +952,12 @@ extension DartInputStreamAdapter$Methods on DartInputStreamAdapter {
 
   /// initWithData:
   DartInputStreamAdapter initWithData(NSData data) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithData_,
-      data.ref.pointer,
+      _$$ref$1.pointer,
     );
     return DartInputStreamAdapter.fromPointer(
       $ret,
@@ -952,10 +968,12 @@ extension DartInputStreamAdapter$Methods on DartInputStreamAdapter {
 
   /// initWithFileAtPath:
   DartInputStreamAdapter? initWithFileAtPath(NSString path) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithFileAtPath_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -968,15 +986,17 @@ extension DartInputStreamAdapter$Methods on DartInputStreamAdapter {
 
   /// initWithURL:
   DartInputStreamAdapter? initWithURL(NSURL url) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     objc.checkOsVersionInternal(
       'DOBJCDartInputStreamAdapter.initWithURL:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithURL_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -989,33 +1009,31 @@ extension DartInputStreamAdapter$Methods on DartInputStreamAdapter {
 
   /// setDone
   void setDone() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_setDone);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_setDone);
   }
 
   /// setError:
   void setError(NSError error) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setError_,
-      error.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = error.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setError_, _$$ref$1.pointer);
   }
 
   /// stream:handleEvent:
   void stream(NSStream aStream, {required int handleEvent}) {
-    if (!objc.respondsToSelector(
-      object$.ref.pointer,
-      _sel_stream_handleEvent_,
-    )) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aStream.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_stream_handleEvent_)) {
       throw objc.UnimplementedOptionalMethodException(
         'DOBJCDartInputStreamAdapter',
         'stream:handleEvent:',
       );
     }
     _objc_msgSend_3l8zum(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stream_handleEvent_,
-      aStream.ref.pointer,
+      _$$ref$1.pointer,
       handleEvent,
     );
   }
@@ -1080,10 +1098,11 @@ extension type DartInputStreamAdapterWeakHolder._(objc.ObjCObject object$)
   static DartInputStreamAdapterWeakHolder holderWithInputStreamAdapter(
     DartInputStreamAdapter adapter,
   ) {
+    final _$$ref = adapter.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_DOBJCDartInputStreamAdapterWeakHolder,
       _sel_holderWithInputStreamAdapter_,
-      adapter.ref.pointer,
+      _$$ref.pointer,
     );
     return DartInputStreamAdapterWeakHolder.fromPointer(
       $ret,
@@ -1113,7 +1132,8 @@ extension DartInputStreamAdapterWeakHolder$Methods
     on DartInputStreamAdapterWeakHolder {
   /// adapter
   DartInputStreamAdapter get adapter {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_adapter);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_adapter);
     return DartInputStreamAdapter.fromPointer(
       $ret,
       retain: true,
@@ -1123,13 +1143,14 @@ extension DartInputStreamAdapterWeakHolder$Methods
 
   /// init
   DartInputStreamAdapterWeakHolder init() {
+    final _$$ref$2 = object$.ref;
     objc.checkOsVersionInternal(
       'DOBJCDartInputStreamAdapterWeakHolder.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_init,
     );
     return DartInputStreamAdapterWeakHolder.fromPointer(
@@ -1195,15 +1216,17 @@ extension type DartProtocol._(objc.ObjCObject object$)
 extension DartProtocol$Methods on DartProtocol {
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_dealloc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_dealloc);
   }
 
   /// getDOBJCDartProtocolMethodForSelector:
   objc.ObjCObject getDOBJCDartProtocolMethodForSelector(
     ffi.Pointer<objc.ObjCSelector> sel,
   ) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_3ctkt6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getDOBJCDartProtocolMethodForSelector_,
       sel,
     );
@@ -1212,13 +1235,14 @@ extension DartProtocol$Methods on DartProtocol {
 
   /// init
   DartProtocol init() {
+    final _$$ref$3 = object$.ref;
     objc.checkOsVersionInternal(
       'DOBJCDartProtocol.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$3.retainAndReturnPointer(),
       _sel_init,
     );
     return DartProtocol.fromPointer($ret, retain: false, release: true);
@@ -1229,10 +1253,12 @@ extension DartProtocol$Methods on DartProtocol {
     DartProtocolBuilder builder, {
     required int withDisposePort,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = builder.ref;
     final $ret = _objc_msgSend_dbvvll(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initDOBJCDartProtocolFromDartProtocolBuilder_withDisposePort_,
-      builder.ref.pointer,
+      _$$ref$1.pointer,
       withDisposePort,
     );
     return DartProtocol.fromPointer($ret, retain: false, release: true);
@@ -1301,17 +1327,16 @@ extension type DartProtocolBuilder._(objc.ObjCObject object$)
 extension DartProtocolBuilder$Methods on DartProtocolBuilder {
   /// addProtocol:
   void addProtocol(Protocol protocol) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_addProtocol_,
-      protocol.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = protocol.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_addProtocol_, _$$ref$1.pointer);
   }
 
   /// buildInstance:
   DartProtocol buildInstance(int port) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1ya1kjn(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_buildInstance_,
       port,
     );
@@ -1325,8 +1350,9 @@ extension DartProtocolBuilder$Methods on DartProtocolBuilder {
     required ffi.Pointer<ffi.Void> withTrampoline,
     required ffi.Pointer<ffi.Char> withSignature,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_1s2gdyk(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_implementMethod_withBlock_withTrampoline_withSignature_,
       sel,
       withBlock,
@@ -1337,13 +1363,14 @@ extension DartProtocolBuilder$Methods on DartProtocolBuilder {
 
   /// init
   DartProtocolBuilder init() {
+    final _$$ref$4 = object$.ref;
     objc.checkOsVersionInternal(
       'DOBJCDartProtocolBuilder.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$4.retainAndReturnPointer(),
       _sel_init,
     );
     return DartProtocolBuilder.fromPointer($ret, retain: false, release: true);
@@ -1351,8 +1378,9 @@ extension DartProtocolBuilder$Methods on DartProtocolBuilder {
 
   /// initWithClassName:
   DartProtocolBuilder initWithClassName(ffi.Pointer<ffi.Char> name) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_56zxyn(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithClassName_,
       name,
     );
@@ -1361,7 +1389,8 @@ extension DartProtocolBuilder$Methods on DartProtocolBuilder {
 
   /// registerClass
   void registerClass() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_registerClass);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_registerClass);
   }
 }
 
@@ -1447,30 +1476,33 @@ extension type NSArray._(objc.ObjCObject object$)
 
   /// arrayWithArray:
   static NSArray arrayWithArray(NSArray array) {
+    final _$$ref = array.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSArray,
       _sel_arrayWithArray_,
-      array.ref.pointer,
+      _$$ref.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// arrayWithObject:
   static NSArray arrayWithObject(objc.ObjCObject anObject) {
+    final _$$ref = anObject.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSArray,
       _sel_arrayWithObject_,
-      anObject.ref.pointer,
+      _$$ref.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// arrayWithObjects:
   static NSArray arrayWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref = firstObj.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSArray,
       _sel_arrayWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
@@ -1507,7 +1539,8 @@ extension type NSArray._(objc.ObjCObject object$)
 extension NSArray$Methods on NSArray {
   /// count
   int get count {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_count);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_count);
   }
 
   /// countByEnumeratingWithState:objects:count:
@@ -1516,8 +1549,9 @@ extension NSArray$Methods on NSArray {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects,
     required int count,
   }) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_1b5ysjl(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_countByEnumeratingWithState_objects_count_,
       state,
       objects,
@@ -1527,22 +1561,25 @@ extension NSArray$Methods on NSArray {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// init
   NSArray init() {
+    final _$$ref$5 = object$.ref;
     objc.checkOsVersionInternal(
       'NSArray.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$5.retainAndReturnPointer(),
       _sel_init,
     );
     return NSArray.fromPointer($ret, retain: false, release: true);
@@ -1550,20 +1587,24 @@ extension NSArray$Methods on NSArray {
 
   /// initWithArray:
   NSArray initWithArray(NSArray array) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = array.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
   NSArray initWithArray$1(NSArray array, {required bool copyItems}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = array.ref;
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithArray_copyItems_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
       copyItems,
     );
     return NSArray.fromPointer($ret, retain: false, release: true);
@@ -1571,10 +1612,12 @@ extension NSArray$Methods on NSArray {
 
   /// initWithCoder:
   NSArray? initWithCoder(NSCoder coder) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -1583,10 +1626,12 @@ extension NSArray$Methods on NSArray {
 
   /// initWithObjects:
   NSArray initWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = firstObj.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: false, release: true);
   }
@@ -1596,8 +1641,9 @@ extension NSArray$Methods on NSArray {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required int count,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_zmbtbd(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjects_count_,
       objects,
       count,
@@ -1607,8 +1653,9 @@ extension NSArray$Methods on NSArray {
 
   /// objectAtIndex:
   objc.ObjCObject objectAtIndex(int index) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectAtIndex_,
       index,
     );
@@ -1680,6 +1727,7 @@ extension type NSAttributedString._(objc.ObjCObject object$)
   static NSAttributedString localizedAttributedStringWithFormat(
     NSAttributedString format,
   ) {
+    final _$$ref = format.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.localizedAttributedStringWithFormat:',
       iOS: (false, (15, 0, 0)),
@@ -1688,7 +1736,7 @@ extension type NSAttributedString._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSAttributedString,
       _sel_localizedAttributedStringWithFormat_,
-      format.ref.pointer,
+      _$$ref.pointer,
     );
     return NSAttributedString.fromPointer($ret, retain: true, release: true);
   }
@@ -1701,6 +1749,8 @@ extension type NSAttributedString._(objc.ObjCObject object$)
     NSAttributedString format, {
     required NSDictionary context,
   }) {
+    final _$$ref = format.ref;
+    final _$$ref$1 = context.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.localizedAttributedStringWithFormat:context:',
       iOS: (false, (17, 0, 0)),
@@ -1709,8 +1759,8 @@ extension type NSAttributedString._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_15qeuct(
       _class_NSAttributedString,
       _sel_localizedAttributedStringWithFormat_context_,
-      format.ref.pointer,
-      context.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSAttributedString.fromPointer($ret, retain: true, release: true);
   }
@@ -1723,6 +1773,7 @@ extension type NSAttributedString._(objc.ObjCObject object$)
     NSAttributedString format, {
     required int options,
   }) {
+    final _$$ref = format.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.localizedAttributedStringWithFormat:options:',
       iOS: (false, (15, 0, 0)),
@@ -1731,7 +1782,7 @@ extension type NSAttributedString._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_s058d2(
       _class_NSAttributedString,
       _sel_localizedAttributedStringWithFormat_options_,
-      format.ref.pointer,
+      _$$ref.pointer,
       options,
     );
     return NSAttributedString.fromPointer($ret, retain: true, release: true);
@@ -1746,6 +1797,8 @@ extension type NSAttributedString._(objc.ObjCObject object$)
     required int options,
     required NSDictionary context,
   }) {
+    final _$$ref = format.ref;
+    final _$$ref$1 = context.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.localizedAttributedStringWithFormat:options:context:',
       iOS: (false, (17, 0, 0)),
@@ -1754,9 +1807,9 @@ extension type NSAttributedString._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_187k8ck(
       _class_NSAttributedString,
       _sel_localizedAttributedStringWithFormat_options_context_,
-      format.ref.pointer,
+      _$$ref.pointer,
       options,
-      context.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSAttributedString.fromPointer($ret, retain: true, release: true);
   }
@@ -1785,13 +1838,14 @@ extension NSAttributedString$Methods on NSAttributedString {
     int location, {
     required ffi.Pointer<NSRange> effectiveRange,
   }) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.attributesAtIndex:effectiveRange:',
       iOS: (false, (3, 2, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1776v9k(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_attributesAtIndex_effectiveRange_,
       location,
       effectiveRange,
@@ -1801,22 +1855,25 @@ extension NSAttributedString$Methods on NSAttributedString {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$2.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$3.pointer,
     );
   }
 
   /// init
   NSAttributedString init() {
+    final _$$ref$6 = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$6.retainAndReturnPointer(),
       _sel_init,
     );
     return NSAttributedString.fromPointer($ret, retain: false, release: true);
@@ -1824,25 +1881,29 @@ extension NSAttributedString$Methods on NSAttributedString {
 
   /// initWithAttributedString:
   NSAttributedString initWithAttributedString(NSAttributedString attrStr) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = attrStr.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.initWithAttributedString:',
       iOS: (false, (3, 2, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithAttributedString_,
-      attrStr.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSAttributedString.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSAttributedString? initWithCoder(NSCoder coder) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$3.pointer,
     );
     return $ret.address == 0
         ? null
@@ -1858,6 +1919,10 @@ extension NSAttributedString$Methods on NSAttributedString {
     NSAttributedStringMarkdownParsingOptions? options,
     NSURL? baseURL,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = markdownFile.ref;
+    final _$$ref$2 = options?.ref;
+    final _$$ref$3 = baseURL?.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.initWithContentsOfMarkdownFileAtURL:options:baseURL:error:',
       iOS: (false, (15, 0, 0)),
@@ -1866,11 +1931,11 @@ extension NSAttributedString$Methods on NSAttributedString {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1k0ezzm(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithContentsOfMarkdownFileAtURL_options_baseURL_error_,
-        markdownFile.ref.pointer,
-        options?.ref.pointer ?? ffi.nullptr,
-        baseURL?.ref.pointer ?? ffi.nullptr,
+        _$$ref$1.pointer,
+        _$$ref$2?.pointer ?? ffi.nullptr,
+        _$$ref$3?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -1891,17 +1956,20 @@ extension NSAttributedString$Methods on NSAttributedString {
     required int options,
     NSLocale? locale,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = format.ref;
+    final _$$ref$2 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.initWithFormat:options:locale:',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
     final $ret = _objc_msgSend_187k8ck(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithFormat_options_locale_,
-      format.ref.pointer,
+      _$$ref$1.pointer,
       options,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSAttributedString.fromPointer($ret, retain: false, release: true);
   }
@@ -1916,18 +1984,22 @@ extension NSAttributedString$Methods on NSAttributedString {
     NSLocale? locale,
     required NSDictionary context,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = format.ref;
+    final _$$ref$2 = locale?.ref;
+    final _$$ref$3 = context.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.initWithFormat:options:locale:context:',
       iOS: (false, (17, 0, 0)),
       macOS: (false, (14, 0, 0)),
     );
     final $ret = _objc_msgSend_3fn4ca(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithFormat_options_locale_context_,
-      format.ref.pointer,
+      _$$ref$1.pointer,
       options,
-      locale?.ref.pointer ?? ffi.nullptr,
-      context.ref.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3.pointer,
     );
     return NSAttributedString.fromPointer($ret, retain: false, release: true);
   }
@@ -1941,6 +2013,10 @@ extension NSAttributedString$Methods on NSAttributedString {
     NSAttributedStringMarkdownParsingOptions? options,
     NSURL? baseURL,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = markdown.ref;
+    final _$$ref$2 = options?.ref;
+    final _$$ref$3 = baseURL?.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.initWithMarkdown:options:baseURL:error:',
       iOS: (false, (15, 0, 0)),
@@ -1949,11 +2025,11 @@ extension NSAttributedString$Methods on NSAttributedString {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1k0ezzm(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithMarkdown_options_baseURL_error_,
-        markdown.ref.pointer,
-        options?.ref.pointer ?? ffi.nullptr,
-        baseURL?.ref.pointer ?? ffi.nullptr,
+        _$$ref$1.pointer,
+        _$$ref$2?.pointer ?? ffi.nullptr,
+        _$$ref$3?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -1974,6 +2050,10 @@ extension NSAttributedString$Methods on NSAttributedString {
     NSAttributedStringMarkdownParsingOptions? options,
     NSURL? baseURL,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = markdownString.ref;
+    final _$$ref$2 = options?.ref;
+    final _$$ref$3 = baseURL?.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.initWithMarkdownString:options:baseURL:error:',
       iOS: (false, (15, 0, 0)),
@@ -1982,11 +2062,11 @@ extension NSAttributedString$Methods on NSAttributedString {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1k0ezzm(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithMarkdownString_options_baseURL_error_,
-        markdownString.ref.pointer,
-        options?.ref.pointer ?? ffi.nullptr,
-        baseURL?.ref.pointer ?? ffi.nullptr,
+        _$$ref$1.pointer,
+        _$$ref$2?.pointer ?? ffi.nullptr,
+        _$$ref$3?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -2000,15 +2080,17 @@ extension NSAttributedString$Methods on NSAttributedString {
 
   /// initWithString:
   NSAttributedString initWithString(NSString str) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.initWithString:',
       iOS: (false, (3, 2, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithString_,
-      str.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSAttributedString.fromPointer($ret, retain: false, release: true);
   }
@@ -2018,28 +2100,32 @@ extension NSAttributedString$Methods on NSAttributedString {
     NSString str, {
     NSDictionary? attributes,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
+    final _$$ref$2 = attributes?.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.initWithString:attributes:',
       iOS: (false, (3, 2, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithString_attributes_,
-      str.ref.pointer,
-      attributes?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSAttributedString.fromPointer($ret, retain: false, release: true);
   }
 
   /// string
   NSString get string {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedString.string',
       iOS: (false, (3, 2, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_string);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_string);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -2192,27 +2278,26 @@ extension NSAttributedStringMarkdownParsingOptions$Methods
   /// iOS: introduced 15.0.0
   /// macOS: introduced 12.0.0
   bool get allowsExtendedAttributes {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.allowsExtendedAttributes',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
-    return _objc_msgSend_91o635(
-      object$.ref.pointer,
-      _sel_allowsExtendedAttributes,
-    );
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_allowsExtendedAttributes);
   }
 
   /// iOS: introduced 16.0.0
   /// macOS: introduced 13.0.0
   bool get appliesSourcePositionAttributes {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.appliesSourcePositionAttributes',
       iOS: (false, (16, 0, 0)),
       macOS: (false, (13, 0, 0)),
     );
     return _objc_msgSend_91o635(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_appliesSourcePositionAttributes,
     );
   }
@@ -2220,24 +2305,26 @@ extension NSAttributedStringMarkdownParsingOptions$Methods
   /// iOS: introduced 15.0.0
   /// macOS: introduced 12.0.0
   NSAttributedStringMarkdownParsingFailurePolicy get failurePolicy {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.failurePolicy',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
-    final $ret = _objc_msgSend_194u5n2(object$.ref.pointer, _sel_failurePolicy);
+    final $ret = _objc_msgSend_194u5n2(_$$ref.pointer, _sel_failurePolicy);
     return NSAttributedStringMarkdownParsingFailurePolicy.fromValue($ret);
   }
 
   /// init
   NSAttributedStringMarkdownParsingOptions init() {
+    final _$$ref$7 = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$7.retainAndReturnPointer(),
       _sel_init,
     );
     return NSAttributedStringMarkdownParsingOptions.fromPointer(
@@ -2250,27 +2337,26 @@ extension NSAttributedStringMarkdownParsingOptions$Methods
   /// iOS: introduced 15.0.0
   /// macOS: introduced 12.0.0
   NSAttributedStringMarkdownInterpretedSyntax get interpretedSyntax {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.interpretedSyntax',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
-    final $ret = _objc_msgSend_h0o9ch(
-      object$.ref.pointer,
-      _sel_interpretedSyntax,
-    );
+    final $ret = _objc_msgSend_h0o9ch(_$$ref.pointer, _sel_interpretedSyntax);
     return NSAttributedStringMarkdownInterpretedSyntax.fromValue($ret);
   }
 
   /// iOS: introduced 15.0.0
   /// macOS: introduced 12.0.0
   NSString? get languageCode {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.languageCode',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_languageCode);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_languageCode);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -2279,13 +2365,14 @@ extension NSAttributedStringMarkdownParsingOptions$Methods
   /// iOS: introduced 15.0.0
   /// macOS: introduced 12.0.0
   set allowsExtendedAttributes(bool value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.setAllowsExtendedAttributes:',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
     _objc_msgSend_1s56lr9(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setAllowsExtendedAttributes_,
       value,
     );
@@ -2294,13 +2381,14 @@ extension NSAttributedStringMarkdownParsingOptions$Methods
   /// iOS: introduced 16.0.0
   /// macOS: introduced 13.0.0
   set appliesSourcePositionAttributes(bool value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.setAppliesSourcePositionAttributes:',
       iOS: (false, (16, 0, 0)),
       macOS: (false, (13, 0, 0)),
     );
     _objc_msgSend_1s56lr9(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setAppliesSourcePositionAttributes_,
       value,
     );
@@ -2309,28 +2397,26 @@ extension NSAttributedStringMarkdownParsingOptions$Methods
   /// iOS: introduced 15.0.0
   /// macOS: introduced 12.0.0
   set failurePolicy(NSAttributedStringMarkdownParsingFailurePolicy value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.setFailurePolicy:',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
-    _objc_msgSend_mt0t38(
-      object$.ref.pointer,
-      _sel_setFailurePolicy_,
-      value.value,
-    );
+    _objc_msgSend_mt0t38(_$$ref.pointer, _sel_setFailurePolicy_, value.value);
   }
 
   /// iOS: introduced 15.0.0
   /// macOS: introduced 12.0.0
   set interpretedSyntax(NSAttributedStringMarkdownInterpretedSyntax value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.setInterpretedSyntax:',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
     _objc_msgSend_1ay2tmt(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setInterpretedSyntax_,
       value.value,
     );
@@ -2339,15 +2425,17 @@ extension NSAttributedStringMarkdownParsingOptions$Methods
   /// iOS: introduced 15.0.0
   /// macOS: introduced 12.0.0
   set languageCode(NSString? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSAttributedStringMarkdownParsingOptions.setLanguageCode:',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setLanguageCode_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 }
@@ -2391,6 +2479,10 @@ extension type NSBundle._(objc.ObjCObject object$)
     NSString? subdirectory,
     required NSURL inBundleWithURL,
   }) {
+    final _$$ref = name?.ref;
+    final _$$ref$1 = withExtension?.ref;
+    final _$$ref$2 = subdirectory?.ref;
+    final _$$ref$3 = inBundleWithURL.ref;
     objc.checkOsVersionInternal(
       'NSBundle.URLForResource:withExtension:subdirectory:inBundleWithURL:',
       iOS: (false, (4, 0, 0)),
@@ -2399,10 +2491,10 @@ extension type NSBundle._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_s92gih(
       _class_NSBundle,
       _sel_URLForResource_withExtension_subdirectory_inBundleWithURL_,
-      name?.ref.pointer ?? ffi.nullptr,
-      withExtension?.ref.pointer ?? ffi.nullptr,
-      subdirectory?.ref.pointer ?? ffi.nullptr,
-      inBundleWithURL.ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2415,6 +2507,9 @@ extension type NSBundle._(objc.ObjCObject object$)
     NSString? subdirectory,
     required NSURL inBundleWithURL,
   }) {
+    final _$$ref = ext?.ref;
+    final _$$ref$1 = subdirectory?.ref;
+    final _$$ref$2 = inBundleWithURL.ref;
     objc.checkOsVersionInternal(
       'NSBundle.URLsForResourcesWithExtension:subdirectory:inBundleWithURL:',
       iOS: (false, (4, 0, 0)),
@@ -2423,9 +2518,9 @@ extension type NSBundle._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_11spmsz(
       _class_NSBundle,
       _sel_URLsForResourcesWithExtension_subdirectory_inBundleWithURL_,
-      ext?.ref.pointer ?? ffi.nullptr,
-      subdirectory?.ref.pointer ?? ffi.nullptr,
-      inBundleWithURL.ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2462,20 +2557,22 @@ extension type NSBundle._(objc.ObjCObject object$)
 
   /// bundleForClass:
   static NSBundle bundleForClass(objc.ObjCObject aClass) {
+    final _$$ref = aClass.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSBundle,
       _sel_bundleForClass_,
-      aClass.ref.pointer,
+      _$$ref.pointer,
     );
     return NSBundle.fromPointer($ret, retain: true, release: true);
   }
 
   /// bundleWithIdentifier:
   static NSBundle? bundleWithIdentifier(NSString identifier) {
+    final _$$ref = identifier.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSBundle,
       _sel_bundleWithIdentifier_,
-      identifier.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2484,10 +2581,11 @@ extension type NSBundle._(objc.ObjCObject object$)
 
   /// bundleWithPath:
   static NSBundle? bundleWithPath(NSString path) {
+    final _$$ref = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSBundle,
       _sel_bundleWithPath_,
-      path.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2496,6 +2594,7 @@ extension type NSBundle._(objc.ObjCObject object$)
 
   /// bundleWithURL:
   static NSBundle? bundleWithURL(NSURL url) {
+    final _$$ref = url.ref;
     objc.checkOsVersionInternal(
       'NSBundle.bundleWithURL:',
       iOS: (false, (4, 0, 0)),
@@ -2504,7 +2603,7 @@ extension type NSBundle._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSBundle,
       _sel_bundleWithURL_,
-      url.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2529,12 +2628,15 @@ extension type NSBundle._(objc.ObjCObject object$)
     NSString? ofType,
     required NSString inDirectory,
   }) {
+    final _$$ref = name?.ref;
+    final _$$ref$1 = ofType?.ref;
+    final _$$ref$2 = inDirectory.ref;
     final $ret = _objc_msgSend_11spmsz(
       _class_NSBundle,
       _sel_pathForResource_ofType_inDirectory_,
-      name?.ref.pointer ?? ffi.nullptr,
-      ofType?.ref.pointer ?? ffi.nullptr,
-      inDirectory.ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2546,21 +2648,24 @@ extension type NSBundle._(objc.ObjCObject object$)
     NSString? ext, {
     required NSString inDirectory,
   }) {
+    final _$$ref = ext?.ref;
+    final _$$ref$1 = inDirectory.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_NSBundle,
       _sel_pathsForResourcesOfType_inDirectory_,
-      ext?.ref.pointer ?? ffi.nullptr,
-      inDirectory.ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// preferredLocalizationsFromArray:
   static NSArray preferredLocalizationsFromArray(NSArray localizationsArray) {
+    final _$$ref = localizationsArray.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSBundle,
       _sel_preferredLocalizationsFromArray_,
-      localizationsArray.ref.pointer,
+      _$$ref.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
@@ -2570,11 +2675,13 @@ extension type NSBundle._(objc.ObjCObject object$)
     NSArray localizationsArray, {
     NSArray? forPreferences,
   }) {
+    final _$$ref = localizationsArray.ref;
+    final _$$ref$1 = forPreferences?.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_NSBundle,
       _sel_preferredLocalizationsFromArray_forPreferences_,
-      localizationsArray.ref.pointer,
-      forPreferences?.ref.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
@@ -2586,15 +2693,17 @@ extension type NSBundle._(objc.ObjCObject object$)
 extension NSBundle$Methods on NSBundle {
   /// URLForAuxiliaryExecutable:
   NSURL? URLForAuxiliaryExecutable(NSString executableName) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = executableName.ref;
     objc.checkOsVersionInternal(
       'NSBundle.URLForAuxiliaryExecutable:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_URLForAuxiliaryExecutable_,
-      executableName.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2603,16 +2712,19 @@ extension NSBundle$Methods on NSBundle {
 
   /// URLForResource:withExtension:
   NSURL? URLForResource(NSString? name, {NSString? withExtension}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = name?.ref;
+    final _$$ref$2 = withExtension?.ref;
     objc.checkOsVersionInternal(
       'NSBundle.URLForResource:withExtension:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_URLForResource_withExtension_,
-      name?.ref.pointer ?? ffi.nullptr,
-      withExtension?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -2625,17 +2737,21 @@ extension NSBundle$Methods on NSBundle {
     NSString? withExtension,
     NSString? subdirectory,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = name?.ref;
+    final _$$ref$2 = withExtension?.ref;
+    final _$$ref$3 = subdirectory?.ref;
     objc.checkOsVersionInternal(
       'NSBundle.URLForResource:withExtension:subdirectory:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_11spmsz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_URLForResource_withExtension_subdirectory_,
-      name?.ref.pointer ?? ffi.nullptr,
-      withExtension?.ref.pointer ?? ffi.nullptr,
-      subdirectory?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -2649,18 +2765,23 @@ extension NSBundle$Methods on NSBundle {
     NSString? subdirectory,
     NSString? localization,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = name?.ref;
+    final _$$ref$2 = withExtension?.ref;
+    final _$$ref$3 = subdirectory?.ref;
+    final _$$ref$4 = localization?.ref;
     objc.checkOsVersionInternal(
       'NSBundle.URLForResource:withExtension:subdirectory:localization:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_s92gih(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_URLForResource_withExtension_subdirectory_localization_,
-      name?.ref.pointer ?? ffi.nullptr,
-      withExtension?.ref.pointer ?? ffi.nullptr,
-      subdirectory?.ref.pointer ?? ffi.nullptr,
-      localization?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
+      _$$ref$4?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -2672,16 +2793,19 @@ extension NSBundle$Methods on NSBundle {
     NSString? ext, {
     NSString? subdirectory,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = ext?.ref;
+    final _$$ref$2 = subdirectory?.ref;
     objc.checkOsVersionInternal(
       'NSBundle.URLsForResourcesWithExtension:subdirectory:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_URLsForResourcesWithExtension_subdirectory_,
-      ext?.ref.pointer ?? ffi.nullptr,
-      subdirectory?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -2694,17 +2818,21 @@ extension NSBundle$Methods on NSBundle {
     NSString? subdirectory,
     NSString? localization,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = ext?.ref;
+    final _$$ref$2 = subdirectory?.ref;
+    final _$$ref$3 = localization?.ref;
     objc.checkOsVersionInternal(
       'NSBundle.URLsForResourcesWithExtension:subdirectory:localization:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_11spmsz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_URLsForResourcesWithExtension_subdirectory_localization_,
-      ext?.ref.pointer ?? ffi.nullptr,
-      subdirectory?.ref.pointer ?? ffi.nullptr,
-      localization?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -2713,15 +2841,13 @@ extension NSBundle$Methods on NSBundle {
 
   /// appStoreReceiptURL
   NSURL? get appStoreReceiptURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.appStoreReceiptURL',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_appStoreReceiptURL,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_appStoreReceiptURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -2729,10 +2855,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// builtInPlugInsPath
   NSString? get builtInPlugInsPath {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_builtInPlugInsPath,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_builtInPlugInsPath);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -2740,15 +2864,13 @@ extension NSBundle$Methods on NSBundle {
 
   /// builtInPlugInsURL
   NSURL? get builtInPlugInsURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.builtInPlugInsURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_builtInPlugInsURL,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_builtInPlugInsURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -2756,10 +2878,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// bundleIdentifier
   NSString? get bundleIdentifier {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_bundleIdentifier,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_bundleIdentifier);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -2767,27 +2887,31 @@ extension NSBundle$Methods on NSBundle {
 
   /// bundlePath
   NSString get bundlePath {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_bundlePath);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_bundlePath);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// bundleURL
   NSURL get bundleURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.bundleURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_bundleURL);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_bundleURL);
     return NSURL.fromPointer($ret, retain: true, release: true);
   }
 
   /// classNamed:
   objc.ObjCObject? classNamed(NSString className) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = className.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_classNamed_,
-      className.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2796,8 +2920,9 @@ extension NSBundle$Methods on NSBundle {
 
   /// developmentLocalization
   NSString? get developmentLocalization {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_developmentLocalization,
     );
     return $ret.address == 0
@@ -2807,13 +2932,14 @@ extension NSBundle$Methods on NSBundle {
 
   /// executableArchitectures
   NSArray? get executableArchitectures {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.executableArchitectures',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_executableArchitectures,
     );
     return $ret.address == 0
@@ -2823,10 +2949,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// executablePath
   NSString? get executablePath {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_executablePath,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_executablePath);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -2834,12 +2958,13 @@ extension NSBundle$Methods on NSBundle {
 
   /// executableURL
   NSURL? get executableURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.executableURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_executableURL);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_executableURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -2847,10 +2972,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// infoDictionary
   NSDictionary? get infoDictionary {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_infoDictionary,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_infoDictionary);
     return $ret.address == 0
         ? null
         : NSDictionary.fromPointer($ret, retain: true, release: true);
@@ -2858,13 +2981,14 @@ extension NSBundle$Methods on NSBundle {
 
   /// init
   NSBundle init() {
+    final _$$ref$8 = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$8.retainAndReturnPointer(),
       _sel_init,
     );
     return NSBundle.fromPointer($ret, retain: false, release: true);
@@ -2872,10 +2996,12 @@ extension NSBundle$Methods on NSBundle {
 
   /// initWithPath:
   NSBundle? initWithPath(NSString path) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithPath_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2884,15 +3010,17 @@ extension NSBundle$Methods on NSBundle {
 
   /// initWithURL:
   NSBundle? initWithURL(NSURL url) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     objc.checkOsVersionInternal(
       'NSBundle.initWithURL:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithURL_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -2901,16 +3029,19 @@ extension NSBundle$Methods on NSBundle {
 
   /// isLoaded
   bool get isLoaded {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isLoaded);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isLoaded);
   }
 
   /// load
   bool load$1() {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_load);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_load);
   }
 
   /// loadAndReturnError:
   bool loadAndReturnError() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.loadAndReturnError:',
       iOS: (false, (2, 0, 0)),
@@ -2919,7 +3050,7 @@ extension NSBundle$Methods on NSBundle {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1dom33q(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_loadAndReturnError_,
         $err,
       );
@@ -2932,7 +3063,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// localizations
   NSArray get localizations {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_localizations);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_localizations);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
@@ -2945,25 +3077,30 @@ extension NSBundle$Methods on NSBundle {
     NSString? value,
     NSString? table,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = key.ref;
+    final _$$ref$2 = value?.ref;
+    final _$$ref$3 = table?.ref;
     objc.checkOsVersionInternal(
       'NSBundle.localizedAttributedStringForKey:value:table:',
       iOS: (false, (15, 0, 0)),
       macOS: (false, (12, 0, 0)),
     );
     final $ret = _objc_msgSend_11spmsz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedAttributedStringForKey_value_table_,
-      key.ref.pointer,
-      value?.ref.pointer ?? ffi.nullptr,
-      table?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return NSAttributedString.fromPointer($ret, retain: true, release: true);
   }
 
   /// localizedInfoDictionary
   NSDictionary? get localizedInfoDictionary {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedInfoDictionary,
     );
     return $ret.address == 0
@@ -2977,22 +3114,28 @@ extension NSBundle$Methods on NSBundle {
     NSString? value,
     NSString? table,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = key.ref;
+    final _$$ref$2 = value?.ref;
+    final _$$ref$3 = table?.ref;
     final $ret = _objc_msgSend_11spmsz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedStringForKey_value_table_,
-      key.ref.pointer,
-      value?.ref.pointer ?? ffi.nullptr,
-      table?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// objectForInfoDictionaryKey:
   objc.ObjCObject? objectForInfoDictionaryKey(NSString key) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = key.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectForInfoDictionaryKey_,
-      key.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -3001,10 +3144,12 @@ extension NSBundle$Methods on NSBundle {
 
   /// pathForAuxiliaryExecutable:
   NSString? pathForAuxiliaryExecutable(NSString executableName) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = executableName.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_pathForAuxiliaryExecutable_,
-      executableName.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -3013,11 +3158,14 @@ extension NSBundle$Methods on NSBundle {
 
   /// pathForResource:ofType:
   NSString? pathForResource(NSString? name, {NSString? ofType}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = name?.ref;
+    final _$$ref$2 = ofType?.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_pathForResource_ofType_,
-      name?.ref.pointer ?? ffi.nullptr,
-      ofType?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -3030,12 +3178,16 @@ extension NSBundle$Methods on NSBundle {
     NSString? ofType,
     NSString? inDirectory,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = name?.ref;
+    final _$$ref$2 = ofType?.ref;
+    final _$$ref$3 = inDirectory?.ref;
     final $ret = _objc_msgSend_11spmsz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_pathForResource_ofType_inDirectory_,
-      name?.ref.pointer ?? ffi.nullptr,
-      ofType?.ref.pointer ?? ffi.nullptr,
-      inDirectory?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -3049,13 +3201,18 @@ extension NSBundle$Methods on NSBundle {
     NSString? inDirectory,
     NSString? forLocalization,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = name?.ref;
+    final _$$ref$2 = ofType?.ref;
+    final _$$ref$3 = inDirectory?.ref;
+    final _$$ref$4 = forLocalization?.ref;
     final $ret = _objc_msgSend_s92gih(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_pathForResource_ofType_inDirectory_forLocalization_,
-      name?.ref.pointer ?? ffi.nullptr,
-      ofType?.ref.pointer ?? ffi.nullptr,
-      inDirectory?.ref.pointer ?? ffi.nullptr,
-      forLocalization?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
+      _$$ref$4?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -3064,11 +3221,14 @@ extension NSBundle$Methods on NSBundle {
 
   /// pathsForResourcesOfType:inDirectory:
   NSArray pathsForResourcesOfType(NSString? ext, {NSString? inDirectory}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = ext?.ref;
+    final _$$ref$2 = inDirectory?.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_pathsForResourcesOfType_inDirectory_,
-      ext?.ref.pointer ?? ffi.nullptr,
-      inDirectory?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
@@ -3079,20 +3239,25 @@ extension NSBundle$Methods on NSBundle {
     NSString? inDirectory,
     NSString? forLocalization,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = ext?.ref;
+    final _$$ref$2 = inDirectory?.ref;
+    final _$$ref$3 = forLocalization?.ref;
     final $ret = _objc_msgSend_11spmsz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_pathsForResourcesOfType_inDirectory_forLocalization_,
-      ext?.ref.pointer ?? ffi.nullptr,
-      inDirectory?.ref.pointer ?? ffi.nullptr,
-      forLocalization?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// preferredLocalizations
   NSArray get preferredLocalizations {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_preferredLocalizations,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
@@ -3100,6 +3265,7 @@ extension NSBundle$Methods on NSBundle {
 
   /// preflightAndReturnError:
   bool preflightAndReturnError() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.preflightAndReturnError:',
       iOS: (false, (2, 0, 0)),
@@ -3108,7 +3274,7 @@ extension NSBundle$Methods on NSBundle {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1dom33q(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_preflightAndReturnError_,
         $err,
       );
@@ -3121,10 +3287,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// principalClass
   objc.ObjCObject? get principalClass {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_principalClass,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_principalClass);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -3132,8 +3296,9 @@ extension NSBundle$Methods on NSBundle {
 
   /// privateFrameworksPath
   NSString? get privateFrameworksPath {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_privateFrameworksPath,
     );
     return $ret.address == 0
@@ -3143,13 +3308,14 @@ extension NSBundle$Methods on NSBundle {
 
   /// privateFrameworksURL
   NSURL? get privateFrameworksURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.privateFrameworksURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_privateFrameworksURL,
     );
     return $ret.address == 0
@@ -3159,7 +3325,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// resourcePath
   NSString? get resourcePath {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_resourcePath);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_resourcePath);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -3167,12 +3334,13 @@ extension NSBundle$Methods on NSBundle {
 
   /// resourceURL
   NSURL? get resourceURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.resourceURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_resourceURL);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_resourceURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -3180,8 +3348,9 @@ extension NSBundle$Methods on NSBundle {
 
   /// sharedFrameworksPath
   NSString? get sharedFrameworksPath {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sharedFrameworksPath,
     );
     return $ret.address == 0
@@ -3191,13 +3360,14 @@ extension NSBundle$Methods on NSBundle {
 
   /// sharedFrameworksURL
   NSURL? get sharedFrameworksURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.sharedFrameworksURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sharedFrameworksURL,
     );
     return $ret.address == 0
@@ -3207,10 +3377,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// sharedSupportPath
   NSString? get sharedSupportPath {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_sharedSupportPath,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_sharedSupportPath);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -3218,15 +3386,13 @@ extension NSBundle$Methods on NSBundle {
 
   /// sharedSupportURL
   NSURL? get sharedSupportURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSBundle.sharedSupportURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_sharedSupportURL,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_sharedSupportURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -3234,7 +3400,8 @@ extension NSBundle$Methods on NSBundle {
 
   /// unload
   bool unload() {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_unload);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_unload);
   }
 }
 
@@ -3305,30 +3472,33 @@ extension type NSCharacterSet._(objc.ObjCObject object$)
 
   /// characterSetWithBitmapRepresentation:
   static NSCharacterSet characterSetWithBitmapRepresentation(NSData data) {
+    final _$$ref = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSCharacterSet,
       _sel_characterSetWithBitmapRepresentation_,
-      data.ref.pointer,
+      _$$ref.pointer,
     );
     return NSCharacterSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// characterSetWithCharactersInString:
   static NSCharacterSet characterSetWithCharactersInString(NSString aString) {
+    final _$$ref = aString.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSCharacterSet,
       _sel_characterSetWithCharactersInString_,
-      aString.ref.pointer,
+      _$$ref.pointer,
     );
     return NSCharacterSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// characterSetWithContentsOfFile:
   static NSCharacterSet? characterSetWithContentsOfFile(NSString fName) {
+    final _$$ref = fName.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSCharacterSet,
       _sel_characterSetWithContentsOfFile_,
-      fName.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -3488,8 +3658,9 @@ extension type NSCharacterSet._(objc.ObjCObject object$)
 extension NSCharacterSet$Methods on NSCharacterSet {
   /// bitmapRepresentation
   NSData get bitmapRepresentation {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_bitmapRepresentation,
     );
     return NSData.fromPointer($ret, retain: true, release: true);
@@ -3497,8 +3668,9 @@ extension NSCharacterSet$Methods on NSCharacterSet {
 
   /// characterIsMember:
   bool characterIsMember(int aCharacter) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_1co9mn4(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_characterIsMember_,
       aCharacter,
     );
@@ -3506,17 +3678,20 @@ extension NSCharacterSet$Methods on NSCharacterSet {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$4 = object$.ref;
+    final _$$ref$5 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$4.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$5.pointer,
     );
   }
 
   /// hasMemberInPlane:
   bool hasMemberInPlane(int thePlane) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_gerswc(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_hasMemberInPlane_,
       thePlane,
     );
@@ -3524,13 +3699,14 @@ extension NSCharacterSet$Methods on NSCharacterSet {
 
   /// init
   NSCharacterSet init() {
+    final _$$ref$9 = object$.ref;
     objc.checkOsVersionInternal(
       'NSCharacterSet.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$9.retainAndReturnPointer(),
       _sel_init,
     );
     return NSCharacterSet.fromPointer($ret, retain: false, release: true);
@@ -3538,10 +3714,12 @@ extension NSCharacterSet$Methods on NSCharacterSet {
 
   /// initWithCoder:
   NSCharacterSet? initWithCoder(NSCoder coder) {
+    final _$$ref$4 = object$.ref;
+    final _$$ref$5 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$4.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$5.pointer,
     );
     return $ret.address == 0
         ? null
@@ -3550,23 +3728,27 @@ extension NSCharacterSet$Methods on NSCharacterSet {
 
   /// invertedSet
   NSCharacterSet get invertedSet {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_invertedSet);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_invertedSet);
     return NSCharacterSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// isSupersetOfSet:
   bool isSupersetOfSet(NSCharacterSet theOtherSet) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = theOtherSet.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isSupersetOfSet_,
-      theOtherSet.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// longCharacterIsMember:
   bool longCharacterIsMember(int theLongChar) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_jsclrq(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_longCharacterIsMember_,
       theLongChar,
     );
@@ -3628,10 +3810,8 @@ extension type NSCoder._(objc.ObjCObject object$)
 extension NSCoder$Methods on NSCoder {
   /// decodeDataObject
   NSData? decodeDataObject() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_decodeDataObject,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_decodeDataObject);
     return $ret.address == 0
         ? null
         : NSData.fromPointer($ret, retain: true, release: true);
@@ -3643,13 +3823,14 @@ extension NSCoder$Methods on NSCoder {
     required ffi.Pointer<ffi.Void> at,
     required int size,
   }) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSCoder.decodeValueOfObjCType:at:size:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_nc6uds(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_decodeValueOfObjCType_at_size_,
       type,
       at,
@@ -3659,10 +3840,12 @@ extension NSCoder$Methods on NSCoder {
 
   /// encodeDataObject:
   void encodeDataObject(NSData data) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_encodeDataObject_,
-      data.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -3671,8 +3854,9 @@ extension NSCoder$Methods on NSCoder {
     ffi.Pointer<ffi.Char> type, {
     required ffi.Pointer<ffi.Void> at,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_1flkydz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_encodeValueOfObjCType_at_,
       type,
       at,
@@ -3681,13 +3865,14 @@ extension NSCoder$Methods on NSCoder {
 
   /// init
   NSCoder init() {
+    final _$$ref$10 = object$.ref;
     objc.checkOsVersionInternal(
       'NSCoder.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$10.retainAndReturnPointer(),
       _sel_init,
     );
     return NSCoder.fromPointer($ret, retain: false, release: true);
@@ -3695,10 +3880,12 @@ extension NSCoder$Methods on NSCoder {
 
   /// versionForClassName:
   int versionForClassName(NSString className) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = className.ref;
     return _objc_msgSend_1r6ymhb(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_versionForClassName_,
-      className.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 }
@@ -3729,19 +3916,23 @@ extension type NSCoding._(objc.ObjCProtocol object$)
 extension NSCoding$Methods on NSCoding {
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$6 = object$.ref;
+    final _$$ref$7 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$6.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$7.pointer,
     );
   }
 
   /// initWithCoder:
   NSCoding? initWithCoder(NSCoder coder) {
+    final _$$ref$6 = object$.ref;
+    final _$$ref$7 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$6.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$7.pointer,
     );
     return $ret.address == 0
         ? null
@@ -3989,8 +4180,9 @@ extension type NSCopying._(objc.ObjCProtocol object$)
 extension NSCopying$Methods on NSCopying {
   /// copyWithZone:
   objc.ObjCObject copyWithZone(ffi.Pointer<NSZone> zone) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1cwp428(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_copyWithZone_,
       zone,
     );
@@ -4158,10 +4350,11 @@ extension type NSData._(objc.ObjCObject object$)
 
   /// dataWithContentsOfFile:
   static NSData? dataWithContentsOfFile(NSString path) {
+    final _$$ref = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSData,
       _sel_dataWithContentsOfFile_,
-      path.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -4174,10 +4367,11 @@ extension type NSData._(objc.ObjCObject object$)
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref = path.ref;
     final $ret = _objc_msgSend_8321cp(
       _class_NSData,
       _sel_dataWithContentsOfFile_options_error_,
-      path.ref.pointer,
+      _$$ref.pointer,
       options,
       error,
     );
@@ -4188,10 +4382,11 @@ extension type NSData._(objc.ObjCObject object$)
 
   /// dataWithContentsOfURL:
   static NSData? dataWithContentsOfURL(NSURL url) {
+    final _$$ref = url.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSData,
       _sel_dataWithContentsOfURL_,
-      url.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -4204,10 +4399,11 @@ extension type NSData._(objc.ObjCObject object$)
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref = url.ref;
     final $ret = _objc_msgSend_8321cp(
       _class_NSData,
       _sel_dataWithContentsOfURL_options_error_,
-      url.ref.pointer,
+      _$$ref.pointer,
       options,
       error,
     );
@@ -4218,10 +4414,11 @@ extension type NSData._(objc.ObjCObject object$)
 
   /// dataWithData:
   static NSData dataWithData(NSData data) {
+    final _$$ref = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSData,
       _sel_dataWithData_,
-      data.ref.pointer,
+      _$$ref.pointer,
     );
     return NSData.fromPointer($ret, retain: true, release: true);
   }
@@ -4244,7 +4441,8 @@ extension type NSData._(objc.ObjCObject object$)
 extension NSData$Methods on NSData {
   /// bytes
   ffi.Pointer<ffi.Void> get bytes {
-    return _objc_msgSend_6ex6p5(object$.ref.pointer, _sel_bytes);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_6ex6p5(_$$ref.pointer, _sel_bytes);
   }
 
   /// compressedDataUsingAlgorithm:error:
@@ -4252,6 +4450,7 @@ extension NSData$Methods on NSData {
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   NSData? compressedDataUsingAlgorithm(NSDataCompressionAlgorithm algorithm) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSData.compressedDataUsingAlgorithm:error:',
       iOS: (false, (13, 0, 0)),
@@ -4260,7 +4459,7 @@ extension NSData$Methods on NSData {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1vnlaqg(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_compressedDataUsingAlgorithm_error_,
         algorithm.value,
         $err,
@@ -4279,6 +4478,7 @@ extension NSData$Methods on NSData {
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   NSData? decompressedDataUsingAlgorithm(NSDataCompressionAlgorithm algorithm) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSData.decompressedDataUsingAlgorithm:error:',
       iOS: (false, (13, 0, 0)),
@@ -4287,7 +4487,7 @@ extension NSData$Methods on NSData {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1vnlaqg(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_decompressedDataUsingAlgorithm_error_,
         algorithm.value,
         $err,
@@ -4303,22 +4503,25 @@ extension NSData$Methods on NSData {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$8 = object$.ref;
+    final _$$ref$9 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$8.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$9.pointer,
     );
   }
 
   /// init
   NSData init() {
+    final _$$ref$11 = object$.ref;
     objc.checkOsVersionInternal(
       'NSData.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$11.retainAndReturnPointer(),
       _sel_init,
     );
     return NSData.fromPointer($ret, retain: false, release: true);
@@ -4326,15 +4529,17 @@ extension NSData$Methods on NSData {
 
   /// initWithBase64EncodedData:options:
   NSData? initWithBase64EncodedData(NSData base64Data, {required int options}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = base64Data.ref;
     objc.checkOsVersionInternal(
       'NSData.initWithBase64EncodedData:options:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_7kpg7m(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBase64EncodedData_options_,
-      base64Data.ref.pointer,
+      _$$ref$1.pointer,
       options,
     );
     return $ret.address == 0
@@ -4347,15 +4552,17 @@ extension NSData$Methods on NSData {
     NSString base64String, {
     required int options,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = base64String.ref;
     objc.checkOsVersionInternal(
       'NSData.initWithBase64EncodedString:options:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_7kpg7m(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBase64EncodedString_options_,
-      base64String.ref.pointer,
+      _$$ref$1.pointer,
       options,
     );
     return $ret.address == 0
@@ -4365,8 +4572,9 @@ extension NSData$Methods on NSData {
 
   /// initWithBytes:length:
   NSData initWithBytes(ffi.Pointer<ffi.Void> bytes, {required int length}) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_3nbx5e(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBytes_length_,
       bytes,
       length,
@@ -4379,8 +4587,9 @@ extension NSData$Methods on NSData {
     ffi.Pointer<ffi.Void> bytes, {
     required int length,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_3nbx5e(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_,
       bytes,
       length,
@@ -4395,17 +4604,19 @@ extension NSData$Methods on NSData {
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.UnsignedLong)>?
     deallocator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = deallocator?.ref;
     objc.checkOsVersionInternal(
       'NSData.initWithBytesNoCopy:length:deallocator:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_134vhyh(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_deallocator_,
       bytes,
       length,
-      deallocator?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSData.fromPointer($ret, retain: false, release: true);
   }
@@ -4416,8 +4627,9 @@ extension NSData$Methods on NSData {
     required int length,
     required bool freeWhenDone,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_161ne8y(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_freeWhenDone_,
       bytes,
       length,
@@ -4428,10 +4640,12 @@ extension NSData$Methods on NSData {
 
   /// initWithCoder:
   NSData? initWithCoder(NSCoder coder) {
+    final _$$ref$8 = object$.ref;
+    final _$$ref$9 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$8.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$9.pointer,
     );
     return $ret.address == 0
         ? null
@@ -4440,10 +4654,12 @@ extension NSData$Methods on NSData {
 
   /// initWithContentsOfFile:
   NSData? initWithContentsOfFile(NSString path) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithContentsOfFile_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -4456,10 +4672,12 @@ extension NSData$Methods on NSData {
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_8321cp(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithContentsOfFile_options_error_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
       options,
       error,
     );
@@ -4470,10 +4688,12 @@ extension NSData$Methods on NSData {
 
   /// initWithContentsOfURL:
   NSData? initWithContentsOfURL(NSURL url) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithContentsOfURL_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -4486,10 +4706,12 @@ extension NSData$Methods on NSData {
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     final $ret = _objc_msgSend_8321cp(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithContentsOfURL_options_error_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
       options,
       error,
     );
@@ -4500,17 +4722,20 @@ extension NSData$Methods on NSData {
 
   /// initWithData:
   NSData initWithData(NSData data) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithData_,
-      data.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSData.fromPointer($ret, retain: false, release: true);
   }
 
   /// length
   int get length {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_length);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_length);
   }
 }
 
@@ -4630,11 +4855,12 @@ extension type NSDate._(objc.ObjCObject object$)
     double secsToBeAdded, {
     required NSDate sinceDate,
   }) {
+    final _$$ref = sinceDate.ref;
     final $ret = _objc_msgSend_1ozwf6k(
       _class_NSDate,
       _sel_dateWithTimeInterval_sinceDate_,
       secsToBeAdded,
-      sinceDate.ref.pointer,
+      _$$ref.pointer,
     );
     return NSDate.fromPointer($ret, retain: true, release: true);
   }
@@ -4687,13 +4913,14 @@ extension type NSDate._(objc.ObjCObject object$)
 extension NSDate$Methods on NSDate {
   /// dateByAddingTimeInterval:
   NSDate dateByAddingTimeInterval(double ti) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSDate.dateByAddingTimeInterval:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_oa8mke(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_dateByAddingTimeInterval_,
       ti,
     );
@@ -4702,22 +4929,25 @@ extension NSDate$Methods on NSDate {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$10 = object$.ref;
+    final _$$ref$11 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$10.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$11.pointer,
     );
   }
 
   /// init
   NSDate init() {
+    final _$$ref$12 = object$.ref;
     objc.checkOsVersionInternal(
       'NSDate.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$12.retainAndReturnPointer(),
       _sel_init,
     );
     return NSDate.fromPointer($ret, retain: false, release: true);
@@ -4725,10 +4955,12 @@ extension NSDate$Methods on NSDate {
 
   /// initWithCoder:
   NSDate? initWithCoder(NSCoder coder) {
+    final _$$ref$10 = object$.ref;
+    final _$$ref$11 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$10.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$11.pointer,
     );
     return $ret.address == 0
         ? null
@@ -4740,19 +4972,22 @@ extension NSDate$Methods on NSDate {
     double secsToBeAdded, {
     required NSDate sinceDate,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = sinceDate.ref;
     final $ret = _objc_msgSend_1ozwf6k(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithTimeInterval_sinceDate_,
       secsToBeAdded,
-      sinceDate.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSDate.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithTimeIntervalSince1970:
   NSDate initWithTimeIntervalSince1970(double secs) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_oa8mke(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithTimeIntervalSince1970_,
       secs,
     );
@@ -4761,8 +4996,9 @@ extension NSDate$Methods on NSDate {
 
   /// initWithTimeIntervalSinceNow:
   NSDate initWithTimeIntervalSinceNow(double secs) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_oa8mke(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithTimeIntervalSinceNow_,
       secs,
     );
@@ -4771,8 +5007,9 @@ extension NSDate$Methods on NSDate {
 
   /// initWithTimeIntervalSinceReferenceDate:
   NSDate initWithTimeIntervalSinceReferenceDate(double ti) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_oa8mke(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithTimeIntervalSinceReferenceDate_,
       ti,
     );
@@ -4781,13 +5018,14 @@ extension NSDate$Methods on NSDate {
 
   /// timeIntervalSinceReferenceDate
   double get timeIntervalSinceReferenceDate {
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
         ? _objc_msgSend_1ukqyt8Fpret(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_timeIntervalSinceReferenceDate,
           )
         : _objc_msgSend_1ukqyt8(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_timeIntervalSinceReferenceDate,
           );
   }
@@ -4874,10 +5112,11 @@ extension type NSDictionary._(objc.ObjCObject object$)
 
   /// dictionaryWithDictionary:
   static NSDictionary dictionaryWithDictionary(NSDictionary dict) {
+    final _$$ref = dict.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSDictionary,
       _sel_dictionaryWithDictionary_,
-      dict.ref.pointer,
+      _$$ref.pointer,
     );
     return NSDictionary.fromPointer($ret, retain: true, release: true);
   }
@@ -4887,11 +5126,13 @@ extension type NSDictionary._(objc.ObjCObject object$)
     objc.ObjCObject object, {
     required NSCopying forKey,
   }) {
+    final _$$ref = object.ref;
+    final _$$ref$1 = forKey.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_NSDictionary,
       _sel_dictionaryWithObject_forKey_,
-      object.ref.pointer,
-      forKey.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSDictionary.fromPointer($ret, retain: true, release: true);
   }
@@ -4901,11 +5142,13 @@ extension type NSDictionary._(objc.ObjCObject object$)
     NSArray objects, {
     required NSArray forKeys,
   }) {
+    final _$$ref = objects.ref;
+    final _$$ref$1 = forKeys.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_NSDictionary,
       _sel_dictionaryWithObjects_forKeys_,
-      objects.ref.pointer,
-      forKeys.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSDictionary.fromPointer($ret, retain: true, release: true);
   }
@@ -4930,10 +5173,11 @@ extension type NSDictionary._(objc.ObjCObject object$)
   static NSDictionary dictionaryWithObjectsAndKeys(
     objc.ObjCObject firstObject,
   ) {
+    final _$$ref = firstObject.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSDictionary,
       _sel_dictionaryWithObjectsAndKeys_,
-      firstObject.ref.pointer,
+      _$$ref.pointer,
     );
     return NSDictionary.fromPointer($ret, retain: true, release: true);
   }
@@ -4956,7 +5200,8 @@ extension type NSDictionary._(objc.ObjCObject object$)
 extension NSDictionary$Methods on NSDictionary {
   /// count
   int get count {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_count);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_count);
   }
 
   /// countByEnumeratingWithState:objects:count:
@@ -4965,8 +5210,9 @@ extension NSDictionary$Methods on NSDictionary {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects,
     required int count,
   }) {
+    final _$$ref$1 = object$.ref;
     return _objc_msgSend_1b5ysjl(
-      object$.ref.pointer,
+      _$$ref$1.pointer,
       _sel_countByEnumeratingWithState_objects_count_,
       state,
       objects,
@@ -4976,22 +5222,25 @@ extension NSDictionary$Methods on NSDictionary {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$12 = object$.ref;
+    final _$$ref$13 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$12.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$13.pointer,
     );
   }
 
   /// init
   NSDictionary init() {
+    final _$$ref$13 = object$.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$13.retainAndReturnPointer(),
       _sel_init,
     );
     return NSDictionary.fromPointer($ret, retain: false, release: true);
@@ -4999,10 +5248,12 @@ extension NSDictionary$Methods on NSDictionary {
 
   /// initWithCoder:
   NSDictionary? initWithCoder(NSCoder coder) {
+    final _$$ref$12 = object$.ref;
+    final _$$ref$13 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$12.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$13.pointer,
     );
     return $ret.address == 0
         ? null
@@ -5011,10 +5262,12 @@ extension NSDictionary$Methods on NSDictionary {
 
   /// initWithDictionary:
   NSDictionary initWithDictionary(NSDictionary otherDictionary) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherDictionary.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithDictionary_,
-      otherDictionary.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSDictionary.fromPointer($ret, retain: false, release: true);
   }
@@ -5024,10 +5277,12 @@ extension NSDictionary$Methods on NSDictionary {
     NSDictionary otherDictionary, {
     required bool copyItems,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherDictionary.ref;
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithDictionary_copyItems_,
-      otherDictionary.ref.pointer,
+      _$$ref$1.pointer,
       copyItems,
     );
     return NSDictionary.fromPointer($ret, retain: false, release: true);
@@ -5035,11 +5290,14 @@ extension NSDictionary$Methods on NSDictionary {
 
   /// initWithObjects:forKeys:
   NSDictionary initWithObjects(NSArray objects, {required NSArray forKeys}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = objects.ref;
+    final _$$ref$2 = forKeys.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjects_forKeys_,
-      objects.ref.pointer,
-      forKeys.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return NSDictionary.fromPointer($ret, retain: false, release: true);
   }
@@ -5050,8 +5308,9 @@ extension NSDictionary$Methods on NSDictionary {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> forKeys,
     required int count,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1dydpdi(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjects_forKeys_count_,
       objects,
       forKeys,
@@ -5062,26 +5321,31 @@ extension NSDictionary$Methods on NSDictionary {
 
   /// initWithObjectsAndKeys:
   NSDictionary initWithObjectsAndKeys(objc.ObjCObject firstObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = firstObject.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjectsAndKeys_,
-      firstObject.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSDictionary.fromPointer($ret, retain: false, release: true);
   }
 
   /// keyEnumerator
   NSEnumerator keyEnumerator() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_keyEnumerator);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_keyEnumerator);
     return NSEnumerator.fromPointer($ret, retain: true, release: true);
   }
 
   /// objectForKey:
   objc.ObjCObject? objectForKey(objc.ObjCObject aKey) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aKey.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectForKey_,
-      aKey.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -5179,8 +5443,9 @@ extension NSEnumerator$Methods on NSEnumerator {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects,
     required int count,
   }) {
+    final _$$ref$2 = object$.ref;
     return _objc_msgSend_1b5ysjl(
-      object$.ref.pointer,
+      _$$ref$2.pointer,
       _sel_countByEnumeratingWithState_objects_count_,
       state,
       objects,
@@ -5190,13 +5455,14 @@ extension NSEnumerator$Methods on NSEnumerator {
 
   /// init
   NSEnumerator init() {
+    final _$$ref$14 = object$.ref;
     objc.checkOsVersionInternal(
       'NSEnumerator.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$14.retainAndReturnPointer(),
       _sel_init,
     );
     return NSEnumerator.fromPointer($ret, retain: false, release: true);
@@ -5204,7 +5470,8 @@ extension NSEnumerator$Methods on NSEnumerator {
 
   /// nextObject
   objc.ObjCObject? nextObject() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_nextObject);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_nextObject);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -5259,12 +5526,14 @@ extension type NSError._(objc.ObjCObject object$)
     required int code,
     NSDictionary? userInfo,
   }) {
+    final _$$ref = domain.ref;
+    final _$$ref$1 = userInfo?.ref;
     final $ret = _objc_msgSend_rc4ypv(
       _class_NSError,
       _sel_errorWithDomain_code_userInfo_,
-      domain.ref.pointer,
+      _$$ref.pointer,
       code,
-      userInfo?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSError.fromPointer($ret, retain: true, release: true);
   }
@@ -5283,6 +5552,8 @@ extension type NSError._(objc.ObjCObject object$)
     >?
     provider,
   }) {
+    final _$$ref = errorDomain.ref;
+    final _$$ref$1 = provider?.ref;
     objc.checkOsVersionInternal(
       'NSError.setUserInfoValueProviderForDomain:provider:',
       iOS: (false, (9, 0, 0)),
@@ -5291,8 +5562,8 @@ extension type NSError._(objc.ObjCObject object$)
     _objc_msgSend_o762yo(
       _class_NSError,
       _sel_setUserInfoValueProviderForDomain_provider_,
-      errorDomain.ref.pointer,
-      provider?.ref.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -5310,6 +5581,9 @@ extension type NSError._(objc.ObjCObject object$)
     required NSString userInfoKey,
     required NSString errorDomain,
   }) {
+    final _$$ref = err.ref;
+    final _$$ref$1 = userInfoKey.ref;
+    final _$$ref$2 = errorDomain.ref;
     objc.checkOsVersionInternal(
       'NSError.userInfoValueProviderForDomain:',
       iOS: (false, (9, 0, 0)),
@@ -5318,9 +5592,9 @@ extension type NSError._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_cnxxyq(
       _class_NSError,
       _sel_userInfoValueProviderForDomain_,
-      err.ref.pointer,
-      userInfoKey.ref.pointer,
-      errorDomain.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return $ret.address == 0
         ? null
@@ -5338,27 +5612,32 @@ extension type NSError._(objc.ObjCObject object$)
 extension NSError$Methods on NSError {
   /// code
   int get code {
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_code);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_code);
   }
 
   /// domain
   NSString get domain {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_domain);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_domain);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$14 = object$.ref;
+    final _$$ref$15 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$14.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$15.pointer,
     );
   }
 
   /// helpAnchor
   NSString? get helpAnchor {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_helpAnchor);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_helpAnchor);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -5366,13 +5645,14 @@ extension NSError$Methods on NSError {
 
   /// init
   NSError init() {
+    final _$$ref$15 = object$.ref;
     objc.checkOsVersionInternal(
       'NSError.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$15.retainAndReturnPointer(),
       _sel_init,
     );
     return NSError.fromPointer($ret, retain: false, release: true);
@@ -5380,10 +5660,12 @@ extension NSError$Methods on NSError {
 
   /// initWithCoder:
   NSError? initWithCoder(NSCoder coder) {
+    final _$$ref$14 = object$.ref;
+    final _$$ref$15 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$14.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$15.pointer,
     );
     return $ret.address == 0
         ? null
@@ -5396,20 +5678,24 @@ extension NSError$Methods on NSError {
     required int code,
     NSDictionary? userInfo,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = domain.ref;
+    final _$$ref$2 = userInfo?.ref;
     final $ret = _objc_msgSend_rc4ypv(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithDomain_code_userInfo_,
-      domain.ref.pointer,
+      _$$ref$1.pointer,
       code,
-      userInfo?.ref.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSError.fromPointer($ret, retain: false, release: true);
   }
 
   /// localizedDescription
   NSString get localizedDescription {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedDescription,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -5417,8 +5703,9 @@ extension NSError$Methods on NSError {
 
   /// localizedFailureReason
   NSString? get localizedFailureReason {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedFailureReason,
     );
     return $ret.address == 0
@@ -5428,8 +5715,9 @@ extension NSError$Methods on NSError {
 
   /// localizedRecoveryOptions
   NSArray? get localizedRecoveryOptions {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedRecoveryOptions,
     );
     return $ret.address == 0
@@ -5439,8 +5727,9 @@ extension NSError$Methods on NSError {
 
   /// localizedRecoverySuggestion
   NSString? get localizedRecoverySuggestion {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedRecoverySuggestion,
     );
     return $ret.address == 0
@@ -5450,10 +5739,8 @@ extension NSError$Methods on NSError {
 
   /// recoveryAttempter
   objc.ObjCObject? get recoveryAttempter {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_recoveryAttempter,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_recoveryAttempter);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -5462,21 +5749,20 @@ extension NSError$Methods on NSError {
   /// iOS: introduced 14.5.0
   /// macOS: introduced 11.3.0
   NSArray get underlyingErrors {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSError.underlyingErrors',
       iOS: (false, (14, 5, 0)),
       macOS: (false, (11, 3, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_underlyingErrors,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_underlyingErrors);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// userInfo
   NSDictionary get userInfo {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_userInfo);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_userInfo);
     return NSDictionary.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -5485,55 +5771,66 @@ extension NSError$Methods on NSError {
 extension NSExtendedArray on NSArray {
   /// arrayByAddingObject:
   NSArray arrayByAddingObject(objc.ObjCObject anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_arrayByAddingObject_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// arrayByAddingObjectsFromArray:
   NSArray arrayByAddingObjectsFromArray(NSArray otherArray) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherArray.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_arrayByAddingObjectsFromArray_,
-      otherArray.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// componentsJoinedByString:
   NSString componentsJoinedByString(NSString separator) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = separator.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_componentsJoinedByString_,
-      separator.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// containsObject:
   bool containsObject(objc.ObjCObject anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_containsObject_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// description
   NSString get description$1 {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_description);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_description);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale(objc.ObjCObject? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -5543,10 +5840,12 @@ extension NSExtendedArray on NSArray {
     objc.ObjCObject? locale, {
     required int indent,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     final $ret = _objc_msgSend_1k4kd9s(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_indent_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
       indent,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -5565,17 +5864,20 @@ extension NSExtendedArray on NSArray {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = s.ref;
+    final _$$ref$2 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSArray.enumerateObjectsAtIndexes:options:usingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_a3wp08(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateObjectsAtIndexes_options_usingBlock_,
-      s.ref.pointer,
+      _$$ref$1.pointer,
       options,
-      usingBlock.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -5590,15 +5892,17 @@ extension NSExtendedArray on NSArray {
     >
     block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSArray.enumerateObjectsUsingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateObjectsUsingBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -5614,27 +5918,30 @@ extension NSExtendedArray on NSArray {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSArray.enumerateObjectsWithOptions:usingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_yx8yc6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateObjectsWithOptions_usingBlock_,
       opts,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// firstObject
   objc.ObjCObject? get firstObject {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSArray.firstObject',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_firstObject);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_firstObject);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -5642,10 +5949,12 @@ extension NSExtendedArray on NSArray {
 
   /// firstObjectCommonWithArray:
   objc.ObjCObject? firstObjectCommonWithArray(NSArray otherArray) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherArray.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_firstObjectCommonWithArray_,
-      otherArray.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -5657,8 +5966,9 @@ extension NSExtendedArray on NSArray {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required NSRange range,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_o16d3k(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getObjects_range_,
       objects,
       range,
@@ -5667,19 +5977,23 @@ extension NSExtendedArray on NSArray {
 
   /// indexOfObject:
   int indexOfObject(objc.ObjCObject anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     return _objc_msgSend_1vd1c5m(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObject_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// indexOfObject:inRange:
   int indexOfObject$1(objc.ObjCObject anObject, {required NSRange inRange}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     return _objc_msgSend_zug4wi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObject_inRange_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
       inRange,
     );
   }
@@ -5697,18 +6011,21 @@ extension NSExtendedArray on NSArray {
     >
     usingComparator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj.ref;
+    final _$$ref$2 = usingComparator.ref;
     objc.checkOsVersionInternal(
       'NSArray.indexOfObject:inSortedRange:options:usingComparator:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return _objc_msgSend_kshx9d(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObject_inSortedRange_options_usingComparator_,
-      obj.ref.pointer,
+      _$$ref$1.pointer,
       inSortedRange,
       options,
-      usingComparator.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -5725,26 +6042,31 @@ extension NSExtendedArray on NSArray {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = s.ref;
+    final _$$ref$2 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSArray.indexOfObjectAtIndexes:options:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return _objc_msgSend_k1x6mt(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObjectAtIndexes_options_passingTest_,
-      s.ref.pointer,
+      _$$ref$1.pointer,
       options,
-      passingTest.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// indexOfObjectIdenticalTo:
   int indexOfObjectIdenticalTo(objc.ObjCObject anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     return _objc_msgSend_1vd1c5m(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObjectIdenticalTo_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -5753,10 +6075,12 @@ extension NSExtendedArray on NSArray {
     objc.ObjCObject anObject, {
     required NSRange inRange,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     return _objc_msgSend_zug4wi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObjectIdenticalTo_inRange_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
       inRange,
     );
   }
@@ -5772,15 +6096,17 @@ extension NSExtendedArray on NSArray {
     >
     predicate,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = predicate.ref;
     objc.checkOsVersionInternal(
       'NSArray.indexOfObjectPassingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return _objc_msgSend_10mlopr(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObjectPassingTest_,
-      predicate.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -5796,16 +6122,18 @@ extension NSExtendedArray on NSArray {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSArray.indexOfObjectWithOptions:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return _objc_msgSend_1698hqz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObjectWithOptions_passingTest_,
       opts,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -5822,17 +6150,20 @@ extension NSExtendedArray on NSArray {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = s.ref;
+    final _$$ref$2 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSArray.indexesOfObjectsAtIndexes:options:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1i9v144(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesOfObjectsAtIndexes_options_passingTest_,
-      s.ref.pointer,
+      _$$ref$1.pointer,
       options,
-      passingTest.ref.pointer,
+      _$$ref$2.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
@@ -5848,15 +6179,17 @@ extension NSExtendedArray on NSArray {
     >
     predicate,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = predicate.ref;
     objc.checkOsVersionInternal(
       'NSArray.indexesOfObjectsPassingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesOfObjectsPassingTest_,
-      predicate.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
@@ -5873,32 +6206,37 @@ extension NSExtendedArray on NSArray {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSArray.indexesOfObjectsWithOptions:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_13x5boi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesOfObjectsWithOptions_passingTest_,
       opts,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// isEqualToArray:
   bool isEqualToArray(NSArray otherArray) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherArray.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToArray_,
-      otherArray.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// lastObject
   objc.ObjCObject? get lastObject {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_lastObject);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_lastObject);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -5906,8 +6244,9 @@ extension NSExtendedArray on NSArray {
 
   /// makeObjectsPerformSelector:
   void makeObjectsPerformSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
+    final _$$ref = object$.ref;
     _objc_msgSend_1d9e4oe(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_makeObjectsPerformSelector_,
       aSelector,
     );
@@ -5918,23 +6257,26 @@ extension NSExtendedArray on NSArray {
     ffi.Pointer<objc.ObjCSelector> aSelector, {
     objc.ObjCObject? withObject,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withObject?.ref;
     _objc_msgSend_1qv0eq4(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_makeObjectsPerformSelector_withObject_,
       aSelector,
-      withObject?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// objectAtIndexedSubscript:
   objc.ObjCObject objectAtIndexedSubscript(int idx) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSArray.objectAtIndexedSubscript:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectAtIndexedSubscript_,
       idx,
     );
@@ -5943,27 +6285,28 @@ extension NSExtendedArray on NSArray {
 
   /// objectEnumerator
   NSEnumerator objectEnumerator() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_objectEnumerator,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_objectEnumerator);
     return NSEnumerator.fromPointer($ret, retain: true, release: true);
   }
 
   /// objectsAtIndexes:
   NSArray objectsAtIndexes(NSIndexSet indexes) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexes.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectsAtIndexes_,
-      indexes.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// reverseObjectEnumerator
   NSEnumerator reverseObjectEnumerator() {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_reverseObjectEnumerator,
     );
     return NSEnumerator.fromPointer($ret, retain: true, release: true);
@@ -5971,10 +6314,8 @@ extension NSExtendedArray on NSArray {
 
   /// sortedArrayHint
   NSData get sortedArrayHint {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_sortedArrayHint,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_sortedArrayHint);
     return NSData.fromPointer($ret, retain: true, release: true);
   }
 
@@ -5988,15 +6329,17 @@ extension NSExtendedArray on NSArray {
     >
     cmptr,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = cmptr.ref;
     objc.checkOsVersionInternal(
       'NSArray.sortedArrayUsingComparator:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortedArrayUsingComparator_,
-      cmptr.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
@@ -6015,8 +6358,9 @@ extension NSExtendedArray on NSArray {
     comparator, {
     required ffi.Pointer<ffi.Void> context,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1ffoev1(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortedArrayUsingFunction_context_,
       comparator,
       context,
@@ -6039,20 +6383,23 @@ extension NSExtendedArray on NSArray {
     required ffi.Pointer<ffi.Void> context,
     NSData? hint,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = hint?.ref;
     final $ret = _objc_msgSend_1i2r70j(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortedArrayUsingFunction_context_hint_,
       comparator,
       context,
-      hint?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// sortedArrayUsingSelector:
   NSArray sortedArrayUsingSelector(ffi.Pointer<objc.ObjCSelector> comparator) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_3ctkt6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortedArrayUsingSelector_,
       comparator,
     );
@@ -6070,24 +6417,27 @@ extension NSExtendedArray on NSArray {
     >
     usingComparator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingComparator.ref;
     objc.checkOsVersionInternal(
       'NSArray.sortedArrayWithOptions:usingComparator:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1x5ew3h(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortedArrayWithOptions_usingComparator_,
       opts,
-      usingComparator.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// subarrayWithRange:
   NSArray subarrayWithRange(NSRange range) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1k1o1s7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_subarrayWithRange_,
       range,
     );
@@ -6096,6 +6446,8 @@ extension NSExtendedArray on NSArray {
 
   /// writeToURL:error:
   bool writeToURL(NSURL url) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     objc.checkOsVersionInternal(
       'NSArray.writeToURL:error:',
       iOS: (false, (11, 0, 0)),
@@ -6104,9 +6456,9 @@ extension NSExtendedArray on NSArray {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_l9p60w(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_writeToURL_error_,
-        url.ref.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -6121,7 +6473,8 @@ extension NSExtendedArray on NSArray {
 extension NSExtendedData on NSData {
   /// description
   NSString get description$1 {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_description);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_description);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
@@ -6132,44 +6485,40 @@ extension NSExtendedData on NSData {
     >
     block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSData.enumerateByteRangesUsingBlock:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateByteRangesUsingBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// getBytes:length:
   void getBytes(ffi.Pointer<ffi.Void> buffer, {required int length}) {
-    _objc_msgSend_zuf90e(
-      object$.ref.pointer,
-      _sel_getBytes_length_,
-      buffer,
-      length,
-    );
+    final _$$ref = object$.ref;
+    _objc_msgSend_zuf90e(_$$ref.pointer, _sel_getBytes_length_, buffer, length);
   }
 
   /// getBytes:range:
   void getBytes$1(ffi.Pointer<ffi.Void> buffer, {required NSRange range}) {
-    _objc_msgSend_xpqfd7(
-      object$.ref.pointer,
-      _sel_getBytes_range_,
-      buffer,
-      range,
-    );
+    final _$$ref = object$.ref;
+    _objc_msgSend_xpqfd7(_$$ref.pointer, _sel_getBytes_range_, buffer, range);
   }
 
   /// isEqualToData:
   bool isEqualToData(NSData other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToData_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -6179,6 +6528,8 @@ extension NSExtendedData on NSData {
     required int options,
     required NSRange range,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = dataToFind.ref;
     objc.checkOsVersionInternal(
       'NSData.rangeOfData:options:range:',
       iOS: (false, (4, 0, 0)),
@@ -6188,16 +6539,16 @@ extension NSExtendedData on NSData {
     objc.useMsgSendVariants
         ? _objc_msgSend_1d8s65wStret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfData_options_range_,
-            dataToFind.ref.pointer,
+            _$$ref$1.pointer,
             options,
             range,
           )
         : $ptr.ref = _objc_msgSend_1d8s65w(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfData_options_range_,
-            dataToFind.ref.pointer,
+            _$$ref$1.pointer,
             options,
             range,
           );
@@ -6210,8 +6561,9 @@ extension NSExtendedData on NSData {
 
   /// subdataWithRange:
   NSData subdataWithRange(NSRange range) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1k1o1s7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_subdataWithRange_,
       range,
     );
@@ -6220,10 +6572,12 @@ extension NSExtendedData on NSData {
 
   /// writeToFile:atomically:
   bool writeToFile(NSString path, {required bool atomically}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     return _objc_msgSend_1iyq28l(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_writeToFile_atomically_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
       atomically,
     );
   }
@@ -6234,10 +6588,12 @@ extension NSExtendedData on NSData {
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     return _objc_msgSend_1xi08ar(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_writeToFile_options_error_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
       options,
       error,
     );
@@ -6245,10 +6601,12 @@ extension NSExtendedData on NSData {
 
   /// writeToURL:atomically:
   bool writeToURL(NSURL url, {required bool atomically}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     return _objc_msgSend_1iyq28l(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_writeToURL_atomically_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
       atomically,
     );
   }
@@ -6259,10 +6617,12 @@ extension NSExtendedData on NSData {
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     return _objc_msgSend_1xi08ar(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_writeToURL_options_error_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
       options,
       error,
     );
@@ -6273,95 +6633,101 @@ extension NSExtendedData on NSData {
 extension NSExtendedDate on NSDate {
   /// compare:
   NSComparisonResult compare(NSDate other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     final $ret = _objc_msgSend_1ym6zyw(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_compare_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSComparisonResult.fromValue($ret);
   }
 
   /// description
   NSString get description$1 {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_description);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_description);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale(objc.ObjCObject? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// earlierDate:
   NSDate earlierDate(NSDate anotherDate) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anotherDate.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_earlierDate_,
-      anotherDate.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSDate.fromPointer($ret, retain: true, release: true);
   }
 
   /// isEqualToDate:
   bool isEqualToDate(NSDate otherDate) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherDate.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToDate_,
-      otherDate.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// laterDate:
   NSDate laterDate(NSDate anotherDate) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anotherDate.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_laterDate_,
-      anotherDate.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSDate.fromPointer($ret, retain: true, release: true);
   }
 
   /// timeIntervalSince1970
   double get timeIntervalSince1970 {
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(
-            object$.ref.pointer,
-            _sel_timeIntervalSince1970,
-          )
-        : _objc_msgSend_1ukqyt8(
-            object$.ref.pointer,
-            _sel_timeIntervalSince1970,
-          );
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_timeIntervalSince1970)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_timeIntervalSince1970);
   }
 
   /// timeIntervalSinceDate:
   double timeIntervalSinceDate(NSDate anotherDate) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anotherDate.ref;
     return objc.useMsgSendVariants
         ? _objc_msgSend_mabicuFpret(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_timeIntervalSinceDate_,
-            anotherDate.ref.pointer,
+            _$$ref$1.pointer,
           )
         : _objc_msgSend_mabicu(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_timeIntervalSinceDate_,
-            anotherDate.ref.pointer,
+            _$$ref$1.pointer,
           );
   }
 
   /// timeIntervalSinceNow
   double get timeIntervalSinceNow {
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(
-            object$.ref.pointer,
-            _sel_timeIntervalSinceNow,
-          )
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_timeIntervalSinceNow);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_timeIntervalSinceNow)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_timeIntervalSinceNow);
   }
 
   /// timeIntervalSinceReferenceDate
@@ -6382,36 +6748,42 @@ extension NSExtendedDate on NSDate {
 extension NSExtendedDictionary on NSDictionary {
   /// allKeys
   NSArray get allKeys {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_allKeys);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_allKeys);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// allKeysForObject:
   NSArray allKeysForObject(objc.ObjCObject anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_allKeysForObject_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// allValues
   NSArray get allValues {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_allValues);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_allValues);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// description
   NSString get description$1 {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_description);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_description);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// descriptionInStringsFileFormat
   NSString get descriptionInStringsFileFormat {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionInStringsFileFormat,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -6419,10 +6791,12 @@ extension NSExtendedDictionary on NSDictionary {
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale(objc.ObjCObject? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -6432,10 +6806,12 @@ extension NSExtendedDictionary on NSDictionary {
     objc.ObjCObject? locale, {
     required int indent,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     final $ret = _objc_msgSend_1k4kd9s(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_indent_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
       indent,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -6452,15 +6828,17 @@ extension NSExtendedDictionary on NSDictionary {
     >
     block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.enumerateKeysAndObjectsUsingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateKeysAndObjectsUsingBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -6476,16 +6854,18 @@ extension NSExtendedDictionary on NSDictionary {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.enumerateKeysAndObjectsWithOptions:usingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_yx8yc6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateKeysAndObjectsWithOptions_usingBlock_,
       opts,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -6495,13 +6875,14 @@ extension NSExtendedDictionary on NSDictionary {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> andKeys,
     required int count,
   }) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.getObjects:andKeys:count:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_n2svg2(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getObjects_andKeys_count_,
       objects,
       andKeys,
@@ -6511,10 +6892,12 @@ extension NSExtendedDictionary on NSDictionary {
 
   /// isEqualToDictionary:
   bool isEqualToDictionary(NSDictionary otherDictionary) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherDictionary.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToDictionary_,
-      otherDictionary.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -6529,15 +6912,17 @@ extension NSExtendedDictionary on NSDictionary {
     >
     predicate,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = predicate.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.keysOfEntriesPassingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_keysOfEntriesPassingTest_,
-      predicate.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
@@ -6554,16 +6939,18 @@ extension NSExtendedDictionary on NSDictionary {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.keysOfEntriesWithOptions:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_13x5boi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_keysOfEntriesWithOptions_passingTest_,
       opts,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
@@ -6578,15 +6965,17 @@ extension NSExtendedDictionary on NSDictionary {
     >
     cmptr,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = cmptr.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.keysSortedByValueUsingComparator:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_keysSortedByValueUsingComparator_,
-      cmptr.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
@@ -6595,8 +6984,9 @@ extension NSExtendedDictionary on NSDictionary {
   NSArray keysSortedByValueUsingSelector(
     ffi.Pointer<objc.ObjCSelector> comparator,
   ) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_3ctkt6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_keysSortedByValueUsingSelector_,
       comparator,
     );
@@ -6614,40 +7004,42 @@ extension NSExtendedDictionary on NSDictionary {
     >
     usingComparator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingComparator.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.keysSortedByValueWithOptions:usingComparator:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1x5ew3h(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_keysSortedByValueWithOptions_usingComparator_,
       opts,
-      usingComparator.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// objectEnumerator
   NSEnumerator objectEnumerator() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_objectEnumerator,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_objectEnumerator);
     return NSEnumerator.fromPointer($ret, retain: true, release: true);
   }
 
   /// objectForKeyedSubscript:
   objc.ObjCObject? objectForKeyedSubscript(objc.ObjCObject key) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = key.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.objectForKeyedSubscript:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectForKeyedSubscript_,
-      key.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -6659,17 +7051,22 @@ extension NSExtendedDictionary on NSDictionary {
     NSArray keys, {
     required objc.ObjCObject notFoundMarker,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = keys.ref;
+    final _$$ref$2 = notFoundMarker.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectsForKeys_notFoundMarker_,
-      keys.ref.pointer,
-      notFoundMarker.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// writeToURL:error:
   bool writeToURL(NSURL url) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     objc.checkOsVersionInternal(
       'NSDictionary.writeToURL:error:',
       iOS: (false, (11, 0, 0)),
@@ -6678,9 +7075,9 @@ extension NSExtendedDictionary on NSDictionary {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_l9p60w(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_writeToURL_error_,
-        url.ref.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -6695,7 +7092,8 @@ extension NSExtendedDictionary on NSDictionary {
 extension NSExtendedEnumerator on NSEnumerator {
   /// allObjects
   NSArray get allObjects {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_allObjects);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_allObjects);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -6704,17 +7102,20 @@ extension NSExtendedEnumerator on NSEnumerator {
 extension NSExtendedMutableArray on NSMutableArray {
   /// addObjectsFromArray:
   void addObjectsFromArray(NSArray otherArray) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherArray.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addObjectsFromArray_,
-      otherArray.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// exchangeObjectAtIndex:withObjectAtIndex:
   void exchangeObjectAtIndex(int idx1, {required int withObjectAtIndex}) {
+    final _$$ref = object$.ref;
     _objc_msgSend_bfp043(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_exchangeObjectAtIndex_withObjectAtIndex_,
       idx1,
       withObjectAtIndex,
@@ -6723,44 +7124,50 @@ extension NSExtendedMutableArray on NSMutableArray {
 
   /// insertObjects:atIndexes:
   void insertObjects(NSArray objects, {required NSIndexSet atIndexes}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = objects.ref;
+    final _$$ref$2 = atIndexes.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_insertObjects_atIndexes_,
-      objects.ref.pointer,
-      atIndexes.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// removeAllObjects
   void removeAllObjects() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_removeAllObjects);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_removeAllObjects);
   }
 
   /// removeObject:
   void removeObject(objc.ObjCObject anObject) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_removeObject_,
-      anObject.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_removeObject_, _$$ref$1.pointer);
   }
 
   /// removeObject:inRange:
   void removeObject$1(objc.ObjCObject anObject, {required NSRange inRange}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     _objc_msgSend_1oteutl(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObject_inRange_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
       inRange,
     );
   }
 
   /// removeObjectIdenticalTo:
   void removeObjectIdenticalTo(objc.ObjCObject anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObjectIdenticalTo_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -6769,39 +7176,42 @@ extension NSExtendedMutableArray on NSMutableArray {
     objc.ObjCObject anObject, {
     required NSRange inRange,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     _objc_msgSend_1oteutl(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObjectIdenticalTo_inRange_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
       inRange,
     );
   }
 
   /// removeObjectsAtIndexes:
   void removeObjectsAtIndexes(NSIndexSet indexes) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexes.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObjectsAtIndexes_,
-      indexes.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// removeObjectsInArray:
   void removeObjectsInArray(NSArray otherArray) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherArray.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObjectsInArray_,
-      otherArray.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// removeObjectsInRange:
   void removeObjectsInRange(NSRange range) {
-    _objc_msgSend_1e3pm0z(
-      object$.ref.pointer,
-      _sel_removeObjectsInRange_,
-      range,
-    );
+    final _$$ref = object$.ref;
+    _objc_msgSend_1e3pm0z(_$$ref.pointer, _sel_removeObjectsInRange_, range);
   }
 
   /// replaceObjectsAtIndexes:withObjects:
@@ -6809,11 +7219,14 @@ extension NSExtendedMutableArray on NSMutableArray {
     NSIndexSet indexes, {
     required NSArray withObjects,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexes.ref;
+    final _$$ref$2 = withObjects.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceObjectsAtIndexes_withObjects_,
-      indexes.ref.pointer,
-      withObjects.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -6822,11 +7235,13 @@ extension NSExtendedMutableArray on NSMutableArray {
     NSRange range, {
     required NSArray withObjectsFromArray,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withObjectsFromArray.ref;
     _objc_msgSend_1tv4uax(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceObjectsInRange_withObjectsFromArray_,
       range,
-      withObjectsFromArray.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -6836,35 +7251,37 @@ extension NSExtendedMutableArray on NSMutableArray {
     required NSArray withObjectsFromArray,
     required NSRange range$1,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withObjectsFromArray.ref;
     _objc_msgSend_15bolr3(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceObjectsInRange_withObjectsFromArray_range_,
       range,
-      withObjectsFromArray.ref.pointer,
+      _$$ref$1.pointer,
       range$1,
     );
   }
 
   /// setArray:
   void setArray(NSArray otherArray) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setArray_,
-      otherArray.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherArray.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setArray_, _$$ref$1.pointer);
   }
 
   /// setObject:atIndexedSubscript:
   void setObject(objc.ObjCObject obj, {required int atIndexedSubscript}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj.ref;
     objc.checkOsVersionInternal(
       'NSMutableArray.setObject:atIndexedSubscript:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     _objc_msgSend_djsa9o(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setObject_atIndexedSubscript_,
-      obj.ref.pointer,
+      _$$ref$1.pointer,
       atIndexedSubscript,
     );
   }
@@ -6879,15 +7296,17 @@ extension NSExtendedMutableArray on NSMutableArray {
     >
     cmptr,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = cmptr.ref;
     objc.checkOsVersionInternal(
       'NSMutableArray.sortUsingComparator:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortUsingComparator_,
-      cmptr.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -6905,8 +7324,9 @@ extension NSExtendedMutableArray on NSMutableArray {
     compare, {
     required ffi.Pointer<ffi.Void> context,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_1bvics1(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortUsingFunction_context_,
       compare,
       context,
@@ -6915,11 +7335,8 @@ extension NSExtendedMutableArray on NSMutableArray {
 
   /// sortUsingSelector:
   void sortUsingSelector(ffi.Pointer<objc.ObjCSelector> comparator) {
-    _objc_msgSend_1d9e4oe(
-      object$.ref.pointer,
-      _sel_sortUsingSelector_,
-      comparator,
-    );
+    final _$$ref = object$.ref;
+    _objc_msgSend_1d9e4oe(_$$ref.pointer, _sel_sortUsingSelector_, comparator);
   }
 
   /// sortWithOptions:usingComparator:
@@ -6933,16 +7350,18 @@ extension NSExtendedMutableArray on NSMutableArray {
     >
     usingComparator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingComparator.ref;
     objc.checkOsVersionInternal(
       'NSMutableArray.sortWithOptions:usingComparator:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_jjgvjt(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortWithOptions_usingComparator_,
       opts,
-      usingComparator.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 }
@@ -6951,8 +7370,9 @@ extension NSExtendedMutableArray on NSMutableArray {
 extension NSExtendedMutableData on NSMutableData {
   /// appendBytes:length:
   void appendBytes(ffi.Pointer<ffi.Void> bytes, {required int length}) {
+    final _$$ref = object$.ref;
     _objc_msgSend_zuf90e(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_appendBytes_length_,
       bytes,
       length,
@@ -6961,20 +7381,15 @@ extension NSExtendedMutableData on NSMutableData {
 
   /// appendData:
   void appendData(NSData other) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_appendData_,
-      other.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_appendData_, _$$ref$1.pointer);
   }
 
   /// increaseLengthBy:
   void increaseLengthBy(int extraLength) {
-    _objc_msgSend_1i9r4xy(
-      object$.ref.pointer,
-      _sel_increaseLengthBy_,
-      extraLength,
-    );
+    final _$$ref = object$.ref;
+    _objc_msgSend_1i9r4xy(_$$ref.pointer, _sel_increaseLengthBy_, extraLength);
   }
 
   /// replaceBytesInRange:withBytes:
@@ -6982,8 +7397,9 @@ extension NSExtendedMutableData on NSMutableData {
     NSRange range, {
     required ffi.Pointer<ffi.Void> withBytes,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_eh32gn(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceBytesInRange_withBytes_,
       range,
       withBytes,
@@ -6996,8 +7412,9 @@ extension NSExtendedMutableData on NSMutableData {
     required ffi.Pointer<ffi.Void> withBytes,
     required int length,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_c0vg4w(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceBytesInRange_withBytes_length_,
       range,
       withBytes,
@@ -7007,12 +7424,15 @@ extension NSExtendedMutableData on NSMutableData {
 
   /// resetBytesInRange:
   void resetBytesInRange(NSRange range) {
-    _objc_msgSend_1e3pm0z(object$.ref.pointer, _sel_resetBytesInRange_, range);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1e3pm0z(_$$ref.pointer, _sel_resetBytesInRange_, range);
   }
 
   /// setData:
   void setData(NSData data) {
-    _objc_msgSend_xtuoz7(object$.ref.pointer, _sel_setData_, data.ref.pointer);
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setData_, _$$ref$1.pointer);
   }
 }
 
@@ -7020,34 +7440,37 @@ extension NSExtendedMutableData on NSMutableData {
 extension NSExtendedMutableDictionary on NSMutableDictionary {
   /// addEntriesFromDictionary:
   void addEntriesFromDictionary(NSDictionary otherDictionary) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherDictionary.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addEntriesFromDictionary_,
-      otherDictionary.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// removeAllObjects
   void removeAllObjects() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_removeAllObjects);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_removeAllObjects);
   }
 
   /// removeObjectsForKeys:
   void removeObjectsForKeys(NSArray keyArray) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = keyArray.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObjectsForKeys_,
-      keyArray.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// setDictionary:
   void setDictionary(NSDictionary otherDictionary) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setDictionary_,
-      otherDictionary.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherDictionary.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setDictionary_, _$$ref$1.pointer);
   }
 
   /// setObject:forKeyedSubscript:
@@ -7055,16 +7478,19 @@ extension NSExtendedMutableDictionary on NSMutableDictionary {
     objc.ObjCObject? obj, {
     required NSCopying forKeyedSubscript,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj?.ref;
+    final _$$ref$2 = forKeyedSubscript.ref;
     objc.checkOsVersionInternal(
       'NSMutableDictionary.setObject:forKeyedSubscript:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setObject_forKeyedSubscript_,
-      obj?.ref.pointer ?? ffi.nullptr,
-      forKeyedSubscript.ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2.pointer,
     );
   }
 }
@@ -7073,16 +7499,14 @@ extension NSExtendedMutableDictionary on NSMutableDictionary {
 extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   /// addObject:
   void addObject(objc.ObjCObject object) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.addObject:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_addObject_,
-      object.ref.pointer,
-    );
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_addObject_, _$$ref$1.pointer);
   }
 
   /// addObjects:count:
@@ -7090,13 +7514,14 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required int count,
   }) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.addObjects:count:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_gcjqkl(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addObjects_count_,
       objects,
       count,
@@ -7105,27 +7530,30 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
 
   /// addObjectsFromArray:
   void addObjectsFromArray(NSArray array) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = array.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.addObjectsFromArray:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addObjectsFromArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// exchangeObjectAtIndex:withObjectAtIndex:
   void exchangeObjectAtIndex(int idx1, {required int withObjectAtIndex}) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.exchangeObjectAtIndex:withObjectAtIndex:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_bfp043(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_exchangeObjectAtIndex_withObjectAtIndex_,
       idx1,
       withObjectAtIndex,
@@ -7134,154 +7562,159 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
 
   /// insertObjects:atIndexes:
   void insertObjects(NSArray objects, {required NSIndexSet atIndexes}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = objects.ref;
+    final _$$ref$2 = atIndexes.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.insertObjects:atIndexes:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_insertObjects_atIndexes_,
-      objects.ref.pointer,
-      atIndexes.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// intersectOrderedSet:
   void intersectOrderedSet(NSOrderedSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.intersectOrderedSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_intersectOrderedSet_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// intersectSet:
   void intersectSet(NSSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.intersectSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_intersectSet_,
-      other.ref.pointer,
-    );
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_intersectSet_, _$$ref$1.pointer);
   }
 
   /// minusOrderedSet:
   void minusOrderedSet(NSOrderedSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.minusOrderedSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_minusOrderedSet_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// minusSet:
   void minusSet(NSSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.minusSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_minusSet_,
-      other.ref.pointer,
-    );
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_minusSet_, _$$ref$1.pointer);
   }
 
   /// moveObjectsAtIndexes:toIndex:
   void moveObjectsAtIndexes(NSIndexSet indexes, {required int toIndex}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexes.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.moveObjectsAtIndexes:toIndex:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_djsa9o(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_moveObjectsAtIndexes_toIndex_,
-      indexes.ref.pointer,
+      _$$ref$1.pointer,
       toIndex,
     );
   }
 
   /// removeAllObjects
   void removeAllObjects() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.removeAllObjects',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_removeAllObjects);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_removeAllObjects);
   }
 
   /// removeObject:
   void removeObject(objc.ObjCObject object) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.removeObject:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_removeObject_,
-      object.ref.pointer,
-    );
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_removeObject_, _$$ref$1.pointer);
   }
 
   /// removeObjectsAtIndexes:
   void removeObjectsAtIndexes(NSIndexSet indexes) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexes.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.removeObjectsAtIndexes:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObjectsAtIndexes_,
-      indexes.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// removeObjectsInArray:
   void removeObjectsInArray(NSArray array) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = array.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.removeObjectsInArray:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObjectsInArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// removeObjectsInRange:
   void removeObjectsInRange(NSRange range) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.removeObjectsInRange:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1e3pm0z(
-      object$.ref.pointer,
-      _sel_removeObjectsInRange_,
-      range,
-    );
+    _objc_msgSend_1e3pm0z(_$$ref.pointer, _sel_removeObjectsInRange_, range);
   }
 
   /// replaceObjectsAtIndexes:withObjects:
@@ -7289,16 +7722,19 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
     NSIndexSet indexes, {
     required NSArray withObjects,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexes.ref;
+    final _$$ref$2 = withObjects.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.replaceObjectsAtIndexes:withObjects:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceObjectsAtIndexes_withObjects_,
-      indexes.ref.pointer,
-      withObjects.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -7308,13 +7744,14 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> withObjects,
     required int count,
   }) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.replaceObjectsInRange:withObjects:count:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_122v0cv(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceObjectsInRange_withObjects_count_,
       range,
       withObjects,
@@ -7324,30 +7761,34 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
 
   /// setObject:atIndex:
   void setObject(objc.ObjCObject obj, {required int atIndex}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.setObject:atIndex:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_djsa9o(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setObject_atIndex_,
-      obj.ref.pointer,
+      _$$ref$1.pointer,
       atIndex,
     );
   }
 
   /// setObject:atIndexedSubscript:
   void setObject$1(objc.ObjCObject obj, {required int atIndexedSubscript}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = obj.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.setObject:atIndexedSubscript:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     _objc_msgSend_djsa9o(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setObject_atIndexedSubscript_,
-      obj.ref.pointer,
+      _$$ref$1.pointer,
       atIndexedSubscript,
     );
   }
@@ -7364,17 +7805,19 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
     >
     usingComparator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingComparator.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.sortRange:options:usingComparator:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_arew0j(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortRange_options_usingComparator_,
       range,
       options,
-      usingComparator.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -7388,15 +7831,17 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
     >
     cmptr,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = cmptr.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.sortUsingComparator:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortUsingComparator_,
-      cmptr.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -7411,45 +7856,47 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
     >
     usingComparator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingComparator.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.sortWithOptions:usingComparator:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_jjgvjt(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortWithOptions_usingComparator_,
       opts,
-      usingComparator.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// unionOrderedSet:
   void unionOrderedSet(NSOrderedSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.unionOrderedSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_unionOrderedSet_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// unionSet:
   void unionSet(NSSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.unionSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_unionSet_,
-      other.ref.pointer,
-    );
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_unionSet_, _$$ref$1.pointer);
   }
 }
 
@@ -7457,52 +7904,47 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
 extension NSExtendedMutableSet on NSMutableSet {
   /// addObjectsFromArray:
   void addObjectsFromArray(NSArray array) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = array.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addObjectsFromArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// intersectSet:
   void intersectSet(NSSet otherSet) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_intersectSet_,
-      otherSet.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherSet.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_intersectSet_, _$$ref$1.pointer);
   }
 
   /// minusSet:
   void minusSet(NSSet otherSet) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_minusSet_,
-      otherSet.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherSet.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_minusSet_, _$$ref$1.pointer);
   }
 
   /// removeAllObjects
   void removeAllObjects() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_removeAllObjects);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_removeAllObjects);
   }
 
   /// setSet:
   void setSet(NSSet otherSet) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setSet_,
-      otherSet.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherSet.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setSet_, _$$ref$1.pointer);
   }
 
   /// unionSet:
   void unionSet(NSSet otherSet) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_unionSet_,
-      otherSet.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherSet.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_unionSet_, _$$ref$1.pointer);
   }
 }
 
@@ -7510,51 +7952,57 @@ extension NSExtendedMutableSet on NSMutableSet {
 extension NSExtendedOrderedSet on NSOrderedSet {
   /// array
   NSArray get array {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.array',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_array);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_array);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// containsObject:
   bool containsObject(objc.ObjCObject object) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.containsObject:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_containsObject_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// description
   NSString get description$1 {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.description',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_description);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_description);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale(objc.ObjCObject? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.descriptionWithLocale:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -7564,15 +8012,17 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     objc.ObjCObject? locale, {
     required int indent,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.descriptionWithLocale:indent:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1k4kd9s(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_indent_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
       indent,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -7591,17 +8041,20 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = s.ref;
+    final _$$ref$2 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.enumerateObjectsAtIndexes:options:usingBlock:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_a3wp08(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateObjectsAtIndexes_options_usingBlock_,
-      s.ref.pointer,
+      _$$ref$1.pointer,
       options,
-      usingBlock.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -7616,15 +8069,17 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.enumerateObjectsUsingBlock:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateObjectsUsingBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -7640,27 +8095,30 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.enumerateObjectsWithOptions:usingBlock:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_yx8yc6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateObjectsWithOptions_usingBlock_,
       opts,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// firstObject
   objc.ObjCObject? get firstObject {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.firstObject',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_firstObject);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_firstObject);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -7671,8 +8129,9 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required NSRange range,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_o16d3k(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getObjects_range_,
       objects,
       range,
@@ -7692,18 +8151,21 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     usingComparator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
+    final _$$ref$2 = usingComparator.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.indexOfObject:inSortedRange:options:usingComparator:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_kshx9d(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObject_inSortedRange_options_usingComparator_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
       inSortedRange,
       options,
-      usingComparator.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -7720,17 +8182,20 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = s.ref;
+    final _$$ref$2 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.indexOfObjectAtIndexes:options:passingTest:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_k1x6mt(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObjectAtIndexes_options_passingTest_,
-      s.ref.pointer,
+      _$$ref$1.pointer,
       options,
-      passingTest.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -7745,15 +8210,17 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     predicate,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = predicate.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.indexOfObjectPassingTest:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_10mlopr(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObjectPassingTest_,
-      predicate.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -7769,16 +8236,18 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.indexOfObjectWithOptions:passingTest:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_1698hqz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObjectWithOptions_passingTest_,
       opts,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -7795,17 +8264,20 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = s.ref;
+    final _$$ref$2 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.indexesOfObjectsAtIndexes:options:passingTest:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1i9v144(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesOfObjectsAtIndexes_options_passingTest_,
-      s.ref.pointer,
+      _$$ref$1.pointer,
       options,
-      passingTest.ref.pointer,
+      _$$ref$2.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
@@ -7821,15 +8293,17 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     predicate,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = predicate.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.indexesOfObjectsPassingTest:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesOfObjectsPassingTest_,
-      predicate.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
@@ -7846,98 +8320,111 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.indexesOfObjectsWithOptions:passingTest:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_13x5boi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesOfObjectsWithOptions_passingTest_,
       opts,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// intersectsOrderedSet:
   bool intersectsOrderedSet(NSOrderedSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.intersectsOrderedSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_intersectsOrderedSet_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// intersectsSet:
   bool intersectsSet(NSSet set) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.intersectsSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_intersectsSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// isEqualToOrderedSet:
   bool isEqualToOrderedSet(NSOrderedSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.isEqualToOrderedSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToOrderedSet_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// isSubsetOfOrderedSet:
   bool isSubsetOfOrderedSet(NSOrderedSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.isSubsetOfOrderedSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isSubsetOfOrderedSet_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// isSubsetOfSet:
   bool isSubsetOfSet(NSSet set) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.isSubsetOfSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isSubsetOfSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// lastObject
   objc.ObjCObject? get lastObject {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.lastObject',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_lastObject);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_lastObject);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -7945,13 +8432,14 @@ extension NSExtendedOrderedSet on NSOrderedSet {
 
   /// objectAtIndexedSubscript:
   objc.ObjCObject objectAtIndexedSubscript(int idx) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.objectAtIndexedSubscript:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectAtIndexedSubscript_,
       idx,
     );
@@ -7960,42 +8448,43 @@ extension NSExtendedOrderedSet on NSOrderedSet {
 
   /// objectEnumerator
   NSEnumerator objectEnumerator() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.objectEnumerator',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_objectEnumerator,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_objectEnumerator);
     return NSEnumerator.fromPointer($ret, retain: true, release: true);
   }
 
   /// objectsAtIndexes:
   NSArray objectsAtIndexes(NSIndexSet indexes) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexes.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.objectsAtIndexes:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectsAtIndexes_,
-      indexes.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// reverseObjectEnumerator
   NSEnumerator reverseObjectEnumerator() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.reverseObjectEnumerator',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_reverseObjectEnumerator,
     );
     return NSEnumerator.fromPointer($ret, retain: true, release: true);
@@ -8003,26 +8492,25 @@ extension NSExtendedOrderedSet on NSOrderedSet {
 
   /// reversedOrderedSet
   NSOrderedSet get reversedOrderedSet {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.reversedOrderedSet',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_reversedOrderedSet,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_reversedOrderedSet);
     return NSOrderedSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// set
   NSSet get set {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.set',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_set);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_set);
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
 
@@ -8036,15 +8524,17 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     cmptr,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = cmptr.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.sortedArrayUsingComparator:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortedArrayUsingComparator_,
-      cmptr.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
@@ -8060,16 +8550,18 @@ extension NSExtendedOrderedSet on NSOrderedSet {
     >
     usingComparator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingComparator.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.sortedArrayWithOptions:usingComparator:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1x5ew3h(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sortedArrayWithOptions_usingComparator_,
       opts,
-      usingComparator.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
@@ -8079,13 +8571,15 @@ extension NSExtendedOrderedSet on NSOrderedSet {
 extension NSExtendedSet on NSSet {
   /// allObjects
   NSArray get allObjects {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_allObjects);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_allObjects);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// anyObject
   objc.ObjCObject? anyObject() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_anyObject);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_anyObject);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -8093,25 +8587,30 @@ extension NSExtendedSet on NSSet {
 
   /// containsObject:
   bool containsObject(objc.ObjCObject anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_containsObject_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// description
   NSString get description$1 {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_description);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_description);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale(objc.ObjCObject? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -8123,15 +8622,17 @@ extension NSExtendedSet on NSSet {
     >
     block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSSet.enumerateObjectsUsingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateObjectsUsingBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -8143,50 +8644,59 @@ extension NSExtendedSet on NSSet {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSSet.enumerateObjectsWithOptions:usingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_yx8yc6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateObjectsWithOptions_usingBlock_,
       opts,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// intersectsSet:
   bool intersectsSet(NSSet otherSet) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherSet.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_intersectsSet_,
-      otherSet.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// isEqualToSet:
   bool isEqualToSet(NSSet otherSet) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherSet.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToSet_,
-      otherSet.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// isSubsetOfSet:
   bool isSubsetOfSet(NSSet otherSet) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherSet.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isSubsetOfSet_,
-      otherSet.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// makeObjectsPerformSelector:
   void makeObjectsPerformSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
+    final _$$ref = object$.ref;
     _objc_msgSend_1d9e4oe(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_makeObjectsPerformSelector_,
       aSelector,
     );
@@ -8197,11 +8707,13 @@ extension NSExtendedSet on NSSet {
     ffi.Pointer<objc.ObjCSelector> aSelector, {
     objc.ObjCObject? withObject,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withObject?.ref;
     _objc_msgSend_1qv0eq4(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_makeObjectsPerformSelector_withObject_,
       aSelector,
-      withObject?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -8212,15 +8724,17 @@ extension NSExtendedSet on NSSet {
     >
     predicate,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = predicate.ref;
     objc.checkOsVersionInternal(
       'NSSet.objectsPassingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectsPassingTest_,
-      predicate.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
@@ -8233,61 +8747,69 @@ extension NSExtendedSet on NSSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSSet.objectsWithOptions:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_13x5boi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectsWithOptions_passingTest_,
       opts,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// setByAddingObject:
   NSSet setByAddingObject(objc.ObjCObject anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     objc.checkOsVersionInternal(
       'NSSet.setByAddingObject:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setByAddingObject_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// setByAddingObjectsFromArray:
   NSSet setByAddingObjectsFromArray(NSArray other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSSet.setByAddingObjectsFromArray:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setByAddingObjectsFromArray_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// setByAddingObjectsFromSet:
   NSSet setByAddingObjectsFromSet(NSSet other) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = other.ref;
     objc.checkOsVersionInternal(
       'NSSet.setByAddingObjectsFromSet:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setByAddingObjectsFromSet_,
-      other.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
@@ -8323,8 +8845,9 @@ extension NSFastEnumeration$Methods on NSFastEnumeration {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects,
     required int count,
   }) {
+    final _$$ref$3 = object$.ref;
     return _objc_msgSend_1b5ysjl(
-      object$.ref.pointer,
+      _$$ref$3.pointer,
       _sel_countByEnumeratingWithState_objects_count_,
       state,
       objects,
@@ -8531,26 +9054,26 @@ extension type NSIndexSet._(objc.ObjCObject object$)
 extension NSIndexSet$Methods on NSIndexSet {
   /// containsIndex:
   bool containsIndex(int value) {
-    return _objc_msgSend_6peh6o(
-      object$.ref.pointer,
-      _sel_containsIndex_,
-      value,
-    );
+    final _$$ref = object$.ref;
+    return _objc_msgSend_6peh6o(_$$ref.pointer, _sel_containsIndex_, value);
   }
 
   /// containsIndexes:
   bool containsIndexes(NSIndexSet indexSet) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexSet.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_containsIndexes_,
-      indexSet.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// containsIndexesInRange:
   bool containsIndexesInRange(NSRange range) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_p4nurx(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_containsIndexesInRange_,
       range,
     );
@@ -8558,18 +9081,20 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// count
   int get count {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_count);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_count);
   }
 
   /// countOfIndexesInRange:
   int countOfIndexesInRange(NSRange range) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.countOfIndexesInRange:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     return _objc_msgSend_qm9f5w(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_countOfIndexesInRange_,
       range,
     );
@@ -8577,10 +9102,12 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$16 = object$.ref;
+    final _$$ref$17 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$16.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$17.pointer,
     );
   }
 
@@ -8593,17 +9120,19 @@ extension NSIndexSet$Methods on NSIndexSet {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.enumerateIndexesInRange:options:usingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_177cajs(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateIndexesInRange_options_usingBlock_,
       range,
       options,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -8612,15 +9141,17 @@ extension NSIndexSet$Methods on NSIndexSet {
     objc.ObjCBlock<ffi.Void Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)>
     block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.enumerateIndexesUsingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateIndexesUsingBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -8632,16 +9163,18 @@ extension NSIndexSet$Methods on NSIndexSet {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.enumerateIndexesWithOptions:usingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_yx8yc6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateIndexesWithOptions_usingBlock_,
       opts,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -8652,17 +9185,19 @@ extension NSIndexSet$Methods on NSIndexSet {
     required objc.ObjCBlock<ffi.Void Function(NSRange, ffi.Pointer<ffi.Bool>)>
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.enumerateRangesInRange:options:usingBlock:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_177cajs(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateRangesInRange_options_usingBlock_,
       range,
       options,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -8670,15 +9205,17 @@ extension NSIndexSet$Methods on NSIndexSet {
   void enumerateRangesUsingBlock(
     objc.ObjCBlock<ffi.Void Function(NSRange, ffi.Pointer<ffi.Bool>)> block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.enumerateRangesUsingBlock:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateRangesUsingBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -8688,22 +9225,25 @@ extension NSIndexSet$Methods on NSIndexSet {
     required objc.ObjCBlock<ffi.Void Function(NSRange, ffi.Pointer<ffi.Bool>)>
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.enumerateRangesWithOptions:usingBlock:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_yx8yc6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateRangesWithOptions_usingBlock_,
       opts,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// firstIndex
   int get firstIndex {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_firstIndex);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_firstIndex);
   }
 
   /// getIndexes:maxCount:inIndexRange:
@@ -8712,8 +9252,9 @@ extension NSIndexSet$Methods on NSIndexSet {
     required int maxCount,
     required ffi.Pointer<NSRange> inIndexRange,
   }) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_89xgla(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getIndexes_maxCount_inIndexRange_,
       indexBuffer,
       maxCount,
@@ -8723,8 +9264,9 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// indexGreaterThanIndex:
   int indexGreaterThanIndex(int value) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_12py2ux(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexGreaterThanIndex_,
       value,
     );
@@ -8732,8 +9274,9 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// indexGreaterThanOrEqualToIndex:
   int indexGreaterThanOrEqualToIndex(int value) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_12py2ux(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexGreaterThanOrEqualToIndex_,
       value,
     );
@@ -8748,24 +9291,27 @@ extension NSIndexSet$Methods on NSIndexSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.indexInRange:options:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return _objc_msgSend_6jmuyz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexInRange_options_passingTest_,
       range,
       options,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// indexLessThanIndex:
   int indexLessThanIndex(int value) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_12py2ux(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexLessThanIndex_,
       value,
     );
@@ -8773,8 +9319,9 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// indexLessThanOrEqualToIndex:
   int indexLessThanOrEqualToIndex(int value) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_12py2ux(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexLessThanOrEqualToIndex_,
       value,
     );
@@ -8785,15 +9332,17 @@ extension NSIndexSet$Methods on NSIndexSet {
     objc.ObjCBlock<ffi.Bool Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)>
     predicate,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = predicate.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.indexPassingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return _objc_msgSend_10mlopr(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexPassingTest_,
-      predicate.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -8805,16 +9354,18 @@ extension NSIndexSet$Methods on NSIndexSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.indexWithOptions:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     return _objc_msgSend_1698hqz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexWithOptions_passingTest_,
       opts,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -8827,17 +9378,19 @@ extension NSIndexSet$Methods on NSIndexSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.indexesInRange:options:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1q30cs4(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesInRange_options_passingTest_,
       range,
       options,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
@@ -8847,15 +9400,17 @@ extension NSIndexSet$Methods on NSIndexSet {
     objc.ObjCBlock<ffi.Bool Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)>
     predicate,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = predicate.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.indexesPassingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesPassingTest_,
-      predicate.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
@@ -8868,29 +9423,32 @@ extension NSIndexSet$Methods on NSIndexSet {
     >
     passingTest,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = passingTest.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.indexesWithOptions:passingTest:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_13x5boi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexesWithOptions_passingTest_,
       opts,
-      passingTest.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   NSIndexSet init() {
+    final _$$ref$16 = object$.ref;
     objc.checkOsVersionInternal(
       'NSIndexSet.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$16.retainAndReturnPointer(),
       _sel_init,
     );
     return NSIndexSet.fromPointer($ret, retain: false, release: true);
@@ -8898,10 +9456,12 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// initWithCoder:
   NSIndexSet? initWithCoder(NSCoder coder) {
+    final _$$ref$16 = object$.ref;
+    final _$$ref$17 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$16.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$17.pointer,
     );
     return $ret.address == 0
         ? null
@@ -8910,8 +9470,9 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// initWithIndex:
   NSIndexSet initWithIndex(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithIndex_,
       value,
     );
@@ -8920,18 +9481,21 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// initWithIndexSet:
   NSIndexSet initWithIndexSet(NSIndexSet indexSet) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexSet.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithIndexSet_,
-      indexSet.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSIndexSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithIndexesInRange:
   NSIndexSet initWithIndexesInRange(NSRange range) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1k1o1s7(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithIndexesInRange_,
       range,
     );
@@ -8940,8 +9504,9 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// intersectsIndexesInRange:
   bool intersectsIndexesInRange(NSRange range) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_p4nurx(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_intersectsIndexesInRange_,
       range,
     );
@@ -8949,16 +9514,19 @@ extension NSIndexSet$Methods on NSIndexSet {
 
   /// isEqualToIndexSet:
   bool isEqualToIndexSet(NSIndexSet indexSet) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexSet.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToIndexSet_,
-      indexSet.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// lastIndex
   int get lastIndex {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_lastIndex);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_lastIndex);
   }
 }
 
@@ -9006,10 +9574,11 @@ extension type NSInputStream._(objc.ObjCObject object$)
 
   /// inputStreamWithData:
   static NSInputStream? inputStreamWithData(NSData data) {
+    final _$$ref$1 = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSInputStream,
       _sel_inputStreamWithData_,
-      data.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -9018,10 +9587,11 @@ extension type NSInputStream._(objc.ObjCObject object$)
 
   /// inputStreamWithFileAtPath:
   static NSInputStream? inputStreamWithFileAtPath(NSString path) {
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSInputStream,
       _sel_inputStreamWithFileAtPath_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -9030,6 +9600,7 @@ extension type NSInputStream._(objc.ObjCObject object$)
 
   /// inputStreamWithURL:
   static NSInputStream? inputStreamWithURL(NSURL url) {
+    final _$$ref$1 = url.ref;
     objc.checkOsVersionInternal(
       'NSInputStream.inputStreamWithURL:',
       iOS: (false, (4, 0, 0)),
@@ -9038,7 +9609,7 @@ extension type NSInputStream._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSInputStream,
       _sel_inputStreamWithURL_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -9061,8 +9632,9 @@ extension NSInputStream$Methods on NSInputStream {
     ffi.Pointer<ffi.Pointer<ffi.Uint8>> buffer, {
     required ffi.Pointer<ffi.UnsignedLong> length,
   }) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_19lrthf(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getBuffer_length_,
       buffer,
       length,
@@ -9071,18 +9643,20 @@ extension NSInputStream$Methods on NSInputStream {
 
   /// hasBytesAvailable
   bool get hasBytesAvailable {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_hasBytesAvailable);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_hasBytesAvailable);
   }
 
   /// init
   NSInputStream init() {
+    final _$$ref$17 = object$.ref;
     objc.checkOsVersionInternal(
       'NSInputStream.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$17.retainAndReturnPointer(),
       _sel_init,
     );
     return NSInputStream.fromPointer($ret, retain: false, release: true);
@@ -9090,20 +9664,24 @@ extension NSInputStream$Methods on NSInputStream {
 
   /// initWithData:
   NSInputStream initWithData(NSData data) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithData_,
-      data.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSInputStream.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithFileAtPath:
   NSInputStream? initWithFileAtPath(NSString path) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithFileAtPath_,
-      path.ref.pointer,
+      _$$ref$3.pointer,
     );
     return $ret.address == 0
         ? null
@@ -9112,15 +9690,17 @@ extension NSInputStream$Methods on NSInputStream {
 
   /// initWithURL:
   NSInputStream? initWithURL(NSURL url) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = url.ref;
     objc.checkOsVersionInternal(
       'NSInputStream.initWithURL:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithURL_,
-      url.ref.pointer,
+      _$$ref$3.pointer,
     );
     return $ret.address == 0
         ? null
@@ -9129,8 +9709,9 @@ extension NSInputStream$Methods on NSInputStream {
 
   /// read:maxLength:
   int read(ffi.Pointer<ffi.Uint8> buffer, {required int maxLength}) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_11e9f5x(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_read_maxLength_,
       buffer,
       maxLength,
@@ -9182,10 +9763,11 @@ extension type NSInvocation._(objc.ObjCObject object$)
 
   /// invocationWithMethodSignature:
   static NSInvocation invocationWithMethodSignature(NSMethodSignature sig) {
+    final _$$ref = sig.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSInvocation,
       _sel_invocationWithMethodSignature_,
-      sig.ref.pointer,
+      _$$ref.pointer,
     );
     return NSInvocation.fromPointer($ret, retain: true, release: true);
   }
@@ -9203,7 +9785,8 @@ extension type NSInvocation._(objc.ObjCObject object$)
 extension NSInvocation$Methods on NSInvocation {
   /// argumentsRetained
   bool get argumentsRetained {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_argumentsRetained);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_argumentsRetained);
   }
 
   /// getArgument:atIndex:
@@ -9211,8 +9794,9 @@ extension NSInvocation$Methods on NSInvocation {
     ffi.Pointer<ffi.Void> argumentLocation, {
     required int atIndex,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_unr2j3(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getArgument_atIndex_,
       argumentLocation,
       atIndex,
@@ -9221,18 +9805,20 @@ extension NSInvocation$Methods on NSInvocation {
 
   /// getReturnValue:
   void getReturnValue(ffi.Pointer<ffi.Void> retLoc) {
-    _objc_msgSend_ovsamd(object$.ref.pointer, _sel_getReturnValue_, retLoc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_ovsamd(_$$ref.pointer, _sel_getReturnValue_, retLoc);
   }
 
   /// init
   NSInvocation init() {
+    final _$$ref$18 = object$.ref;
     objc.checkOsVersionInternal(
       'NSInvocation.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$18.retainAndReturnPointer(),
       _sel_init,
     );
     return NSInvocation.fromPointer($ret, retain: false, release: true);
@@ -9240,42 +9826,46 @@ extension NSInvocation$Methods on NSInvocation {
 
   /// invoke
   void invoke() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_invoke);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_invoke);
   }
 
   /// invokeUsingIMP:
   void invokeUsingIMP(
     ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> imp,
   ) {
-    _objc_msgSend_hk6irj(object$.ref.pointer, _sel_invokeUsingIMP_, imp);
+    final _$$ref = object$.ref;
+    _objc_msgSend_hk6irj(_$$ref.pointer, _sel_invokeUsingIMP_, imp);
   }
 
   /// invokeWithTarget:
   void invokeWithTarget(objc.ObjCObject target) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = target.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_invokeWithTarget_,
-      target.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// methodSignature
   NSMethodSignature get methodSignature {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_methodSignature,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_methodSignature);
     return NSMethodSignature.fromPointer($ret, retain: true, release: true);
   }
 
   /// retainArguments
   void retainArguments() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_retainArguments);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_retainArguments);
   }
 
   /// selector
   ffi.Pointer<objc.ObjCSelector> get selector {
-    return _objc_msgSend_1ovaulg(object$.ref.pointer, _sel_selector);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1ovaulg(_$$ref.pointer, _sel_selector);
   }
 
   /// setArgument:atIndex:
@@ -9283,8 +9873,9 @@ extension NSInvocation$Methods on NSInvocation {
     ffi.Pointer<ffi.Void> argumentLocation, {
     required int atIndex,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_unr2j3(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setArgument_atIndex_,
       argumentLocation,
       atIndex,
@@ -9293,26 +9884,31 @@ extension NSInvocation$Methods on NSInvocation {
 
   /// setReturnValue:
   void setReturnValue(ffi.Pointer<ffi.Void> retLoc) {
-    _objc_msgSend_ovsamd(object$.ref.pointer, _sel_setReturnValue_, retLoc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_ovsamd(_$$ref.pointer, _sel_setReturnValue_, retLoc);
   }
 
   /// setSelector:
   set selector(ffi.Pointer<objc.ObjCSelector> value) {
-    _objc_msgSend_1d9e4oe(object$.ref.pointer, _sel_setSelector_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1d9e4oe(_$$ref.pointer, _sel_setSelector_, value);
   }
 
   /// setTarget:
   set target(objc.ObjCObject? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setTarget_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// target
   objc.ObjCObject? get target {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_target);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_target);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -9384,29 +9980,33 @@ extension type NSItemProvider._(objc.ObjCObject object$)
 extension NSItemProvider$Methods on NSItemProvider {
   /// canLoadObjectOfClass:
   bool canLoadObjectOfClass(NSItemProviderReading aClass) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aClass.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.canLoadObjectOfClass:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_canLoadObjectOfClass_,
-      aClass.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// hasItemConformingToTypeIdentifier:
   bool hasItemConformingToTypeIdentifier(NSString typeIdentifier) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.hasItemConformingToTypeIdentifier:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_hasItemConformingToTypeIdentifier_,
-      typeIdentifier.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -9415,28 +10015,31 @@ extension NSItemProvider$Methods on NSItemProvider {
     NSString typeIdentifier, {
     required int fileOptions,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.hasRepresentationConformingToTypeIdentifier:fileOptions:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     return _objc_msgSend_1wdb8ji(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_hasRepresentationConformingToTypeIdentifier_fileOptions_,
-      typeIdentifier.ref.pointer,
+      _$$ref$1.pointer,
       fileOptions,
     );
   }
 
   /// init
   NSItemProvider init() {
+    final _$$ref$19 = object$.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$19.retainAndReturnPointer(),
       _sel_init,
     );
     return NSItemProvider.fromPointer($ret, retain: false, release: true);
@@ -9444,15 +10047,17 @@ extension NSItemProvider$Methods on NSItemProvider {
 
   /// initWithContentsOfURL:
   NSItemProvider? initWithContentsOfURL(NSURL fileURL) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = fileURL.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.initWithContentsOfURL:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithContentsOfURL_,
-      fileURL.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -9464,31 +10069,36 @@ extension NSItemProvider$Methods on NSItemProvider {
     NSSecureCoding? item, {
     NSString? typeIdentifier,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = item?.ref;
+    final _$$ref$2 = typeIdentifier?.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.initWithItem:typeIdentifier:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithItem_typeIdentifier_,
-      item?.ref.pointer ?? ffi.nullptr,
-      typeIdentifier?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSItemProvider.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithObject:
   NSItemProvider initWithObject(NSItemProviderWriting object) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.initWithObject:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObject_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSItemProvider.fromPointer($ret, retain: false, release: true);
   }
@@ -9499,16 +10109,19 @@ extension NSItemProvider$Methods on NSItemProvider {
     required objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>
     completionHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = completionHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.loadDataRepresentationForTypeIdentifier:completionHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_r0bo0s(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_loadDataRepresentationForTypeIdentifier_completionHandler_,
-      typeIdentifier.ref.pointer,
-      completionHandler.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return NSProgress.fromPointer($ret, retain: true, release: true);
   }
@@ -9519,16 +10132,19 @@ extension NSItemProvider$Methods on NSItemProvider {
     required objc.ObjCBlock<ffi.Void Function(NSURL?, NSError?)>
     completionHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = completionHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.loadFileRepresentationForTypeIdentifier:completionHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_r0bo0s(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_loadFileRepresentationForTypeIdentifier_completionHandler_,
-      typeIdentifier.ref.pointer,
-      completionHandler.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return NSProgress.fromPointer($ret, retain: true, release: true);
   }
@@ -9539,16 +10155,19 @@ extension NSItemProvider$Methods on NSItemProvider {
     required objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)>
     completionHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = completionHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.loadInPlaceFileRepresentationForTypeIdentifier:completionHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_r0bo0s(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_loadInPlaceFileRepresentationForTypeIdentifier_completionHandler_,
-      typeIdentifier.ref.pointer,
-      completionHandler.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return NSProgress.fromPointer($ret, retain: true, release: true);
   }
@@ -9562,17 +10181,21 @@ extension NSItemProvider$Methods on NSItemProvider {
     >?
     completionHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = options?.ref;
+    final _$$ref$3 = completionHandler?.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.loadItemForTypeIdentifier:options:completionHandler:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
     _objc_msgSend_18qun1e(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_loadItemForTypeIdentifier_options_completionHandler_,
-      typeIdentifier.ref.pointer,
-      options?.ref.pointer ?? ffi.nullptr,
-      completionHandler?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
   }
 
@@ -9584,16 +10207,19 @@ extension NSItemProvider$Methods on NSItemProvider {
     >
     completionHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aClass.ref;
+    final _$$ref$2 = completionHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.loadObjectOfClass:completionHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_r0bo0s(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_loadObjectOfClass_completionHandler_,
-      aClass.ref.pointer,
-      completionHandler.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return NSProgress.fromPointer($ret, retain: true, release: true);
   }
@@ -9607,17 +10233,20 @@ extension NSItemProvider$Methods on NSItemProvider {
     >
     loadHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = loadHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.registerDataRepresentationForTypeIdentifier:visibility:loadHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_1pl40xc(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_registerDataRepresentationForTypeIdentifier_visibility_loadHandler_,
-      typeIdentifier.ref.pointer,
+      _$$ref$1.pointer,
       visibility.value,
-      loadHandler.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -9633,18 +10262,21 @@ extension NSItemProvider$Methods on NSItemProvider {
     >
     loadHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = loadHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.registerFileRepresentationForTypeIdentifier:fileOptions:visibility:loadHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_t7arir(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_registerFileRepresentationForTypeIdentifier_fileOptions_visibility_loadHandler_,
-      typeIdentifier.ref.pointer,
+      _$$ref$1.pointer,
       fileOptions,
       visibility.value,
-      loadHandler.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -9662,16 +10294,19 @@ extension NSItemProvider$Methods on NSItemProvider {
     >
     loadHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = loadHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.registerItemForTypeIdentifier:loadHandler:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
     _objc_msgSend_o762yo(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_registerItemForTypeIdentifier_loadHandler_,
-      typeIdentifier.ref.pointer,
-      loadHandler.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -9680,15 +10315,17 @@ extension NSItemProvider$Methods on NSItemProvider {
     NSItemProviderWriting object, {
     required NSItemProviderRepresentationVisibility visibility,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.registerObject:visibility:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_1k745tv(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_registerObject_visibility_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
       visibility.value,
     );
   }
@@ -9706,29 +10343,33 @@ extension NSItemProvider$Methods on NSItemProvider {
     >
     loadHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aClass.ref;
+    final _$$ref$2 = loadHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.registerObjectOfClass:visibility:loadHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_1pl40xc(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_registerObjectOfClass_visibility_loadHandler_,
-      aClass.ref.pointer,
+      _$$ref$1.pointer,
       visibility.value,
-      loadHandler.ref.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// registeredTypeIdentifiers
   NSArray get registeredTypeIdentifiers {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.registeredTypeIdentifiers',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_registeredTypeIdentifiers,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
@@ -9736,13 +10377,14 @@ extension NSItemProvider$Methods on NSItemProvider {
 
   /// registeredTypeIdentifiersWithFileOptions:
   NSArray registeredTypeIdentifiersWithFileOptions(int fileOptions) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.registeredTypeIdentifiersWithFileOptions:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_7g3u2y(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_registeredTypeIdentifiersWithFileOptions_,
       fileOptions,
     );
@@ -9751,26 +10393,29 @@ extension NSItemProvider$Methods on NSItemProvider {
 
   /// setSuggestedName:
   set suggestedName(NSString? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.setSuggestedName:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 14, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setSuggestedName_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// suggestedName
   NSString? get suggestedName {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSItemProvider.suggestedName',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 14, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_suggestedName);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_suggestedName);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -9889,13 +10534,15 @@ extension NSItemProviderWriting$Methods on NSItemProviderWriting {
   itemProviderVisibilityForRepresentationWithTypeIdentifier(
     NSString typeIdentifier,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
     objc.checkOsVersionInternal(
       'NSItemProviderWriting.itemProviderVisibilityForRepresentationWithTypeIdentifier:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     if (!objc.respondsToSelector(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_,
     )) {
       throw objc.UnimplementedOptionalMethodException(
@@ -9904,9 +10551,9 @@ extension NSItemProviderWriting$Methods on NSItemProviderWriting {
       );
     }
     final $ret = _objc_msgSend_16fy0up(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_,
-      typeIdentifier.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSItemProviderRepresentationVisibility.fromValue($ret);
   }
@@ -9917,16 +10564,19 @@ extension NSItemProviderWriting$Methods on NSItemProviderWriting {
     required objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>
     forItemProviderCompletionHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = typeIdentifier.ref;
+    final _$$ref$2 = forItemProviderCompletionHandler.ref;
     objc.checkOsVersionInternal(
       'NSItemProviderWriting.loadDataWithTypeIdentifier:forItemProviderCompletionHandler:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_r0bo0s(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_loadDataWithTypeIdentifier_forItemProviderCompletionHandler_,
-      typeIdentifier.ref.pointer,
-      forItemProviderCompletionHandler.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return $ret.address == 0
         ? null
@@ -9935,13 +10585,14 @@ extension NSItemProviderWriting$Methods on NSItemProviderWriting {
 
   /// writableTypeIdentifiersForItemProvider
   NSArray get writableTypeIdentifiersForItemProvider {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSItemProviderWriting.writableTypeIdentifiersForItemProvider',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     if (!objc.respondsToSelector(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_writableTypeIdentifiersForItemProvider,
     )) {
       throw objc.UnimplementedOptionalMethodException(
@@ -9950,7 +10601,7 @@ extension NSItemProviderWriting$Methods on NSItemProviderWriting {
       );
     }
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_writableTypeIdentifiersForItemProvider,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
@@ -10229,6 +10880,7 @@ extension type NSLocale._(objc.ObjCObject object$)
 
   /// localeWithLocaleIdentifier:
   static NSLocale localeWithLocaleIdentifier(NSString ident) {
+    final _$$ref = ident.ref;
     objc.checkOsVersionInternal(
       'NSLocale.localeWithLocaleIdentifier:',
       iOS: (false, (4, 0, 0)),
@@ -10237,7 +10889,7 @@ extension type NSLocale._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSLocale,
       _sel_localeWithLocaleIdentifier_,
-      ident.ref.pointer,
+      _$$ref.pointer,
     );
     return NSLocale.fromPointer($ret, retain: true, release: true);
   }
@@ -10260,11 +10912,14 @@ extension type NSLocale._(objc.ObjCObject object$)
 extension NSLocale$Methods on NSLocale {
   /// displayNameForKey:value:
   NSString? displayNameForKey(NSString key, {required objc.ObjCObject value}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = key.ref;
+    final _$$ref$2 = value.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_displayNameForKey_value_,
-      key.ref.pointer,
-      value.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return $ret.address == 0
         ? null
@@ -10273,22 +10928,25 @@ extension NSLocale$Methods on NSLocale {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$18 = object$.ref;
+    final _$$ref$19 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$18.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$19.pointer,
     );
   }
 
   /// init
   NSLocale init() {
+    final _$$ref$20 = object$.ref;
     objc.checkOsVersionInternal(
       'NSLocale.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$20.retainAndReturnPointer(),
       _sel_init,
     );
     return NSLocale.fromPointer($ret, retain: false, release: true);
@@ -10296,10 +10954,12 @@ extension NSLocale$Methods on NSLocale {
 
   /// initWithCoder:
   NSLocale? initWithCoder(NSCoder coder) {
+    final _$$ref$18 = object$.ref;
+    final _$$ref$19 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$18.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$19.pointer,
     );
     return $ret.address == 0
         ? null
@@ -10308,20 +10968,24 @@ extension NSLocale$Methods on NSLocale {
 
   /// initWithLocaleIdentifier:
   NSLocale initWithLocaleIdentifier(NSString string) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithLocaleIdentifier_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSLocale.fromPointer($ret, retain: false, release: true);
   }
 
   /// objectForKey:
   objc.ObjCObject? objectForKey(NSString key) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = key.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectForKey_,
-      key.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -10420,13 +11084,15 @@ extension type NSMethodSignature._(objc.ObjCObject object$)
 extension NSMethodSignature$Methods on NSMethodSignature {
   /// frameLength
   int get frameLength {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_frameLength);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_frameLength);
   }
 
   /// getArgumentTypeAtIndex:
   ffi.Pointer<ffi.Char> getArgumentTypeAtIndex(int idx) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_1jtxufi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getArgumentTypeAtIndex_,
       idx,
     );
@@ -10434,13 +11100,14 @@ extension NSMethodSignature$Methods on NSMethodSignature {
 
   /// init
   NSMethodSignature init() {
+    final _$$ref$21 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMethodSignature.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$21.retainAndReturnPointer(),
       _sel_init,
     );
     return NSMethodSignature.fromPointer($ret, retain: false, release: true);
@@ -10448,22 +11115,26 @@ extension NSMethodSignature$Methods on NSMethodSignature {
 
   /// isOneway
   bool isOneway() {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isOneway);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isOneway);
   }
 
   /// methodReturnLength
   int get methodReturnLength {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_methodReturnLength);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_methodReturnLength);
   }
 
   /// methodReturnType
   ffi.Pointer<ffi.Char> get methodReturnType {
-    return _objc_msgSend_1fuqfwb(object$.ref.pointer, _sel_methodReturnType);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1fuqfwb(_$$ref.pointer, _sel_methodReturnType);
   }
 
   /// numberOfArguments
   int get numberOfArguments {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_numberOfArguments);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_numberOfArguments);
   }
 }
 
@@ -10534,10 +11205,11 @@ extension type NSMutableArray._(objc.ObjCObject object$)
 
   /// arrayWithArray:
   static NSMutableArray arrayWithArray(NSArray array) {
+    final _$$ref$1 = array.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableArray,
       _sel_arrayWithArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableArray.fromPointer($ret, retain: true, release: true);
   }
@@ -10554,20 +11226,22 @@ extension type NSMutableArray._(objc.ObjCObject object$)
 
   /// arrayWithObject:
   static NSMutableArray arrayWithObject(objc.ObjCObject anObject) {
+    final _$$ref$1 = anObject.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableArray,
       _sel_arrayWithObject_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// arrayWithObjects:
   static NSMutableArray arrayWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref$1 = firstObj.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableArray,
       _sel_arrayWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableArray.fromPointer($ret, retain: true, release: true);
   }
@@ -10607,22 +11281,21 @@ extension type NSMutableArray._(objc.ObjCObject object$)
 extension NSMutableArray$Methods on NSMutableArray {
   /// addObject:
   void addObject(objc.ObjCObject anObject) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_addObject_,
-      anObject.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_addObject_, _$$ref$1.pointer);
   }
 
   /// init
   NSMutableArray init() {
+    final _$$ref$22 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableArray.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$22.retainAndReturnPointer(),
       _sel_init,
     );
     return NSMutableArray.fromPointer($ret, retain: false, release: true);
@@ -10630,20 +11303,24 @@ extension NSMutableArray$Methods on NSMutableArray {
 
   /// initWithArray:
   NSMutableArray initWithArray(NSArray array) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = array.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithArray_,
-      array.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSMutableArray.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
   NSMutableArray initWithArray$1(NSArray array, {required bool copyItems}) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = array.ref;
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithArray_copyItems_,
-      array.ref.pointer,
+      _$$ref$3.pointer,
       copyItems,
     );
     return NSMutableArray.fromPointer($ret, retain: false, release: true);
@@ -10651,8 +11328,9 @@ extension NSMutableArray$Methods on NSMutableArray {
 
   /// initWithCapacity:
   NSMutableArray initWithCapacity(int numItems) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCapacity_,
       numItems,
     );
@@ -10661,10 +11339,12 @@ extension NSMutableArray$Methods on NSMutableArray {
 
   /// initWithCoder:
   NSMutableArray? initWithCoder(NSCoder coder) {
+    final _$$ref$20 = object$.ref;
+    final _$$ref$21 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$20.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$21.pointer,
     );
     return $ret.address == 0
         ? null
@@ -10673,10 +11353,12 @@ extension NSMutableArray$Methods on NSMutableArray {
 
   /// initWithObjects:
   NSMutableArray initWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = firstObj.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSMutableArray.fromPointer($ret, retain: false, release: true);
   }
@@ -10686,8 +11368,9 @@ extension NSMutableArray$Methods on NSMutableArray {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required int count,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_zmbtbd(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithObjects_count_,
       objects,
       count,
@@ -10697,35 +11380,37 @@ extension NSMutableArray$Methods on NSMutableArray {
 
   /// insertObject:atIndex:
   void insertObject(objc.ObjCObject anObject, {required int atIndex}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
     _objc_msgSend_djsa9o(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_insertObject_atIndex_,
-      anObject.ref.pointer,
+      _$$ref$1.pointer,
       atIndex,
     );
   }
 
   /// removeLastObject
   void removeLastObject() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_removeLastObject);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_removeLastObject);
   }
 
   /// removeObjectAtIndex:
   void removeObjectAtIndex(int index) {
-    _objc_msgSend_1i9r4xy(
-      object$.ref.pointer,
-      _sel_removeObjectAtIndex_,
-      index,
-    );
+    final _$$ref = object$.ref;
+    _objc_msgSend_1i9r4xy(_$$ref.pointer, _sel_removeObjectAtIndex_, index);
   }
 
   /// replaceObjectAtIndex:withObject:
   void replaceObjectAtIndex(int index, {required objc.ObjCObject withObject}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withObject.ref;
     _objc_msgSend_1gypgok(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceObjectAtIndex_withObject_,
       index,
-      withObject.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 }
@@ -10756,8 +11441,9 @@ extension type NSMutableCopying._(objc.ObjCProtocol object$)
 extension NSMutableCopying$Methods on NSMutableCopying {
   /// mutableCopyWithZone:
   objc.ObjCObject mutableCopyWithZone(ffi.Pointer<NSZone> zone) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1cwp428(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_mutableCopyWithZone_,
       zone,
     );
@@ -10940,10 +11626,11 @@ extension type NSMutableData._(objc.ObjCObject object$)
 
   /// dataWithContentsOfFile:
   static NSMutableData? dataWithContentsOfFile(NSString path) {
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableData,
       _sel_dataWithContentsOfFile_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -10956,10 +11643,11 @@ extension type NSMutableData._(objc.ObjCObject object$)
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_8321cp(
       _class_NSMutableData,
       _sel_dataWithContentsOfFile_options_error_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
       options,
       error,
     );
@@ -10970,10 +11658,11 @@ extension type NSMutableData._(objc.ObjCObject object$)
 
   /// dataWithContentsOfURL:
   static NSMutableData? dataWithContentsOfURL(NSURL url) {
+    final _$$ref$1 = url.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableData,
       _sel_dataWithContentsOfURL_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -10986,10 +11675,11 @@ extension type NSMutableData._(objc.ObjCObject object$)
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref$1 = url.ref;
     final $ret = _objc_msgSend_8321cp(
       _class_NSMutableData,
       _sel_dataWithContentsOfURL_options_error_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
       options,
       error,
     );
@@ -11000,10 +11690,11 @@ extension type NSMutableData._(objc.ObjCObject object$)
 
   /// dataWithData:
   static NSMutableData dataWithData(NSData data) {
+    final _$$ref$1 = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableData,
       _sel_dataWithData_,
-      data.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableData.fromPointer($ret, retain: true, release: true);
   }
@@ -11046,6 +11737,7 @@ extension NSMutableData$Methods on NSMutableData {
   NSMutableData? compressedDataUsingAlgorithm(
     NSDataCompressionAlgorithm algorithm,
   ) {
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableData.compressedDataUsingAlgorithm:error:',
       iOS: (false, (13, 0, 0)),
@@ -11054,7 +11746,7 @@ extension NSMutableData$Methods on NSMutableData {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1vnlaqg(
-        object$.ref.pointer,
+        _$$ref$1.pointer,
         _sel_compressedDataUsingAlgorithm_error_,
         algorithm.value,
         $err,
@@ -11075,6 +11767,7 @@ extension NSMutableData$Methods on NSMutableData {
   NSMutableData? decompressedDataUsingAlgorithm(
     NSDataCompressionAlgorithm algorithm,
   ) {
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableData.decompressedDataUsingAlgorithm:error:',
       iOS: (false, (13, 0, 0)),
@@ -11083,7 +11776,7 @@ extension NSMutableData$Methods on NSMutableData {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1vnlaqg(
-        object$.ref.pointer,
+        _$$ref$1.pointer,
         _sel_decompressedDataUsingAlgorithm_error_,
         algorithm.value,
         $err,
@@ -11099,13 +11792,14 @@ extension NSMutableData$Methods on NSMutableData {
 
   /// init
   NSMutableData init() {
+    final _$$ref$23 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableData.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$23.retainAndReturnPointer(),
       _sel_init,
     );
     return NSMutableData.fromPointer($ret, retain: false, release: true);
@@ -11116,15 +11810,17 @@ extension NSMutableData$Methods on NSMutableData {
     NSData base64Data, {
     required int options,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = base64Data.ref;
     objc.checkOsVersionInternal(
       'NSMutableData.initWithBase64EncodedData:options:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_7kpg7m(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithBase64EncodedData_options_,
-      base64Data.ref.pointer,
+      _$$ref$3.pointer,
       options,
     );
     return $ret.address == 0
@@ -11137,15 +11833,17 @@ extension NSMutableData$Methods on NSMutableData {
     NSString base64String, {
     required int options,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = base64String.ref;
     objc.checkOsVersionInternal(
       'NSMutableData.initWithBase64EncodedString:options:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_7kpg7m(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithBase64EncodedString_options_,
-      base64String.ref.pointer,
+      _$$ref$3.pointer,
       options,
     );
     return $ret.address == 0
@@ -11158,8 +11856,9 @@ extension NSMutableData$Methods on NSMutableData {
     ffi.Pointer<ffi.Void> bytes, {
     required int length,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_3nbx5e(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithBytes_length_,
       bytes,
       length,
@@ -11172,8 +11871,9 @@ extension NSMutableData$Methods on NSMutableData {
     ffi.Pointer<ffi.Void> bytes, {
     required int length,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_3nbx5e(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_,
       bytes,
       length,
@@ -11188,17 +11888,19 @@ extension NSMutableData$Methods on NSMutableData {
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.UnsignedLong)>?
     deallocator,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = deallocator?.ref;
     objc.checkOsVersionInternal(
       'NSMutableData.initWithBytesNoCopy:length:deallocator:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_134vhyh(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_deallocator_,
       bytes,
       length,
-      deallocator?.ref.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return NSMutableData.fromPointer($ret, retain: false, release: true);
   }
@@ -11209,8 +11911,9 @@ extension NSMutableData$Methods on NSMutableData {
     required int length,
     required bool freeWhenDone,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_161ne8y(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_freeWhenDone_,
       bytes,
       length,
@@ -11221,8 +11924,9 @@ extension NSMutableData$Methods on NSMutableData {
 
   /// initWithCapacity:
   NSMutableData? initWithCapacity(int capacity) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCapacity_,
       capacity,
     );
@@ -11233,10 +11937,12 @@ extension NSMutableData$Methods on NSMutableData {
 
   /// initWithCoder:
   NSMutableData? initWithCoder(NSCoder coder) {
+    final _$$ref$22 = object$.ref;
+    final _$$ref$23 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$22.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$23.pointer,
     );
     return $ret.address == 0
         ? null
@@ -11245,10 +11951,12 @@ extension NSMutableData$Methods on NSMutableData {
 
   /// initWithContentsOfFile:
   NSMutableData? initWithContentsOfFile(NSString path) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithContentsOfFile_,
-      path.ref.pointer,
+      _$$ref$3.pointer,
     );
     return $ret.address == 0
         ? null
@@ -11261,10 +11969,12 @@ extension NSMutableData$Methods on NSMutableData {
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = path.ref;
     final $ret = _objc_msgSend_8321cp(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithContentsOfFile_options_error_,
-      path.ref.pointer,
+      _$$ref$3.pointer,
       options,
       error,
     );
@@ -11275,10 +11985,12 @@ extension NSMutableData$Methods on NSMutableData {
 
   /// initWithContentsOfURL:
   NSMutableData? initWithContentsOfURL(NSURL url) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = url.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithContentsOfURL_,
-      url.ref.pointer,
+      _$$ref$3.pointer,
     );
     return $ret.address == 0
         ? null
@@ -11291,10 +12003,12 @@ extension NSMutableData$Methods on NSMutableData {
     required int options,
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> error,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = url.ref;
     final $ret = _objc_msgSend_8321cp(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithContentsOfURL_options_error_,
-      url.ref.pointer,
+      _$$ref$3.pointer,
       options,
       error,
     );
@@ -11305,18 +12019,21 @@ extension NSMutableData$Methods on NSMutableData {
 
   /// initWithData:
   NSMutableData initWithData(NSData data) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = data.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithData_,
-      data.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSMutableData.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithLength:
   NSMutableData? initWithLength(int length) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithLength_,
       length,
     );
@@ -11327,17 +12044,20 @@ extension NSMutableData$Methods on NSMutableData {
 
   /// length
   int get length {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_length);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_length);
   }
 
   /// mutableBytes
   ffi.Pointer<ffi.Void> get mutableBytes {
-    return _objc_msgSend_6ex6p5(object$.ref.pointer, _sel_mutableBytes);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_6ex6p5(_$$ref.pointer, _sel_mutableBytes);
   }
 
   /// setLength:
   set length$1(int value) {
-    _objc_msgSend_1i9r4xy(object$.ref.pointer, _sel_setLength_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1i9r4xy(_$$ref.pointer, _sel_setLength_, value);
   }
 }
 
@@ -11419,10 +12139,11 @@ extension type NSMutableDictionary._(objc.ObjCObject object$)
 
   /// dictionaryWithDictionary:
   static NSMutableDictionary dictionaryWithDictionary(NSDictionary dict) {
+    final _$$ref$1 = dict.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableDictionary,
       _sel_dictionaryWithDictionary_,
-      dict.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableDictionary.fromPointer($ret, retain: true, release: true);
   }
@@ -11432,11 +12153,13 @@ extension type NSMutableDictionary._(objc.ObjCObject object$)
     objc.ObjCObject object, {
     required NSCopying forKey,
   }) {
+    final _$$ref$2 = object.ref;
+    final _$$ref$3 = forKey.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_NSMutableDictionary,
       _sel_dictionaryWithObject_forKey_,
-      object.ref.pointer,
-      forKey.ref.pointer,
+      _$$ref$2.pointer,
+      _$$ref$3.pointer,
     );
     return NSMutableDictionary.fromPointer($ret, retain: true, release: true);
   }
@@ -11446,11 +12169,13 @@ extension type NSMutableDictionary._(objc.ObjCObject object$)
     NSArray objects, {
     required NSArray forKeys,
   }) {
+    final _$$ref$2 = objects.ref;
+    final _$$ref$3 = forKeys.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_NSMutableDictionary,
       _sel_dictionaryWithObjects_forKeys_,
-      objects.ref.pointer,
-      forKeys.ref.pointer,
+      _$$ref$2.pointer,
+      _$$ref$3.pointer,
     );
     return NSMutableDictionary.fromPointer($ret, retain: true, release: true);
   }
@@ -11475,10 +12200,11 @@ extension type NSMutableDictionary._(objc.ObjCObject object$)
   static NSMutableDictionary dictionaryWithObjectsAndKeys(
     objc.ObjCObject firstObject,
   ) {
+    final _$$ref$1 = firstObject.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableDictionary,
       _sel_dictionaryWithObjectsAndKeys_,
-      firstObject.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableDictionary.fromPointer($ret, retain: true, release: true);
   }
@@ -11504,13 +12230,14 @@ extension type NSMutableDictionary._(objc.ObjCObject object$)
 extension NSMutableDictionary$Methods on NSMutableDictionary {
   /// init
   NSMutableDictionary init() {
+    final _$$ref$24 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableDictionary.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$24.retainAndReturnPointer(),
       _sel_init,
     );
     return NSMutableDictionary.fromPointer($ret, retain: false, release: true);
@@ -11518,8 +12245,9 @@ extension NSMutableDictionary$Methods on NSMutableDictionary {
 
   /// initWithCapacity:
   NSMutableDictionary initWithCapacity(int numItems) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCapacity_,
       numItems,
     );
@@ -11528,10 +12256,12 @@ extension NSMutableDictionary$Methods on NSMutableDictionary {
 
   /// initWithCoder:
   NSMutableDictionary? initWithCoder(NSCoder coder) {
+    final _$$ref$24 = object$.ref;
+    final _$$ref$25 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$24.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$25.pointer,
     );
     return $ret.address == 0
         ? null
@@ -11540,10 +12270,12 @@ extension NSMutableDictionary$Methods on NSMutableDictionary {
 
   /// initWithDictionary:
   NSMutableDictionary initWithDictionary(NSDictionary otherDictionary) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = otherDictionary.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithDictionary_,
-      otherDictionary.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSMutableDictionary.fromPointer($ret, retain: false, release: true);
   }
@@ -11553,10 +12285,12 @@ extension NSMutableDictionary$Methods on NSMutableDictionary {
     NSDictionary otherDictionary, {
     required bool copyItems,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = otherDictionary.ref;
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithDictionary_copyItems_,
-      otherDictionary.ref.pointer,
+      _$$ref$3.pointer,
       copyItems,
     );
     return NSMutableDictionary.fromPointer($ret, retain: false, release: true);
@@ -11567,11 +12301,14 @@ extension NSMutableDictionary$Methods on NSMutableDictionary {
     NSArray objects, {
     required NSArray forKeys,
   }) {
+    final _$$ref$3 = object$.ref;
+    final _$$ref$4 = objects.ref;
+    final _$$ref$5 = forKeys.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$3.retainAndReturnPointer(),
       _sel_initWithObjects_forKeys_,
-      objects.ref.pointer,
-      forKeys.ref.pointer,
+      _$$ref$4.pointer,
+      _$$ref$5.pointer,
     );
     return NSMutableDictionary.fromPointer($ret, retain: false, release: true);
   }
@@ -11582,8 +12319,9 @@ extension NSMutableDictionary$Methods on NSMutableDictionary {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> forKeys,
     required int count,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_1dydpdi(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithObjects_forKeys_count_,
       objects,
       forKeys,
@@ -11594,30 +12332,37 @@ extension NSMutableDictionary$Methods on NSMutableDictionary {
 
   /// initWithObjectsAndKeys:
   NSMutableDictionary initWithObjectsAndKeys(objc.ObjCObject firstObject) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = firstObject.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithObjectsAndKeys_,
-      firstObject.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSMutableDictionary.fromPointer($ret, retain: false, release: true);
   }
 
   /// removeObjectForKey:
   void removeObjectForKey(objc.ObjCObject aKey) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aKey.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeObjectForKey_,
-      aKey.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// setObject:forKey:
   void setObject(objc.ObjCObject anObject, {required NSCopying forKey}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject.ref;
+    final _$$ref$2 = forKey.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setObject_forKey_,
-      anObject.ref.pointer,
-      forKey.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 }
@@ -11711,32 +12456,33 @@ extension type NSMutableIndexSet._(objc.ObjCObject object$)
 extension NSMutableIndexSet$Methods on NSMutableIndexSet {
   /// addIndex:
   void addIndex(int value) {
-    _objc_msgSend_1i9r4xy(object$.ref.pointer, _sel_addIndex_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1i9r4xy(_$$ref.pointer, _sel_addIndex_, value);
   }
 
   /// addIndexes:
   void addIndexes(NSIndexSet indexSet) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_addIndexes_,
-      indexSet.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexSet.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_addIndexes_, _$$ref$1.pointer);
   }
 
   /// addIndexesInRange:
   void addIndexesInRange(NSRange range) {
-    _objc_msgSend_1e3pm0z(object$.ref.pointer, _sel_addIndexesInRange_, range);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1e3pm0z(_$$ref.pointer, _sel_addIndexesInRange_, range);
   }
 
   /// init
   NSMutableIndexSet init() {
+    final _$$ref$25 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableIndexSet.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$25.retainAndReturnPointer(),
       _sel_init,
     );
     return NSMutableIndexSet.fromPointer($ret, retain: false, release: true);
@@ -11744,10 +12490,12 @@ extension NSMutableIndexSet$Methods on NSMutableIndexSet {
 
   /// initWithCoder:
   NSMutableIndexSet? initWithCoder(NSCoder coder) {
+    final _$$ref$26 = object$.ref;
+    final _$$ref$27 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$26.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$27.pointer,
     );
     return $ret.address == 0
         ? null
@@ -11756,8 +12504,9 @@ extension NSMutableIndexSet$Methods on NSMutableIndexSet {
 
   /// initWithIndex:
   NSMutableIndexSet initWithIndex(int value) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithIndex_,
       value,
     );
@@ -11766,18 +12515,21 @@ extension NSMutableIndexSet$Methods on NSMutableIndexSet {
 
   /// initWithIndexSet:
   NSMutableIndexSet initWithIndexSet(NSIndexSet indexSet) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = indexSet.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithIndexSet_,
-      indexSet.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSMutableIndexSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithIndexesInRange:
   NSMutableIndexSet initWithIndexesInRange(NSRange range) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_1k1o1s7(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithIndexesInRange_,
       range,
     );
@@ -11786,36 +12538,34 @@ extension NSMutableIndexSet$Methods on NSMutableIndexSet {
 
   /// removeAllIndexes
   void removeAllIndexes() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_removeAllIndexes);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_removeAllIndexes);
   }
 
   /// removeIndex:
   void removeIndex(int value) {
-    _objc_msgSend_1i9r4xy(object$.ref.pointer, _sel_removeIndex_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1i9r4xy(_$$ref.pointer, _sel_removeIndex_, value);
   }
 
   /// removeIndexes:
   void removeIndexes(NSIndexSet indexSet) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_removeIndexes_,
-      indexSet.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = indexSet.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_removeIndexes_, _$$ref$1.pointer);
   }
 
   /// removeIndexesInRange:
   void removeIndexesInRange(NSRange range) {
-    _objc_msgSend_1e3pm0z(
-      object$.ref.pointer,
-      _sel_removeIndexesInRange_,
-      range,
-    );
+    final _$$ref = object$.ref;
+    _objc_msgSend_1e3pm0z(_$$ref.pointer, _sel_removeIndexesInRange_, range);
   }
 
   /// shiftIndexesStartingAtIndex:by:
   void shiftIndexesStartingAtIndex(int index, {required int by}) {
+    final _$$ref = object$.ref;
     _objc_msgSend_otx1t4(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_shiftIndexesStartingAtIndex_by_,
       index,
       by,
@@ -11897,6 +12647,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
 
   /// orderedSetWithArray:
   static NSMutableOrderedSet orderedSetWithArray(NSArray array) {
+    final _$$ref = array.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.orderedSetWithArray:',
       iOS: (false, (5, 0, 0)),
@@ -11905,7 +12656,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableOrderedSet,
       _sel_orderedSetWithArray_,
-      array.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: true, release: true);
   }
@@ -11916,6 +12667,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     required NSRange range,
     required bool copyItems,
   }) {
+    final _$$ref = array.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.orderedSetWithArray:range:copyItems:',
       iOS: (false, (5, 0, 0)),
@@ -11924,7 +12676,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_w9bq5x(
       _class_NSMutableOrderedSet,
       _sel_orderedSetWithArray_range_copyItems_,
-      array.ref.pointer,
+      _$$ref.pointer,
       range,
       copyItems,
     );
@@ -11948,6 +12700,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
 
   /// orderedSetWithObject:
   static NSMutableOrderedSet orderedSetWithObject(objc.ObjCObject object) {
+    final _$$ref = object.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.orderedSetWithObject:',
       iOS: (false, (5, 0, 0)),
@@ -11956,13 +12709,14 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableOrderedSet,
       _sel_orderedSetWithObject_,
-      object.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// orderedSetWithObjects:
   static NSMutableOrderedSet orderedSetWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref = firstObj.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.orderedSetWithObjects:',
       iOS: (false, (5, 0, 0)),
@@ -11971,7 +12725,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableOrderedSet,
       _sel_orderedSetWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: true, release: true);
   }
@@ -11997,6 +12751,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
 
   /// orderedSetWithOrderedSet:
   static NSMutableOrderedSet orderedSetWithOrderedSet(NSOrderedSet set) {
+    final _$$ref = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.orderedSetWithOrderedSet:',
       iOS: (false, (5, 0, 0)),
@@ -12005,7 +12760,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableOrderedSet,
       _sel_orderedSetWithOrderedSet_,
-      set.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: true, release: true);
   }
@@ -12016,6 +12771,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     required NSRange range,
     required bool copyItems,
   }) {
+    final _$$ref = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.orderedSetWithOrderedSet:range:copyItems:',
       iOS: (false, (5, 0, 0)),
@@ -12024,7 +12780,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_w9bq5x(
       _class_NSMutableOrderedSet,
       _sel_orderedSetWithOrderedSet_range_copyItems_,
-      set.ref.pointer,
+      _$$ref.pointer,
       range,
       copyItems,
     );
@@ -12033,6 +12789,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
 
   /// orderedSetWithSet:
   static NSMutableOrderedSet orderedSetWithSet(NSSet set) {
+    final _$$ref = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.orderedSetWithSet:',
       iOS: (false, (5, 0, 0)),
@@ -12041,7 +12798,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableOrderedSet,
       _sel_orderedSetWithSet_,
-      set.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: true, release: true);
   }
@@ -12051,6 +12808,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     NSSet set, {
     required bool copyItems,
   }) {
+    final _$$ref = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.orderedSetWithSet:copyItems:',
       iOS: (false, (5, 0, 0)),
@@ -12059,7 +12817,7 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_17amj0z(
       _class_NSMutableOrderedSet,
       _sel_orderedSetWithSet_copyItems_,
-      set.ref.pointer,
+      _$$ref.pointer,
       copyItems,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: true, release: true);
@@ -12080,13 +12838,14 @@ extension type NSMutableOrderedSet._(objc.ObjCObject object$)
 extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
   /// init
   NSMutableOrderedSet init() {
+    final _$$ref$26 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$26.retainAndReturnPointer(),
       _sel_init,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
@@ -12094,30 +12853,34 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
 
   /// initWithArray:
   NSMutableOrderedSet initWithArray(NSArray array) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = array.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithArray:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
   NSMutableOrderedSet initWithArray$1(NSArray set, {required bool copyItems}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithArray:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithArray_copyItems_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
       copyItems,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
@@ -12129,15 +12892,17 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
     required NSRange range,
     required bool copyItems,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithArray:range:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_w9bq5x(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithArray_range_copyItems_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
       range,
       copyItems,
     );
@@ -12146,13 +12911,14 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
 
   /// initWithCapacity:
   NSMutableOrderedSet initWithCapacity(int numItems) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithCapacity:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCapacity_,
       numItems,
     );
@@ -12161,10 +12927,12 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
 
   /// initWithCoder:
   NSMutableOrderedSet? initWithCoder(NSCoder coder) {
+    final _$$ref$28 = object$.ref;
+    final _$$ref$29 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$28.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$29.pointer,
     );
     return $ret.address == 0
         ? null
@@ -12173,30 +12941,34 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
 
   /// initWithObject:
   NSMutableOrderedSet initWithObject(objc.ObjCObject object) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithObject:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObject_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithObjects:
   NSMutableOrderedSet initWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = firstObj.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithObjects:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
   }
@@ -12206,13 +12978,14 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required int count,
   }) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithObjects:count:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_zmbtbd(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjects_count_,
       objects,
       count,
@@ -12222,15 +12995,17 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
 
   /// initWithOrderedSet:
   NSMutableOrderedSet initWithOrderedSet(NSOrderedSet set) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithOrderedSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithOrderedSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
   }
@@ -12240,15 +13015,17 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
     NSOrderedSet set, {
     required bool copyItems,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithOrderedSet:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithOrderedSet_copyItems_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
       copyItems,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
@@ -12260,15 +13037,17 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
     required NSRange range,
     required bool copyItems,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithOrderedSet:range:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_w9bq5x(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithOrderedSet_range_copyItems_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
       range,
       copyItems,
     );
@@ -12277,30 +13056,34 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
 
   /// initWithSet:
   NSMutableOrderedSet initWithSet(NSSet set) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
   NSMutableOrderedSet initWithSet$1(NSSet set, {required bool copyItems}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.initWithSet:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithSet_copyItems_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
       copyItems,
     );
     return NSMutableOrderedSet.fromPointer($ret, retain: false, release: true);
@@ -12308,41 +13091,46 @@ extension NSMutableOrderedSet$Methods on NSMutableOrderedSet {
 
   /// insertObject:atIndex:
   void insertObject(objc.ObjCObject object, {required int atIndex}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.insertObject:atIndex:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_djsa9o(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_insertObject_atIndex_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
       atIndex,
     );
   }
 
   /// removeObjectAtIndex:
   void removeObjectAtIndex(int idx) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.removeObjectAtIndex:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    _objc_msgSend_1i9r4xy(object$.ref.pointer, _sel_removeObjectAtIndex_, idx);
+    _objc_msgSend_1i9r4xy(_$$ref.pointer, _sel_removeObjectAtIndex_, idx);
   }
 
   /// replaceObjectAtIndex:withObject:
   void replaceObjectAtIndex(int idx, {required objc.ObjCObject withObject}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withObject.ref;
     objc.checkOsVersionInternal(
       'NSMutableOrderedSet.replaceObjectAtIndex:withObject:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_1gypgok(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceObjectAtIndex_withObject_,
       idx,
-      withObject.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 }
@@ -12410,10 +13198,11 @@ extension type NSMutableSet._(objc.ObjCObject object$)
 
   /// setWithArray:
   static NSMutableSet setWithArray(NSArray array) {
+    final _$$ref = array.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableSet,
       _sel_setWithArray_,
-      array.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableSet.fromPointer($ret, retain: true, release: true);
   }
@@ -12430,20 +13219,22 @@ extension type NSMutableSet._(objc.ObjCObject object$)
 
   /// setWithObject:
   static NSMutableSet setWithObject(objc.ObjCObject object) {
+    final _$$ref = object.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableSet,
       _sel_setWithObject_,
-      object.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// setWithObjects:
   static NSMutableSet setWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref = firstObj.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableSet,
       _sel_setWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableSet.fromPointer($ret, retain: true, release: true);
   }
@@ -12464,10 +13255,11 @@ extension type NSMutableSet._(objc.ObjCObject object$)
 
   /// setWithSet:
   static NSMutableSet setWithSet(NSSet set) {
+    final _$$ref = set.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableSet,
       _sel_setWithSet_,
-      set.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableSet.fromPointer($ret, retain: true, release: true);
   }
@@ -12484,22 +13276,21 @@ extension type NSMutableSet._(objc.ObjCObject object$)
 extension NSMutableSet$Methods on NSMutableSet {
   /// addObject:
   void addObject(objc.ObjCObject object) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_addObject_,
-      object.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_addObject_, _$$ref$1.pointer);
   }
 
   /// init
   NSMutableSet init() {
+    final _$$ref$27 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableSet.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$27.retainAndReturnPointer(),
       _sel_init,
     );
     return NSMutableSet.fromPointer($ret, retain: false, release: true);
@@ -12507,18 +13298,21 @@ extension NSMutableSet$Methods on NSMutableSet {
 
   /// initWithArray:
   NSMutableSet initWithArray(NSArray array) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = array.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCapacity:
   NSMutableSet initWithCapacity(int numItems) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCapacity_,
       numItems,
     );
@@ -12527,10 +13321,12 @@ extension NSMutableSet$Methods on NSMutableSet {
 
   /// initWithCoder:
   NSMutableSet? initWithCoder(NSCoder coder) {
+    final _$$ref$30 = object$.ref;
+    final _$$ref$31 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$30.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$31.pointer,
     );
     return $ret.address == 0
         ? null
@@ -12539,10 +13335,12 @@ extension NSMutableSet$Methods on NSMutableSet {
 
   /// initWithObjects:
   NSMutableSet initWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = firstObj.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableSet.fromPointer($ret, retain: false, release: true);
   }
@@ -12552,8 +13350,9 @@ extension NSMutableSet$Methods on NSMutableSet {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required int count,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_zmbtbd(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObjects_count_,
       objects,
       count,
@@ -12563,20 +13362,24 @@ extension NSMutableSet$Methods on NSMutableSet {
 
   /// initWithSet:
   NSMutableSet initWithSet(NSSet set) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
   NSMutableSet initWithSet$1(NSSet set, {required bool copyItems}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithSet_copyItems_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
       copyItems,
     );
     return NSMutableSet.fromPointer($ret, retain: false, release: true);
@@ -12584,11 +13387,9 @@ extension NSMutableSet$Methods on NSMutableSet {
 
   /// removeObject:
   void removeObject(objc.ObjCObject object) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_removeObject_,
-      object.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_removeObject_, _$$ref$1.pointer);
   }
 }
 
@@ -12636,10 +13437,11 @@ extension type NSMutableString._(objc.ObjCObject object$)
 
   /// localizedStringWithFormat:
   static NSMutableString localizedStringWithFormat(NSString format) {
+    final _$$ref = format.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableString,
       _sel_localizedStringWithFormat_,
-      format.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableString.fromPointer($ret, retain: true, release: true);
   }
@@ -12649,6 +13451,8 @@ extension type NSMutableString._(objc.ObjCObject object$)
     NSString format, {
     required NSString validFormatSpecifiers,
   }) {
+    final _$$ref = format.ref;
+    final _$$ref$1 = validFormatSpecifiers.ref;
     objc.checkOsVersionInternal(
       'NSMutableString.localizedStringWithValidatedFormat:validFormatSpecifiers:error:',
       iOS: (false, (11, 0, 0)),
@@ -12659,8 +13463,8 @@ extension type NSMutableString._(objc.ObjCObject object$)
       final $ret = _objc_msgSend_1pnyuds(
         _class_NSMutableString,
         _sel_localizedStringWithValidatedFormat_validFormatSpecifiers_error_,
-        format.ref.pointer,
-        validFormatSpecifiers.ref.pointer,
+        _$$ref.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -12719,12 +13523,13 @@ extension type NSMutableString._(objc.ObjCObject object$)
     NSString path, {
     required int encoding,
   }) {
+    final _$$ref = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1nomli1(
         _class_NSMutableString,
         _sel_stringWithContentsOfFile_encoding_error_,
-        path.ref.pointer,
+        _$$ref.pointer,
         encoding,
         $err,
       );
@@ -12742,12 +13547,13 @@ extension type NSMutableString._(objc.ObjCObject object$)
     NSString path, {
     required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
   }) {
+    final _$$ref = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1alewu7(
         _class_NSMutableString,
         _sel_stringWithContentsOfFile_usedEncoding_error_,
-        path.ref.pointer,
+        _$$ref.pointer,
         usedEncoding,
         $err,
       );
@@ -12765,12 +13571,13 @@ extension type NSMutableString._(objc.ObjCObject object$)
     NSURL url, {
     required int encoding,
   }) {
+    final _$$ref = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1nomli1(
         _class_NSMutableString,
         _sel_stringWithContentsOfURL_encoding_error_,
-        url.ref.pointer,
+        _$$ref.pointer,
         encoding,
         $err,
       );
@@ -12788,12 +13595,13 @@ extension type NSMutableString._(objc.ObjCObject object$)
     NSURL url, {
     required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
   }) {
+    final _$$ref = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1alewu7(
         _class_NSMutableString,
         _sel_stringWithContentsOfURL_usedEncoding_error_,
-        url.ref.pointer,
+        _$$ref.pointer,
         usedEncoding,
         $err,
       );
@@ -12808,20 +13616,22 @@ extension type NSMutableString._(objc.ObjCObject object$)
 
   /// stringWithFormat:
   static NSMutableString stringWithFormat(NSString format) {
+    final _$$ref = format.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableString,
       _sel_stringWithFormat_,
-      format.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableString.fromPointer($ret, retain: true, release: true);
   }
 
   /// stringWithString:
   static NSMutableString stringWithString(NSString string) {
+    final _$$ref = string.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSMutableString,
       _sel_stringWithString_,
-      string.ref.pointer,
+      _$$ref.pointer,
     );
     return NSMutableString.fromPointer($ret, retain: true, release: true);
   }
@@ -12845,6 +13655,8 @@ extension type NSMutableString._(objc.ObjCObject object$)
     NSString format, {
     required NSString validFormatSpecifiers,
   }) {
+    final _$$ref = format.ref;
+    final _$$ref$1 = validFormatSpecifiers.ref;
     objc.checkOsVersionInternal(
       'NSMutableString.stringWithValidatedFormat:validFormatSpecifiers:error:',
       iOS: (false, (11, 0, 0)),
@@ -12855,8 +13667,8 @@ extension type NSMutableString._(objc.ObjCObject object$)
       final $ret = _objc_msgSend_1pnyuds(
         _class_NSMutableString,
         _sel_stringWithValidatedFormat_validFormatSpecifiers_error_,
-        format.ref.pointer,
-        validFormatSpecifiers.ref.pointer,
+        _$$ref.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -12883,13 +13695,14 @@ extension type NSMutableString._(objc.ObjCObject object$)
 extension NSMutableString$Methods on NSMutableString {
   /// init
   NSMutableString init() {
+    final _$$ref$28 = object$.ref;
     objc.checkOsVersionInternal(
       'NSMutableString.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$28.retainAndReturnPointer(),
       _sel_init,
     );
     return NSMutableString.fromPointer($ret, retain: false, release: true);
@@ -12901,8 +13714,9 @@ extension NSMutableString$Methods on NSMutableString {
     required int length,
     required int encoding,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_9b3h4v(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBytes_length_encoding_,
       bytes,
       length,
@@ -12921,13 +13735,15 @@ extension NSMutableString$Methods on NSMutableString {
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.UnsignedLong)>?
     deallocator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = deallocator?.ref;
     final $ret = _objc_msgSend_1lbgrac(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_encoding_deallocator_,
       bytes,
       length,
       encoding,
-      deallocator?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -12941,8 +13757,9 @@ extension NSMutableString$Methods on NSMutableString {
     required int encoding,
     required bool freeWhenDone,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_k4j8m3(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_encoding_freeWhenDone_,
       bytes,
       length,
@@ -12959,8 +13776,9 @@ extension NSMutableString$Methods on NSMutableString {
     ffi.Pointer<ffi.Char> nullTerminatedCString, {
     required int encoding,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_erqryg(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCString_encoding_,
       nullTerminatedCString,
       encoding,
@@ -12975,8 +13793,9 @@ extension NSMutableString$Methods on NSMutableString {
     ffi.Pointer<ffi.UnsignedShort> characters, {
     required int length,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_9x4k8x(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCharacters_length_,
       characters,
       length,
@@ -12993,12 +13812,14 @@ extension NSMutableString$Methods on NSMutableString {
     >?
     deallocator,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = deallocator?.ref;
     final $ret = _objc_msgSend_talwei(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCharactersNoCopy_length_deallocator_,
       chars,
       length,
-      deallocator?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSMutableString.fromPointer($ret, retain: false, release: true);
   }
@@ -13009,8 +13830,9 @@ extension NSMutableString$Methods on NSMutableString {
     required int length,
     required bool freeWhenDone,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_lh0jh5(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithCharactersNoCopy_length_freeWhenDone_,
       characters,
       length,
@@ -13021,10 +13843,12 @@ extension NSMutableString$Methods on NSMutableString {
 
   /// initWithCoder:
   NSMutableString? initWithCoder(NSCoder coder) {
+    final _$$ref$32 = object$.ref;
+    final _$$ref$33 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$32.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$33.pointer,
     );
     return $ret.address == 0
         ? null
@@ -13036,12 +13860,14 @@ extension NSMutableString$Methods on NSMutableString {
     NSString path, {
     required int encoding,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1nomli1(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_encoding_error_,
-        path.ref.pointer,
+        _$$ref$1.pointer,
         encoding,
         $err,
       );
@@ -13059,12 +13885,14 @@ extension NSMutableString$Methods on NSMutableString {
     NSString path, {
     required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1alewu7(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_usedEncoding_error_,
-        path.ref.pointer,
+        _$$ref$1.pointer,
         usedEncoding,
         $err,
       );
@@ -13079,12 +13907,14 @@ extension NSMutableString$Methods on NSMutableString {
 
   /// initWithContentsOfURL:encoding:error:
   NSMutableString? initWithContentsOfURL(NSURL url, {required int encoding}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1nomli1(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_encoding_error_,
-        url.ref.pointer,
+        _$$ref$1.pointer,
         encoding,
         $err,
       );
@@ -13102,12 +13932,14 @@ extension NSMutableString$Methods on NSMutableString {
     NSURL url, {
     required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1alewu7(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_usedEncoding_error_,
-        url.ref.pointer,
+        _$$ref$1.pointer,
         usedEncoding,
         $err,
       );
@@ -13122,10 +13954,12 @@ extension NSMutableString$Methods on NSMutableString {
 
   /// initWithData:encoding:
   NSMutableString? initWithData(NSData data, {required int encoding}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
     final $ret = _objc_msgSend_1k4kd9s(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithData_encoding_,
-      data.ref.pointer,
+      _$$ref$1.pointer,
       encoding,
     );
     return $ret.address == 0
@@ -13135,31 +13969,38 @@ extension NSMutableString$Methods on NSMutableString {
 
   /// initWithFormat:
   NSMutableString initWithFormat(NSString format) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = format.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithFormat_,
-      format.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableString.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithFormat:locale:
   NSMutableString initWithFormat$1(NSString format, {objc.ObjCObject? locale}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = format.ref;
+    final _$$ref$2 = locale?.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithFormat_locale_,
-      format.ref.pointer,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSMutableString.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithString:
   NSMutableString initWithString(NSString aString) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aString.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithString_,
-      aString.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSMutableString.fromPointer($ret, retain: false, release: true);
   }
@@ -13168,8 +14009,9 @@ extension NSMutableString$Methods on NSMutableString {
   NSMutableString? initWithUTF8String(
     ffi.Pointer<ffi.Char> nullTerminatedCString,
   ) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_56zxyn(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithUTF8String_,
       nullTerminatedCString,
     );
@@ -13186,6 +14028,9 @@ extension NSMutableString$Methods on NSMutableString {
     NSString format, {
     required NSString validFormatSpecifiers,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = format.ref;
+    final _$$ref$2 = validFormatSpecifiers.ref;
     objc.checkOsVersionInternal(
       'NSMutableString.initWithValidatedFormat:validFormatSpecifiers:error:',
       iOS: (false, (16, 0, 0)),
@@ -13194,10 +14039,10 @@ extension NSMutableString$Methods on NSMutableString {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1pnyuds(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithValidatedFormat_validFormatSpecifiers_error_,
-        format.ref.pointer,
-        validFormatSpecifiers.ref.pointer,
+        _$$ref$1.pointer,
+        _$$ref$2.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -13218,6 +14063,10 @@ extension NSMutableString$Methods on NSMutableString {
     required NSString validFormatSpecifiers,
     objc.ObjCObject? locale,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = format.ref;
+    final _$$ref$2 = validFormatSpecifiers.ref;
+    final _$$ref$3 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSMutableString.initWithValidatedFormat:validFormatSpecifiers:locale:error:',
       iOS: (false, (16, 0, 0)),
@@ -13226,11 +14075,11 @@ extension NSMutableString$Methods on NSMutableString {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1k0ezzm(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initWithValidatedFormat_validFormatSpecifiers_locale_error_,
-        format.ref.pointer,
-        validFormatSpecifiers.ref.pointer,
-        locale?.ref.pointer ?? ffi.nullptr,
+        _$$ref$1.pointer,
+        _$$ref$2.pointer,
+        _$$ref$3?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -13244,11 +14093,13 @@ extension NSMutableString$Methods on NSMutableString {
 
   /// replaceCharactersInRange:withString:
   void replaceCharactersInRange(NSRange range, {required NSString withString}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withString.ref;
     _objc_msgSend_1tv4uax(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_replaceCharactersInRange_withString_,
       range,
-      withString.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 }
@@ -13306,11 +14157,13 @@ extension type NSNotification._(objc.ObjCObject object$)
     NSString aName, {
     objc.ObjCObject? object,
   }) {
+    final _$$ref = aName.ref;
+    final _$$ref$1 = object?.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_NSNotification,
       _sel_notificationWithName_object_,
-      aName.ref.pointer,
-      object?.ref.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSNotification.fromPointer($ret, retain: true, release: true);
   }
@@ -13321,12 +14174,15 @@ extension type NSNotification._(objc.ObjCObject object$)
     objc.ObjCObject? object,
     NSDictionary? userInfo,
   }) {
+    final _$$ref = aName.ref;
+    final _$$ref$1 = object?.ref;
+    final _$$ref$2 = userInfo?.ref;
     final $ret = _objc_msgSend_11spmsz(
       _class_NSNotification,
       _sel_notificationWithName_object_userInfo_,
-      aName.ref.pointer,
-      object?.ref.pointer ?? ffi.nullptr,
-      userInfo?.ref.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSNotification.fromPointer($ret, retain: true, release: true);
   }
@@ -13338,17 +14194,20 @@ extension type NSNotification._(objc.ObjCObject object$)
 extension NSNotification$Methods on NSNotification {
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$20 = object$.ref;
+    final _$$ref$21 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$20.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$21.pointer,
     );
   }
 
   /// init
   NSNotification init() {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_init,
     );
     return NSNotification.fromPointer($ret, retain: false, release: true);
@@ -13356,10 +14215,12 @@ extension NSNotification$Methods on NSNotification {
 
   /// initWithCoder:
   NSNotification? initWithCoder(NSCoder coder) {
+    final _$$ref$34 = object$.ref;
+    final _$$ref$35 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$34.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$35.pointer,
     );
     return $ret.address == 0
         ? null
@@ -13372,30 +14233,36 @@ extension NSNotification$Methods on NSNotification {
     objc.ObjCObject? object,
     NSDictionary? userInfo,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = name.ref;
+    final _$$ref$2 = object?.ref;
+    final _$$ref$3 = userInfo?.ref;
     objc.checkOsVersionInternal(
       'NSNotification.initWithName:object:userInfo:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_11spmsz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithName_object_userInfo_,
-      name.ref.pointer,
-      object?.ref.pointer ?? ffi.nullptr,
-      userInfo?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return NSNotification.fromPointer($ret, retain: false, release: true);
   }
 
   /// name
   NSString get name {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_name);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_name);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// object
   objc.ObjCObject? get object {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_object);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_object);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -13403,7 +14270,8 @@ extension NSNotification$Methods on NSNotification {
 
   /// userInfo
   NSDictionary? get userInfo {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_userInfo);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_userInfo);
     return $ret.address == 0
         ? null
         : NSDictionary.fromPointer($ret, retain: true, release: true);
@@ -13476,22 +14344,25 @@ extension type NSNull._(objc.ObjCObject object$)
 extension NSNull$Methods on NSNull {
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$22 = object$.ref;
+    final _$$ref$23 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$22.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$23.pointer,
     );
   }
 
   /// init
   NSNull init() {
+    final _$$ref$29 = object$.ref;
     objc.checkOsVersionInternal(
       'NSNull.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$29.retainAndReturnPointer(),
       _sel_init,
     );
     return NSNull.fromPointer($ret, retain: false, release: true);
@@ -13499,10 +14370,12 @@ extension NSNull$Methods on NSNull {
 
   /// initWithCoder:
   NSNull? initWithCoder(NSCoder coder) {
+    final _$$ref$36 = object$.ref;
+    final _$$ref$37 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$36.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$37.pointer,
     );
     return $ret.address == 0
         ? null
@@ -13570,57 +14443,66 @@ extension type NSNumber._(objc.ObjCObject object$)
 extension NSNumber$Methods on NSNumber {
   /// boolValue
   bool get boolValue {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_boolValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_boolValue);
   }
 
   /// charValue
   int get charValue {
-    return _objc_msgSend_xmlz1t(object$.ref.pointer, _sel_charValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xmlz1t(_$$ref.pointer, _sel_charValue);
   }
 
   /// compare:
   NSComparisonResult compare(NSNumber otherNumber) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = otherNumber.ref;
     final $ret = _objc_msgSend_1ym6zyw(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_compare_,
-      otherNumber.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSComparisonResult.fromValue($ret);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale(objc.ObjCObject? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_descriptionWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// doubleValue
   double get doubleValue {
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_doubleValue)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_doubleValue);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_doubleValue)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_doubleValue);
   }
 
   /// floatValue
   double get floatValue {
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(object$.ref.pointer, _sel_floatValue)
-        : _objc_msgSend_2cgrxl(object$.ref.pointer, _sel_floatValue);
+        ? _objc_msgSend_2cgrxlFpret(_$$ref.pointer, _sel_floatValue)
+        : _objc_msgSend_2cgrxl(_$$ref.pointer, _sel_floatValue);
   }
 
   /// init
   NSNumber init() {
+    final _$$ref$30 = object$.ref;
     objc.checkOsVersionInternal(
       'NSNumber.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$30.retainAndReturnPointer(),
       _sel_init,
     );
     return NSNumber.fromPointer($ret, retain: false, release: true);
@@ -13628,8 +14510,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithBool:
   NSNumber initWithBool(bool value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1t6aok9(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBool_,
       value,
     );
@@ -13641,8 +14524,9 @@ extension NSNumber$Methods on NSNumber {
     ffi.Pointer<ffi.Void> value, {
     required ffi.Pointer<ffi.Char> objCType,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_e9mncn(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithBytes_objCType_,
       value,
       objCType,
@@ -13652,8 +14536,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithChar:
   NSNumber initWithChar(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_13mclwd(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithChar_,
       value,
     );
@@ -13662,10 +14547,12 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithCoder:
   NSNumber? initWithCoder(NSCoder coder) {
+    final _$$ref$38 = object$.ref;
+    final _$$ref$39 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$38.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$39.pointer,
     );
     return $ret.address == 0
         ? null
@@ -13674,8 +14561,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithDouble:
   NSNumber initWithDouble(double value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_oa8mke(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithDouble_,
       value,
     );
@@ -13684,8 +14572,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithFloat:
   NSNumber initWithFloat(double value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_et8cuh(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithFloat_,
       value,
     );
@@ -13694,8 +14583,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithInt:
   NSNumber initWithInt(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hvw5k(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithInt_,
       value,
     );
@@ -13704,13 +14594,14 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithInteger:
   NSNumber initWithInteger(int value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSNumber.initWithInteger:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_qugqlf(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithInteger_,
       value,
     );
@@ -13719,8 +14610,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithLong:
   NSNumber initWithLong(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_qugqlf(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithLong_,
       value,
     );
@@ -13729,8 +14621,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithLongLong:
   NSNumber initWithLongLong(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_16f0drb(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithLongLong_,
       value,
     );
@@ -13739,8 +14632,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithShort:
   NSNumber initWithShort(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_68x6r1(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithShort_,
       value,
     );
@@ -13749,8 +14643,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithUnsignedChar:
   NSNumber initWithUnsignedChar(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_7uautw(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithUnsignedChar_,
       value,
     );
@@ -13759,8 +14654,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithUnsignedInt:
   NSNumber initWithUnsignedInt(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_degb40(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithUnsignedInt_,
       value,
     );
@@ -13769,13 +14665,14 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithUnsignedInteger:
   NSNumber initWithUnsignedInteger(int value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSNumber.initWithUnsignedInteger:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithUnsignedInteger_,
       value,
     );
@@ -13784,8 +14681,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithUnsignedLong:
   NSNumber initWithUnsignedLong(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithUnsignedLong_,
       value,
     );
@@ -13794,8 +14692,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithUnsignedLongLong:
   NSNumber initWithUnsignedLongLong(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1x2hskc(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithUnsignedLongLong_,
       value,
     );
@@ -13804,8 +14703,9 @@ extension NSNumber$Methods on NSNumber {
 
   /// initWithUnsignedShort:
   NSNumber initWithUnsignedShort(int value) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1njucl2(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithUnsignedShort_,
       value,
     );
@@ -13814,85 +14714,96 @@ extension NSNumber$Methods on NSNumber {
 
   /// intValue
   int get intValue {
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_intValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_intValue);
   }
 
   /// integerValue
   int get integerValue {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSNumber.integerValue',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_integerValue);
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_integerValue);
   }
 
   /// isEqualToNumber:
   bool isEqualToNumber(NSNumber number) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = number.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToNumber_,
-      number.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// longLongValue
   int get longLongValue {
-    return _objc_msgSend_1k101e3(object$.ref.pointer, _sel_longLongValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1k101e3(_$$ref.pointer, _sel_longLongValue);
   }
 
   /// longValue
   int get longValue {
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_longValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_longValue);
   }
 
   /// shortValue
   int get shortValue {
-    return _objc_msgSend_1jwityx(object$.ref.pointer, _sel_shortValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1jwityx(_$$ref.pointer, _sel_shortValue);
   }
 
   /// stringValue
   NSString get stringValue {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_stringValue);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_stringValue);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// unsignedCharValue
   int get unsignedCharValue {
-    return _objc_msgSend_1ko4qka(object$.ref.pointer, _sel_unsignedCharValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1ko4qka(_$$ref.pointer, _sel_unsignedCharValue);
   }
 
   /// unsignedIntValue
   int get unsignedIntValue {
-    return _objc_msgSend_3pyzne(object$.ref.pointer, _sel_unsignedIntValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_3pyzne(_$$ref.pointer, _sel_unsignedIntValue);
   }
 
   /// unsignedIntegerValue
   int get unsignedIntegerValue {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSNumber.unsignedIntegerValue',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_unsignedIntegerValue);
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_unsignedIntegerValue);
   }
 
   /// unsignedLongLongValue
   int get unsignedLongLongValue {
-    return _objc_msgSend_1p4gbjy(
-      object$.ref.pointer,
-      _sel_unsignedLongLongValue,
-    );
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1p4gbjy(_$$ref.pointer, _sel_unsignedLongLongValue);
   }
 
   /// unsignedLongValue
   int get unsignedLongValue {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_unsignedLongValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_unsignedLongValue);
   }
 
   /// unsignedShortValue
   int get unsignedShortValue {
-    return _objc_msgSend_ud8gg(object$.ref.pointer, _sel_unsignedShortValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_ud8gg(_$$ref.pointer, _sel_unsignedShortValue);
   }
 }
 
@@ -14063,7 +14974,8 @@ extension NSNumberCreation on NSNumber {
 extension NSNumberIsBool on NSNumber {
   /// isBool
   bool get isBool {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isBool);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isBool);
   }
 }
 
@@ -14071,7 +14983,8 @@ extension NSNumberIsBool on NSNumber {
 extension NSNumberIsFloat on NSNumber {
   /// isFloat
   bool get isFloat {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isFloat);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isFloat);
   }
 }
 
@@ -14135,6 +15048,7 @@ extension type NSObject._(objc.ObjCObject object$)
 
   /// conformsToProtocol:
   static bool conformsToProtocol(Protocol protocol) {
+    final _$$ref = protocol.ref;
     objc.checkOsVersionInternal(
       'NSObject.conformsToProtocol:',
       iOS: (false, (2, 0, 0)),
@@ -14143,7 +15057,7 @@ extension type NSObject._(objc.ObjCObject object$)
     return _objc_msgSend_19nvye5(
       _class_NSObject,
       _sel_conformsToProtocol_,
-      protocol.ref.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -14249,6 +15163,7 @@ extension type NSObject._(objc.ObjCObject object$)
 
   /// isSubclassOfClass:
   static bool isSubclassOfClass(objc.ObjCObject aClass) {
+    final _$$ref = aClass.ref;
     objc.checkOsVersionInternal(
       'NSObject.isSubclassOfClass:',
       iOS: (false, (2, 0, 0)),
@@ -14257,7 +15172,7 @@ extension type NSObject._(objc.ObjCObject object$)
     return _objc_msgSend_19nvye5(
       _class_NSObject,
       _sel_isSubclassOfClass_,
-      aClass.ref.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -14338,29 +15253,32 @@ extension type NSObject._(objc.ObjCObject object$)
 extension NSObject$Methods on NSObject {
   /// copy
   objc.ObjCObject copy() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.copy',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_copy);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_copy);
     return objc.ObjCObject($ret, retain: false, release: true);
   }
 
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_dealloc);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_dealloc);
   }
 
   /// doesNotRecognizeSelector:
   void doesNotRecognizeSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.doesNotRecognizeSelector:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     _objc_msgSend_1d9e4oe(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_doesNotRecognizeSelector_,
       aSelector,
     );
@@ -14368,10 +15286,12 @@ extension NSObject$Methods on NSObject {
 
   /// forwardInvocation:
   void forwardInvocation(NSInvocation anInvocation) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anInvocation.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_forwardInvocation_,
-      anInvocation.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -14379,13 +15299,14 @@ extension NSObject$Methods on NSObject {
   objc.ObjCObject forwardingTargetForSelector(
     ffi.Pointer<objc.ObjCSelector> aSelector,
   ) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.forwardingTargetForSelector:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_3ctkt6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_forwardingTargetForSelector_,
       aSelector,
     );
@@ -14394,13 +15315,14 @@ extension NSObject$Methods on NSObject {
 
   /// init
   NSObject init() {
+    final _$$ref$31 = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$31.retainAndReturnPointer(),
       _sel_init,
     );
     return NSObject.fromPointer($ret, retain: false, release: true);
@@ -14408,47 +15330,55 @@ extension NSObject$Methods on NSObject {
 
   /// isEqual:
   bool isEqual(objc.ObjCObject object) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqual_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// isKindOfClass:
   bool isKindOfClass(objc.ObjCObject aClass) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aClass.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isKindOfClass_,
-      aClass.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// isMemberOfClass:
   bool isMemberOfClass(objc.ObjCObject aClass) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aClass.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isMemberOfClass_,
-      aClass.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// isProxy
   bool get isProxy {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isProxy);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isProxy);
   }
 
   /// methodForSelector:
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> methodForSelector(
     ffi.Pointer<objc.ObjCSelector> aSelector,
   ) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.methodForSelector:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     return _objc_msgSend_1pa9f4m(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_methodForSelector_,
       aSelector,
     );
@@ -14458,8 +15388,9 @@ extension NSObject$Methods on NSObject {
   NSMethodSignature methodSignatureForSelector(
     ffi.Pointer<objc.ObjCSelector> aSelector,
   ) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_3ctkt6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_methodSignatureForSelector_,
       aSelector,
     );
@@ -14468,19 +15399,21 @@ extension NSObject$Methods on NSObject {
 
   /// mutableCopy
   objc.ObjCObject mutableCopy() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSObject.mutableCopy',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_mutableCopy);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_mutableCopy);
     return objc.ObjCObject($ret, retain: false, release: true);
   }
 
   /// performSelector:
   objc.ObjCObject performSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_3ctkt6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_performSelector_,
       aSelector,
     );
@@ -14492,11 +15425,13 @@ extension NSObject$Methods on NSObject {
     ffi.Pointer<objc.ObjCSelector> aSelector, {
     required objc.ObjCObject withObject,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withObject.ref;
     final $ret = _objc_msgSend_gx50so(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_performSelector_withObject_,
       aSelector,
-      withObject.ref.pointer,
+      _$$ref$1.pointer,
     );
     return objc.ObjCObject($ret, retain: true, release: true);
   }
@@ -14507,19 +15442,23 @@ extension NSObject$Methods on NSObject {
     required objc.ObjCObject withObject,
     required objc.ObjCObject withObject$1,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withObject.ref;
+    final _$$ref$2 = withObject$1.ref;
     final $ret = _objc_msgSend_cfx8ce(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_performSelector_withObject_withObject_,
       aSelector,
-      withObject.ref.pointer,
-      withObject$1.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return objc.ObjCObject($ret, retain: true, release: true);
   }
 
   /// zone
   ffi.Pointer<NSZone> zone() {
-    return _objc_msgSend_sz90oi(object$.ref.pointer, _sel_zone);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_sz90oi(_$$ref.pointer, _sel_zone);
   }
 }
 
@@ -14549,87 +15488,99 @@ extension type NSObjectProtocol._(objc.ObjCProtocol object$)
 extension NSObjectProtocol$Methods on NSObjectProtocol {
   /// autorelease
   NSObjectProtocol autorelease() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_autorelease);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_autorelease);
     return NSObjectProtocol.fromPointer($ret, retain: true, release: true);
   }
 
   /// class
   objc.ObjCObject class$() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_class);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_class);
     return objc.ObjCObject($ret, retain: true, release: true);
   }
 
   /// conformsToProtocol:
   bool conformsToProtocol(Protocol aProtocol) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aProtocol.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_conformsToProtocol_,
-      aProtocol.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// debugDescription
   NSString get debugDescription {
-    if (!objc.respondsToSelector(object$.ref.pointer, _sel_debugDescription)) {
+    final _$$ref = object$.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_debugDescription)) {
       throw objc.UnimplementedOptionalMethodException(
         'NSObject',
         'debugDescription',
       );
     }
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_debugDescription,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_debugDescription);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// description
   NSString get description {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_description);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_description);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// hash
   int get hash {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_hash);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_hash);
   }
 
   /// isEqual:
   bool isEqual(objc.ObjCObject object) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = object.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref$2.pointer,
       _sel_isEqual_,
-      object.ref.pointer,
+      _$$ref$3.pointer,
     );
   }
 
   /// isKindOfClass:
   bool isKindOfClass(objc.ObjCObject aClass) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = aClass.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref$2.pointer,
       _sel_isKindOfClass_,
-      aClass.ref.pointer,
+      _$$ref$3.pointer,
     );
   }
 
   /// isMemberOfClass:
   bool isMemberOfClass(objc.ObjCObject aClass) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = aClass.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref$2.pointer,
       _sel_isMemberOfClass_,
-      aClass.ref.pointer,
+      _$$ref$3.pointer,
     );
   }
 
   /// isProxy
   bool get isProxy {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isProxy);
+    final _$$ref$1 = object$.ref;
+    return _objc_msgSend_91o635(_$$ref$1.pointer, _sel_isProxy);
   }
 
   /// performSelector:
   objc.ObjCObject performSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_3ctkt6(
-      object$.ref.pointer,
+      _$$ref$1.pointer,
       _sel_performSelector_,
       aSelector,
     );
@@ -14641,11 +15592,13 @@ extension NSObjectProtocol$Methods on NSObjectProtocol {
     ffi.Pointer<objc.ObjCSelector> aSelector, {
     required objc.ObjCObject withObject,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = withObject.ref;
     final $ret = _objc_msgSend_gx50so(
-      object$.ref.pointer,
+      _$$ref$2.pointer,
       _sel_performSelector_withObject_,
       aSelector,
-      withObject.ref.pointer,
+      _$$ref$3.pointer,
     );
     return objc.ObjCObject($ret, retain: true, release: true);
   }
@@ -14656,25 +15609,30 @@ extension NSObjectProtocol$Methods on NSObjectProtocol {
     required objc.ObjCObject withObject,
     required objc.ObjCObject withObject$1,
   }) {
+    final _$$ref$3 = object$.ref;
+    final _$$ref$4 = withObject.ref;
+    final _$$ref$5 = withObject$1.ref;
     final $ret = _objc_msgSend_cfx8ce(
-      object$.ref.pointer,
+      _$$ref$3.pointer,
       _sel_performSelector_withObject_withObject_,
       aSelector,
-      withObject.ref.pointer,
-      withObject$1.ref.pointer,
+      _$$ref$4.pointer,
+      _$$ref$5.pointer,
     );
     return objc.ObjCObject($ret, retain: true, release: true);
   }
 
   /// release
   void release() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_release);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_release);
   }
 
   /// respondsToSelector:
   bool respondsToSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_1srf6wk(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_respondsToSelector_,
       aSelector,
     );
@@ -14682,30 +15640,35 @@ extension NSObjectProtocol$Methods on NSObjectProtocol {
 
   /// retain
   NSObjectProtocol retain() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_retain);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_retain);
     return NSObjectProtocol.fromPointer($ret, retain: true, release: true);
   }
 
   /// retainCount
   int retainCount() {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_retainCount);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_retainCount);
   }
 
   /// self
   NSObjectProtocol self() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_self);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_self);
     return NSObjectProtocol.fromPointer($ret, retain: true, release: true);
   }
 
   /// superclass
   objc.ObjCObject get superclass {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_superclass);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_superclass);
     return objc.ObjCObject($ret, retain: true, release: true);
   }
 
   /// zone
   ffi.Pointer<NSZone> zone() {
-    return _objc_msgSend_sz90oi(object$.ref.pointer, _sel_zone);
+    final _$$ref$1 = object$.ref;
+    return _objc_msgSend_sz90oi(_$$ref$1.pointer, _sel_zone);
   }
 }
 
@@ -15853,6 +16816,7 @@ extension type NSOrderedCollectionChange._(objc.ObjCObject object$)
     required NSCollectionChangeType type,
     required int index,
   }) {
+    final _$$ref = anObject?.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionChange.changeWithObject:type:index:',
       iOS: (false, (13, 0, 0)),
@@ -15861,7 +16825,7 @@ extension type NSOrderedCollectionChange._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_vbymrb(
       _class_NSOrderedCollectionChange,
       _sel_changeWithObject_type_index_,
-      anObject?.ref.pointer ?? ffi.nullptr,
+      _$$ref?.pointer ?? ffi.nullptr,
       type.value,
       index,
     );
@@ -15882,6 +16846,7 @@ extension type NSOrderedCollectionChange._(objc.ObjCObject object$)
     required int index,
     required int associatedIndex,
   }) {
+    final _$$ref = anObject?.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionChange.changeWithObject:type:index:associatedIndex:',
       iOS: (false, (13, 0, 0)),
@@ -15890,7 +16855,7 @@ extension type NSOrderedCollectionChange._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1egc1c(
       _class_NSOrderedCollectionChange,
       _sel_changeWithObject_type_index_associatedIndex_,
-      anObject?.ref.pointer ?? ffi.nullptr,
+      _$$ref?.pointer ?? ffi.nullptr,
       type.value,
       index,
       associatedIndex,
@@ -15923,35 +16888,38 @@ extension NSOrderedCollectionChange$Methods on NSOrderedCollectionChange {
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   int get associatedIndex {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionChange.associatedIndex',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_associatedIndex);
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_associatedIndex);
   }
 
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   NSCollectionChangeType get changeType {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionChange.changeType',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
-    final $ret = _objc_msgSend_hc8exi(object$.ref.pointer, _sel_changeType);
+    final $ret = _objc_msgSend_hc8exi(_$$ref.pointer, _sel_changeType);
     return NSCollectionChangeType.fromValue($ret);
   }
 
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   int get index {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionChange.index',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_index);
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_index);
   }
 
   /// initWithObject:type:index:
@@ -15963,15 +16931,17 @@ extension NSOrderedCollectionChange$Methods on NSOrderedCollectionChange {
     required NSCollectionChangeType type,
     required int index,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject?.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionChange.initWithObject:type:index:',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
     final $ret = _objc_msgSend_vbymrb(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObject_type_index_,
-      anObject?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
       type.value,
       index,
     );
@@ -15992,15 +16962,17 @@ extension NSOrderedCollectionChange$Methods on NSOrderedCollectionChange {
     required int index,
     required int associatedIndex,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject?.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionChange.initWithObject:type:index:associatedIndex:',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
     final $ret = _objc_msgSend_1egc1c(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithObject_type_index_associatedIndex_,
-      anObject?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
       type.value,
       index,
       associatedIndex,
@@ -16015,12 +16987,13 @@ extension NSOrderedCollectionChange$Methods on NSOrderedCollectionChange {
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   objc.ObjCObject? get object {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionChange.object',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_object);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_object);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -16118,8 +17091,9 @@ extension NSOrderedCollectionDifference$Methods
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects,
     required int count,
   }) {
+    final _$$ref$4 = object$.ref;
     return _objc_msgSend_1b5ysjl(
-      object$.ref.pointer,
+      _$$ref$4.pointer,
       _sel_countByEnumeratingWithState_objects_count_,
       state,
       objects,
@@ -16137,15 +17111,17 @@ extension NSOrderedCollectionDifference$Methods
     >
     block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.differenceByTransformingChangesWithBlock:',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
     final $ret = _objc_msgSend_nnxkei(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_differenceByTransformingChangesWithBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSOrderedCollectionDifference.fromPointer(
       $ret,
@@ -16157,23 +17133,25 @@ extension NSOrderedCollectionDifference$Methods
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   bool get hasChanges {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.hasChanges',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_hasChanges);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_hasChanges);
   }
 
   /// init
   NSOrderedCollectionDifference init() {
+    final _$$ref$32 = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$32.retainAndReturnPointer(),
       _sel_init,
     );
     return NSOrderedCollectionDifference.fromPointer(
@@ -16188,15 +17166,17 @@ extension NSOrderedCollectionDifference$Methods
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   NSOrderedCollectionDifference initWithChanges(NSArray changes) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = changes.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.initWithChanges:',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithChanges_,
-      changes.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSOrderedCollectionDifference.fromPointer(
       $ret,
@@ -16215,18 +17195,23 @@ extension NSOrderedCollectionDifference$Methods
     required NSIndexSet removeIndexes,
     NSArray? removedObjects,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = inserts.ref;
+    final _$$ref$2 = insertedObjects?.ref;
+    final _$$ref$3 = removeIndexes.ref;
+    final _$$ref$4 = removedObjects?.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
     final $ret = _objc_msgSend_s92gih(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_,
-      inserts.ref.pointer,
-      insertedObjects?.ref.pointer ?? ffi.nullptr,
-      removeIndexes.ref.pointer,
-      removedObjects?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3.pointer,
+      _$$ref$4?.pointer ?? ffi.nullptr,
     );
     return NSOrderedCollectionDifference.fromPointer(
       $ret,
@@ -16246,19 +17231,25 @@ extension NSOrderedCollectionDifference$Methods
     NSArray? removedObjects,
     required NSArray additionalChanges,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = inserts.ref;
+    final _$$ref$2 = insertedObjects?.ref;
+    final _$$ref$3 = removeIndexes.ref;
+    final _$$ref$4 = removedObjects?.ref;
+    final _$$ref$5 = additionalChanges.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:additionalChanges:',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
     final $ret = _objc_msgSend_3cbdpb(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_additionalChanges_,
-      inserts.ref.pointer,
-      insertedObjects?.ref.pointer ?? ffi.nullptr,
-      removeIndexes.ref.pointer,
-      removedObjects?.ref.pointer ?? ffi.nullptr,
-      additionalChanges.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3.pointer,
+      _$$ref$4?.pointer ?? ffi.nullptr,
+      _$$ref$5.pointer,
     );
     return NSOrderedCollectionDifference.fromPointer(
       $ret,
@@ -16270,12 +17261,13 @@ extension NSOrderedCollectionDifference$Methods
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   NSArray get insertions {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.insertions',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_insertions);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_insertions);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
@@ -16284,15 +17276,13 @@ extension NSOrderedCollectionDifference$Methods
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   NSOrderedCollectionDifference inverseDifference() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.inverseDifference',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_inverseDifference,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_inverseDifference);
     return NSOrderedCollectionDifference.fromPointer(
       $ret,
       retain: true,
@@ -16303,12 +17293,13 @@ extension NSOrderedCollectionDifference$Methods
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
   NSArray get removals {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedCollectionDifference.removals',
       iOS: (false, (13, 0, 0)),
       macOS: (false, (10, 15, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_removals);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_removals);
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -16398,6 +17389,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
 
   /// orderedSetWithArray:
   static NSOrderedSet orderedSetWithArray(NSArray array) {
+    final _$$ref$1 = array.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.orderedSetWithArray:',
       iOS: (false, (5, 0, 0)),
@@ -16406,7 +17398,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSOrderedSet,
       _sel_orderedSetWithArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: true, release: true);
   }
@@ -16417,6 +17409,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     required NSRange range,
     required bool copyItems,
   }) {
+    final _$$ref$1 = array.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.orderedSetWithArray:range:copyItems:',
       iOS: (false, (5, 0, 0)),
@@ -16425,7 +17418,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_w9bq5x(
       _class_NSOrderedSet,
       _sel_orderedSetWithArray_range_copyItems_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
       range,
       copyItems,
     );
@@ -16434,6 +17427,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
 
   /// orderedSetWithObject:
   static NSOrderedSet orderedSetWithObject(objc.ObjCObject object) {
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.orderedSetWithObject:',
       iOS: (false, (5, 0, 0)),
@@ -16442,13 +17436,14 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSOrderedSet,
       _sel_orderedSetWithObject_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// orderedSetWithObjects:
   static NSOrderedSet orderedSetWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref$1 = firstObj.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.orderedSetWithObjects:',
       iOS: (false, (5, 0, 0)),
@@ -16457,7 +17452,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSOrderedSet,
       _sel_orderedSetWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: true, release: true);
   }
@@ -16483,6 +17478,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
 
   /// orderedSetWithOrderedSet:
   static NSOrderedSet orderedSetWithOrderedSet(NSOrderedSet set) {
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.orderedSetWithOrderedSet:',
       iOS: (false, (5, 0, 0)),
@@ -16491,7 +17487,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSOrderedSet,
       _sel_orderedSetWithOrderedSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: true, release: true);
   }
@@ -16502,6 +17498,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     required NSRange range,
     required bool copyItems,
   }) {
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.orderedSetWithOrderedSet:range:copyItems:',
       iOS: (false, (5, 0, 0)),
@@ -16510,7 +17507,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_w9bq5x(
       _class_NSOrderedSet,
       _sel_orderedSetWithOrderedSet_range_copyItems_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
       range,
       copyItems,
     );
@@ -16519,6 +17516,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
 
   /// orderedSetWithSet:
   static NSOrderedSet orderedSetWithSet(NSSet set) {
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.orderedSetWithSet:',
       iOS: (false, (5, 0, 0)),
@@ -16527,7 +17525,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSOrderedSet,
       _sel_orderedSetWithSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: true, release: true);
   }
@@ -16537,6 +17535,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     NSSet set, {
     required bool copyItems,
   }) {
+    final _$$ref$1 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.orderedSetWithSet:copyItems:',
       iOS: (false, (5, 0, 0)),
@@ -16545,7 +17544,7 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_17amj0z(
       _class_NSOrderedSet,
       _sel_orderedSetWithSet_copyItems_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
       copyItems,
     );
     return NSOrderedSet.fromPointer($ret, retain: true, release: true);
@@ -16563,12 +17562,13 @@ extension type NSOrderedSet._(objc.ObjCObject object$)
 extension NSOrderedSet$Methods on NSOrderedSet {
   /// count
   int get count {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.count',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_count);
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_count);
   }
 
   /// countByEnumeratingWithState:objects:count:
@@ -16577,8 +17577,9 @@ extension NSOrderedSet$Methods on NSOrderedSet {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects,
     required int count,
   }) {
+    final _$$ref$5 = object$.ref;
     return _objc_msgSend_1b5ysjl(
-      object$.ref.pointer,
+      _$$ref$5.pointer,
       _sel_countByEnumeratingWithState_objects_count_,
       state,
       objects,
@@ -16588,36 +17589,41 @@ extension NSOrderedSet$Methods on NSOrderedSet {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$24 = object$.ref;
+    final _$$ref$25 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$24.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$25.pointer,
     );
   }
 
   /// indexOfObject:
   int indexOfObject(objc.ObjCObject object) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.indexOfObject:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_1vd1c5m(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_indexOfObject_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// init
   NSOrderedSet init() {
+    final _$$ref$33 = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$33.retainAndReturnPointer(),
       _sel_init,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
@@ -16625,30 +17631,34 @@ extension NSOrderedSet$Methods on NSOrderedSet {
 
   /// initWithArray:
   NSOrderedSet initWithArray(NSArray array) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = array.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithArray:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithArray_,
-      array.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
   NSOrderedSet initWithArray$1(NSArray set, {required bool copyItems}) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithArray:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithArray_copyItems_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
       copyItems,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
@@ -16660,15 +17670,17 @@ extension NSOrderedSet$Methods on NSOrderedSet {
     required NSRange range,
     required bool copyItems,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithArray:range:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_w9bq5x(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithArray_range_copyItems_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
       range,
       copyItems,
     );
@@ -16677,10 +17689,12 @@ extension NSOrderedSet$Methods on NSOrderedSet {
 
   /// initWithCoder:
   NSOrderedSet? initWithCoder(NSCoder coder) {
+    final _$$ref$40 = object$.ref;
+    final _$$ref$41 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$40.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$41.pointer,
     );
     return $ret.address == 0
         ? null
@@ -16689,30 +17703,34 @@ extension NSOrderedSet$Methods on NSOrderedSet {
 
   /// initWithObject:
   NSOrderedSet initWithObject(objc.ObjCObject object) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = object.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithObject:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithObject_,
-      object.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithObjects:
   NSOrderedSet initWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = firstObj.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithObjects:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
   }
@@ -16722,13 +17740,14 @@ extension NSOrderedSet$Methods on NSOrderedSet {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required int count,
   }) {
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithObjects:count:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_zmbtbd(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithObjects_count_,
       objects,
       count,
@@ -16738,15 +17757,17 @@ extension NSOrderedSet$Methods on NSOrderedSet {
 
   /// initWithOrderedSet:
   NSOrderedSet initWithOrderedSet(NSOrderedSet set) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithOrderedSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithOrderedSet_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
   }
@@ -16756,15 +17777,17 @@ extension NSOrderedSet$Methods on NSOrderedSet {
     NSOrderedSet set, {
     required bool copyItems,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithOrderedSet:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithOrderedSet_copyItems_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
       copyItems,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
@@ -16776,15 +17799,17 @@ extension NSOrderedSet$Methods on NSOrderedSet {
     required NSRange range,
     required bool copyItems,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithOrderedSet:range:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_w9bq5x(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithOrderedSet_range_copyItems_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
       range,
       copyItems,
     );
@@ -16793,30 +17818,34 @@ extension NSOrderedSet$Methods on NSOrderedSet {
 
   /// initWithSet:
   NSOrderedSet initWithSet(NSSet set) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithSet:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithSet_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
   NSOrderedSet initWithSet$1(NSSet set, {required bool copyItems}) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.initWithSet:copyItems:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithSet_copyItems_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
       copyItems,
     );
     return NSOrderedSet.fromPointer($ret, retain: false, release: true);
@@ -16824,13 +17853,14 @@ extension NSOrderedSet$Methods on NSOrderedSet {
 
   /// objectAtIndex:
   objc.ObjCObject objectAtIndex(int idx) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSOrderedSet.objectAtIndex:',
       iOS: (false, (5, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_objectAtIndex_,
       idx,
     );
@@ -16905,10 +17935,11 @@ extension type NSOutputStream._(objc.ObjCObject object$)
     NSString path, {
     required bool append,
   }) {
+    final _$$ref = path.ref;
     final $ret = _objc_msgSend_17amj0z(
       _class_NSOutputStream,
       _sel_outputStreamToFileAtPath_append_,
-      path.ref.pointer,
+      _$$ref.pointer,
       append,
     );
     return NSOutputStream.fromPointer($ret, retain: true, release: true);
@@ -16928,6 +17959,7 @@ extension type NSOutputStream._(objc.ObjCObject object$)
     NSURL url, {
     required bool append,
   }) {
+    final _$$ref = url.ref;
     objc.checkOsVersionInternal(
       'NSOutputStream.outputStreamWithURL:append:',
       iOS: (false, (4, 0, 0)),
@@ -16936,7 +17968,7 @@ extension type NSOutputStream._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_17amj0z(
       _class_NSOutputStream,
       _sel_outputStreamWithURL_append_,
-      url.ref.pointer,
+      _$$ref.pointer,
       append,
     );
     return $ret.address == 0
@@ -16951,18 +17983,20 @@ extension type NSOutputStream._(objc.ObjCObject object$)
 extension NSOutputStream$Methods on NSOutputStream {
   /// hasSpaceAvailable
   bool get hasSpaceAvailable {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_hasSpaceAvailable);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_hasSpaceAvailable);
   }
 
   /// init
   NSOutputStream init() {
+    final _$$ref$34 = object$.ref;
     objc.checkOsVersionInternal(
       'NSOutputStream.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$34.retainAndReturnPointer(),
       _sel_init,
     );
     return NSOutputStream.fromPointer($ret, retain: false, release: true);
@@ -16973,8 +18007,9 @@ extension NSOutputStream$Methods on NSOutputStream {
     ffi.Pointer<ffi.Uint8> buffer, {
     required int capacity,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_158ju31(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initToBuffer_capacity_,
       buffer,
       capacity,
@@ -16984,10 +18019,12 @@ extension NSOutputStream$Methods on NSOutputStream {
 
   /// initToFileAtPath:append:
   NSOutputStream? initToFileAtPath(NSString path, {required bool append}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initToFileAtPath_append_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
       append,
     );
     return $ret.address == 0
@@ -16997,8 +18034,9 @@ extension NSOutputStream$Methods on NSOutputStream {
 
   /// initToMemory
   NSOutputStream initToMemory() {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initToMemory,
     );
     return NSOutputStream.fromPointer($ret, retain: false, release: true);
@@ -17006,15 +18044,17 @@ extension NSOutputStream$Methods on NSOutputStream {
 
   /// initWithURL:append:
   NSOutputStream? initWithURL(NSURL url, {required bool append}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     objc.checkOsVersionInternal(
       'NSOutputStream.initWithURL:append:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithURL_append_,
-      url.ref.pointer,
+      _$$ref$1.pointer,
       append,
     );
     return $ret.address == 0
@@ -17024,8 +18064,9 @@ extension NSOutputStream$Methods on NSOutputStream {
 
   /// write:maxLength:
   int write(ffi.Pointer<ffi.Uint8> buffer, {required int maxLength}) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_11e9f5x(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_write_maxLength_,
       buffer,
       maxLength,
@@ -17094,7 +18135,8 @@ extension type NSPort._(objc.ObjCObject object$)
 extension NSPort$Methods on NSPort {
   /// delegate
   NSPortDelegate? delegate() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_delegate);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_delegate);
     return $ret.address == 0
         ? null
         : NSPortDelegate.fromPointer($ret, retain: true, release: true);
@@ -17102,22 +18144,25 @@ extension NSPort$Methods on NSPort {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$26 = object$.ref;
+    final _$$ref$27 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$26.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$27.pointer,
     );
   }
 
   /// init
   NSPort init() {
+    final _$$ref$35 = object$.ref;
     objc.checkOsVersionInternal(
       'NSPort.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$35.retainAndReturnPointer(),
       _sel_init,
     );
     return NSPort.fromPointer($ret, retain: false, release: true);
@@ -17125,10 +18170,12 @@ extension NSPort$Methods on NSPort {
 
   /// initWithCoder:
   NSPort? initWithCoder(NSCoder coder) {
+    final _$$ref$42 = object$.ref;
+    final _$$ref$43 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$42.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$43.pointer,
     );
     return $ret.address == 0
         ? null
@@ -17137,36 +18184,45 @@ extension NSPort$Methods on NSPort {
 
   /// invalidate
   void invalidate() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_invalidate);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_invalidate);
   }
 
   /// isValid
   bool get isValid {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isValid);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isValid);
   }
 
   /// removeFromRunLoop:forMode:
   void removeFromRunLoop(NSRunLoop runLoop, {required NSString forMode}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = runLoop.ref;
+    final _$$ref$2 = forMode.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeFromRunLoop_forMode_,
-      runLoop.ref.pointer,
-      forMode.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// reservedSpaceLength
   int get reservedSpaceLength {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_reservedSpaceLength);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_reservedSpaceLength);
   }
 
   /// scheduleInRunLoop:forMode:
   void scheduleInRunLoop(NSRunLoop runLoop, {required NSString forMode}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = runLoop.ref;
+    final _$$ref$2 = forMode.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_scheduleInRunLoop_forMode_,
-      runLoop.ref.pointer,
-      forMode.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -17177,12 +18233,16 @@ extension NSPort$Methods on NSPort {
     NSPort? from,
     required int reserved,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = limitDate.ref;
+    final _$$ref$2 = components?.ref;
+    final _$$ref$3 = from?.ref;
     return _objc_msgSend_1frfu5e(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sendBeforeDate_components_from_reserved_,
-      limitDate.ref.pointer,
-      components?.ref.pointer ?? ffi.nullptr,
-      from?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
       reserved,
     );
   }
@@ -17195,23 +18255,29 @@ extension NSPort$Methods on NSPort {
     NSPort? from,
     required int reserved,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = limitDate.ref;
+    final _$$ref$2 = components?.ref;
+    final _$$ref$3 = from?.ref;
     return _objc_msgSend_gupwtj(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sendBeforeDate_msgid_components_from_reserved_,
-      limitDate.ref.pointer,
+      _$$ref$1.pointer,
       msgid,
-      components?.ref.pointer ?? ffi.nullptr,
-      from?.ref.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
       reserved,
     );
   }
 
   /// setDelegate:
   void setDelegate(NSPortDelegate? anObject) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = anObject?.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setDelegate_,
-      anObject?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 }
@@ -17242,19 +18308,18 @@ extension type NSPortDelegate._(objc.ObjCProtocol object$)
 extension NSPortDelegate$Methods on NSPortDelegate {
   /// handlePortMessage:
   void handlePortMessage(NSPortMessage message) {
-    if (!objc.respondsToSelector(
-      object$.ref.pointer,
-      _sel_handlePortMessage_,
-    )) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = message.ref;
+    if (!objc.respondsToSelector(_$$ref.pointer, _sel_handlePortMessage_)) {
       throw objc.UnimplementedOptionalMethodException(
         'NSPortDelegate',
         'handlePortMessage:',
       );
     }
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_handlePortMessage_,
-      message.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 }
@@ -17467,7 +18532,8 @@ extension type NSPortMessage._(objc.ObjCObject object$)
 extension NSPortMessage$Methods on NSPortMessage {
   /// components
   NSArray? get components {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_components);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_components);
     return $ret.address == 0
         ? null
         : NSArray.fromPointer($ret, retain: true, release: true);
@@ -17475,13 +18541,14 @@ extension NSPortMessage$Methods on NSPortMessage {
 
   /// init
   NSPortMessage init() {
+    final _$$ref$36 = object$.ref;
     objc.checkOsVersionInternal(
       'NSPortMessage.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$36.retainAndReturnPointer(),
       _sel_init,
     );
     return NSPortMessage.fromPointer($ret, retain: false, release: true);
@@ -17493,24 +18560,30 @@ extension NSPortMessage$Methods on NSPortMessage {
     NSPort? receivePort,
     NSArray? components,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = sendPort?.ref;
+    final _$$ref$2 = receivePort?.ref;
+    final _$$ref$3 = components?.ref;
     final $ret = _objc_msgSend_11spmsz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithSendPort_receivePort_components_,
-      sendPort?.ref.pointer ?? ffi.nullptr,
-      receivePort?.ref.pointer ?? ffi.nullptr,
-      components?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return NSPortMessage.fromPointer($ret, retain: false, release: true);
   }
 
   /// msgid
   int get msgid {
-    return _objc_msgSend_usggvf(object$.ref.pointer, _sel_msgid);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_usggvf(_$$ref.pointer, _sel_msgid);
   }
 
   /// receivePort
   NSPort? get receivePort {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_receivePort);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_receivePort);
     return $ret.address == 0
         ? null
         : NSPort.fromPointer($ret, retain: true, release: true);
@@ -17518,16 +18591,19 @@ extension NSPortMessage$Methods on NSPortMessage {
 
   /// sendBeforeDate:
   bool sendBeforeDate(NSDate date) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = date.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_sendBeforeDate_,
-      date.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// sendPort
   NSPort? get sendPort {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_sendPort);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_sendPort);
     return $ret.address == 0
         ? null
         : NSPort.fromPointer($ret, retain: true, release: true);
@@ -17535,7 +18611,8 @@ extension NSPortMessage$Methods on NSPortMessage {
 
   /// setMsgid:
   set msgid(int value) {
-    _objc_msgSend_1xpk2hb(object$.ref.pointer, _sel_setMsgid_, value);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1xpk2hb(_$$ref.pointer, _sel_setMsgid_, value);
   }
 }
 
@@ -17576,6 +18653,8 @@ extension type NSProgress._(objc.ObjCObject object$)
     >
     withPublishingHandler,
   }) {
+    final _$$ref = url.ref;
+    final _$$ref$1 = withPublishingHandler.ref;
     objc.checkOsVersionInternal(
       'NSProgress.addSubscriberForFileURL:withPublishingHandler:',
       iOS: (true, null),
@@ -17584,8 +18663,8 @@ extension type NSProgress._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_r0bo0s(
       _class_NSProgress,
       _sel_addSubscriberForFileURL_withPublishingHandler_,
-      url.ref.pointer,
-      withPublishingHandler.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
     );
     return objc.ObjCObject($ret, retain: true, release: true);
   }
@@ -17661,6 +18740,7 @@ extension type NSProgress._(objc.ObjCObject object$)
     required NSProgress parent,
     required int pendingUnitCount,
   }) {
+    final _$$ref = parent.ref;
     objc.checkOsVersionInternal(
       'NSProgress.progressWithTotalUnitCount:parent:pendingUnitCount:',
       iOS: (false, (9, 0, 0)),
@@ -17670,7 +18750,7 @@ extension type NSProgress._(objc.ObjCObject object$)
       _class_NSProgress,
       _sel_progressWithTotalUnitCount_parent_pendingUnitCount_,
       unitCount,
-      parent.ref.pointer,
+      _$$ref.pointer,
       pendingUnitCount,
     );
     return NSProgress.fromPointer($ret, retain: true, release: true);
@@ -17681,6 +18761,7 @@ extension type NSProgress._(objc.ObjCObject object$)
   /// iOS: unavailable
   /// macOS: introduced 10.9.0
   static void removeSubscriber(objc.ObjCObject subscriber) {
+    final _$$ref = subscriber.ref;
     objc.checkOsVersionInternal(
       'NSProgress.removeSubscriber:',
       iOS: (true, null),
@@ -17689,7 +18770,7 @@ extension type NSProgress._(objc.ObjCObject object$)
     _objc_msgSend_xtuoz7(
       _class_NSProgress,
       _sel_removeSubscriber_,
-      subscriber.ref.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -17700,28 +18781,31 @@ extension type NSProgress._(objc.ObjCObject object$)
 extension NSProgress$Methods on NSProgress {
   /// addChild:withPendingUnitCount:
   void addChild(NSProgress child, {required int withPendingUnitCount}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = child.ref;
     objc.checkOsVersionInternal(
       'NSProgress.addChild:withPendingUnitCount:',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     _objc_msgSend_1m7prh1(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addChild_withPendingUnitCount_,
-      child.ref.pointer,
+      _$$ref$1.pointer,
       withPendingUnitCount,
     );
   }
 
   /// becomeCurrentWithPendingUnitCount:
   void becomeCurrentWithPendingUnitCount(int unitCount) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.becomeCurrentWithPendingUnitCount:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_17gvxvj(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_becomeCurrentWithPendingUnitCount_,
       unitCount,
     );
@@ -17729,25 +18813,24 @@ extension NSProgress$Methods on NSProgress {
 
   /// cancel
   void cancel() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.cancel',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_cancel);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_cancel);
   }
 
   /// cancellationHandler
   objc.ObjCBlock<ffi.Void Function()>? get cancellationHandler {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.cancellationHandler',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    final $ret = _objc_msgSend_uwvaik(
-      object$.ref.pointer,
-      _sel_cancellationHandler,
-    );
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_cancellationHandler);
     return $ret.address == 0
         ? null
         : ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
@@ -17755,23 +18838,25 @@ extension NSProgress$Methods on NSProgress {
 
   /// completedUnitCount
   int get completedUnitCount {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.completedUnitCount',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_pysgoz(object$.ref.pointer, _sel_completedUnitCount);
+    return _objc_msgSend_pysgoz(_$$ref.pointer, _sel_completedUnitCount);
   }
 
   /// estimatedTimeRemaining
   NSNumber? get estimatedTimeRemaining {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.estimatedTimeRemaining',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_estimatedTimeRemaining,
     );
     return $ret.address == 0
@@ -17781,15 +18866,13 @@ extension NSProgress$Methods on NSProgress {
 
   /// fileCompletedCount
   NSNumber? get fileCompletedCount {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.fileCompletedCount',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_fileCompletedCount,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_fileCompletedCount);
     return $ret.address == 0
         ? null
         : NSNumber.fromPointer($ret, retain: true, release: true);
@@ -17797,15 +18880,13 @@ extension NSProgress$Methods on NSProgress {
 
   /// fileOperationKind
   NSString? get fileOperationKind {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.fileOperationKind',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_fileOperationKind,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_fileOperationKind);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -17813,15 +18894,13 @@ extension NSProgress$Methods on NSProgress {
 
   /// fileTotalCount
   NSNumber? get fileTotalCount {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.fileTotalCount',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_fileTotalCount,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_fileTotalCount);
     return $ret.address == 0
         ? null
         : NSNumber.fromPointer($ret, retain: true, release: true);
@@ -17829,12 +18908,13 @@ extension NSProgress$Methods on NSProgress {
 
   /// fileURL
   NSURL? get fileURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.fileURL',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_fileURL);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_fileURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -17842,28 +18922,27 @@ extension NSProgress$Methods on NSProgress {
 
   /// fractionCompleted
   double get fractionCompleted {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.fractionCompleted',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(
-            object$.ref.pointer,
-            _sel_fractionCompleted,
-          )
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_fractionCompleted);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_fractionCompleted)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_fractionCompleted);
   }
 
   /// init
   NSProgress init() {
+    final _$$ref$37 = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$37.retainAndReturnPointer(),
       _sel_init,
     );
     return NSProgress.fromPointer($ret, retain: false, release: true);
@@ -17874,99 +18953,110 @@ extension NSProgress$Methods on NSProgress {
     NSProgress? parentProgressOrNil, {
     NSDictionary? userInfo,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = parentProgressOrNil?.ref;
+    final _$$ref$2 = userInfo?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.initWithParent:userInfo:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithParent_userInfo_,
-      parentProgressOrNil?.ref.pointer ?? ffi.nullptr,
-      userInfo?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSProgress.fromPointer($ret, retain: false, release: true);
   }
 
   /// isCancellable
   bool get isCancellable {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.isCancellable',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isCancellable);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isCancellable);
   }
 
   /// isCancelled
   bool get isCancelled {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.isCancelled',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isCancelled);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isCancelled);
   }
 
   /// isFinished
   bool get isFinished {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.isFinished',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isFinished);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isFinished);
   }
 
   /// isIndeterminate
   bool get isIndeterminate {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.isIndeterminate',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isIndeterminate);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isIndeterminate);
   }
 
   /// iOS: unavailable
   /// macOS: introduced 10.9.0
   bool get isOld {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.isOld',
       iOS: (true, null),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isOld);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isOld);
   }
 
   /// isPausable
   bool get isPausable {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.isPausable',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isPausable);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isPausable);
   }
 
   /// isPaused
   bool get isPaused {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.isPaused',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isPaused);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isPaused);
   }
 
   /// kind
   NSString? get kind {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.kind',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_kind);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_kind);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -17974,13 +19064,14 @@ extension NSProgress$Methods on NSProgress {
 
   /// localizedAdditionalDescription
   NSString get localizedAdditionalDescription {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.localizedAdditionalDescription',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedAdditionalDescription,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -17988,13 +19079,14 @@ extension NSProgress$Methods on NSProgress {
 
   /// localizedDescription
   NSString get localizedDescription {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.localizedDescription',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedDescription,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -18002,22 +19094,24 @@ extension NSProgress$Methods on NSProgress {
 
   /// pause
   void pause() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.pause',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_pause);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_pause);
   }
 
   /// pausingHandler
   objc.ObjCBlock<ffi.Void Function()>? get pausingHandler {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.pausingHandler',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    final $ret = _objc_msgSend_uwvaik(object$.ref.pointer, _sel_pausingHandler);
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_pausingHandler);
     return $ret.address == 0
         ? null
         : ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
@@ -18028,16 +19122,18 @@ extension NSProgress$Methods on NSProgress {
     int unitCount, {
     required objc.ObjCBlock<ffi.Void Function()> usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSProgress.performAsCurrentWithPendingUnitCount:usingBlock:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_1i0cxyc(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_performAsCurrentWithPendingUnitCount_usingBlock_,
       unitCount,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -18046,45 +19142,46 @@ extension NSProgress$Methods on NSProgress {
   /// iOS: unavailable
   /// macOS: introduced 10.9.0
   void publish() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.publish',
       iOS: (true, null),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_publish);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_publish);
   }
 
   /// resignCurrent
   void resignCurrent() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.resignCurrent',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_resignCurrent);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_resignCurrent);
   }
 
   /// resume
   void resume() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.resume',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_resume);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_resume);
   }
 
   /// resumingHandler
   objc.ObjCBlock<ffi.Void Function()>? get resumingHandler {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.resumingHandler',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
-    final $ret = _objc_msgSend_uwvaik(
-      object$.ref.pointer,
-      _sel_resumingHandler,
-    );
+    final $ret = _objc_msgSend_uwvaik(_$$ref.pointer, _sel_resumingHandler);
     return $ret.address == 0
         ? null
         : ObjCBlock_ffiVoid.fromPointer($ret, retain: true, release: true);
@@ -18092,214 +19189,238 @@ extension NSProgress$Methods on NSProgress {
 
   /// setCancellable:
   set isCancellable(bool value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setCancellable:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_1s56lr9(object$.ref.pointer, _sel_setCancellable_, value);
+    _objc_msgSend_1s56lr9(_$$ref.pointer, _sel_setCancellable_, value);
   }
 
   /// setCancellationHandler:
   set cancellationHandler(objc.ObjCBlock<ffi.Void Function()>? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setCancellationHandler:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setCancellationHandler_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setCompletedUnitCount:
   set completedUnitCount(int value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setCompletedUnitCount:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_17gvxvj(
-      object$.ref.pointer,
-      _sel_setCompletedUnitCount_,
-      value,
-    );
+    _objc_msgSend_17gvxvj(_$$ref.pointer, _sel_setCompletedUnitCount_, value);
   }
 
   /// setEstimatedTimeRemaining:
   set estimatedTimeRemaining(NSNumber? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setEstimatedTimeRemaining:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setEstimatedTimeRemaining_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setFileCompletedCount:
   set fileCompletedCount(NSNumber? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setFileCompletedCount:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setFileCompletedCount_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setFileOperationKind:
   set fileOperationKind(NSString? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setFileOperationKind:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setFileOperationKind_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setFileTotalCount:
   set fileTotalCount(NSNumber? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setFileTotalCount:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setFileTotalCount_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setFileURL:
   set fileURL(NSURL? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setFileURL:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setFileURL_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setKind:
   set kind(NSString? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setKind:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setKind_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setLocalizedAdditionalDescription:
   set localizedAdditionalDescription(NSString value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setLocalizedAdditionalDescription:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setLocalizedAdditionalDescription_,
-      value.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// setLocalizedDescription:
   set localizedDescription(NSString value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setLocalizedDescription:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setLocalizedDescription_,
-      value.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// setPausable:
   set isPausable(bool value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setPausable:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_1s56lr9(object$.ref.pointer, _sel_setPausable_, value);
+    _objc_msgSend_1s56lr9(_$$ref.pointer, _sel_setPausable_, value);
   }
 
   /// setPausingHandler:
   set pausingHandler(objc.ObjCBlock<ffi.Void Function()>? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setPausingHandler:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setPausingHandler_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setResumingHandler:
   set resumingHandler(objc.ObjCBlock<ffi.Void Function()>? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setResumingHandler:',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setResumingHandler_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setThroughput:
   set throughput(NSNumber? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setThroughput:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setThroughput_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setTotalUnitCount:
   set totalUnitCount(int value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setTotalUnitCount:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_17gvxvj(object$.ref.pointer, _sel_setTotalUnitCount_, value);
+    _objc_msgSend_17gvxvj(_$$ref.pointer, _sel_setTotalUnitCount_, value);
   }
 
   /// setUserInfoObject:forKey:
@@ -18307,27 +19428,31 @@ extension NSProgress$Methods on NSProgress {
     objc.ObjCObject? objectOrNil, {
     required NSString forKey,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = objectOrNil?.ref;
+    final _$$ref$2 = forKey.ref;
     objc.checkOsVersionInternal(
       'NSProgress.setUserInfoObject:forKey:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setUserInfoObject_forKey_,
-      objectOrNil?.ref.pointer ?? ffi.nullptr,
-      forKey.ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2.pointer,
     );
   }
 
   /// throughput
   NSNumber? get throughput {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.throughput',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_throughput);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_throughput);
     return $ret.address == 0
         ? null
         : NSNumber.fromPointer($ret, retain: true, release: true);
@@ -18335,12 +19460,13 @@ extension NSProgress$Methods on NSProgress {
 
   /// totalUnitCount
   int get totalUnitCount {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.totalUnitCount',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_pysgoz(object$.ref.pointer, _sel_totalUnitCount);
+    return _objc_msgSend_pysgoz(_$$ref.pointer, _sel_totalUnitCount);
   }
 
   /// unpublish
@@ -18348,22 +19474,24 @@ extension NSProgress$Methods on NSProgress {
   /// iOS: unavailable
   /// macOS: introduced 10.9.0
   void unpublish() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.unpublish',
       iOS: (true, null),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_unpublish);
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_unpublish);
   }
 
   /// userInfo
   NSDictionary get userInfo {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSProgress.userInfo',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_userInfo);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_userInfo);
     return NSDictionary.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -18492,37 +19620,47 @@ extension type NSRunLoop._(objc.ObjCObject object$)
 extension NSRunLoop$Methods on NSRunLoop {
   /// acceptInputForMode:beforeDate:
   void acceptInputForMode(NSString mode, {required NSDate beforeDate}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = mode.ref;
+    final _$$ref$2 = beforeDate.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_acceptInputForMode_beforeDate_,
-      mode.ref.pointer,
-      beforeDate.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// addPort:forMode:
   void addPort(NSPort aPort, {required NSString forMode}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aPort.ref;
+    final _$$ref$2 = forMode.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addPort_forMode_,
-      aPort.ref.pointer,
-      forMode.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// addTimer:forMode:
   void addTimer(NSTimer timer, {required NSString forMode}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = timer.ref;
+    final _$$ref$2 = forMode.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_addTimer_forMode_,
-      timer.ref.pointer,
-      forMode.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// currentMode
   NSString? get currentMode {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_currentMode);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_currentMode);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -18530,18 +19668,20 @@ extension NSRunLoop$Methods on NSRunLoop {
 
   /// getCFRunLoop
   ffi.Pointer<CFRunLoop> getCFRunLoop() {
-    return _objc_msgSend_1bbja28(object$.ref.pointer, _sel_getCFRunLoop);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1bbja28(_$$ref.pointer, _sel_getCFRunLoop);
   }
 
   /// init
   NSRunLoop init() {
+    final _$$ref$38 = object$.ref;
     objc.checkOsVersionInternal(
       'NSRunLoop.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$38.retainAndReturnPointer(),
       _sel_init,
     );
     return NSRunLoop.fromPointer($ret, retain: false, release: true);
@@ -18549,10 +19689,12 @@ extension NSRunLoop$Methods on NSRunLoop {
 
   /// limitDateForMode:
   NSDate? limitDateForMode(NSString mode) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = mode.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_limitDateForMode_,
-      mode.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -18561,11 +19703,14 @@ extension NSRunLoop$Methods on NSRunLoop {
 
   /// removePort:forMode:
   void removePort(NSPort aPort, {required NSString forMode}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aPort.ref;
+    final _$$ref$2 = forMode.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removePort_forMode_,
-      aPort.ref.pointer,
-      forMode.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 }
@@ -18596,19 +19741,23 @@ extension type NSSecureCoding._(objc.ObjCProtocol object$)
 extension NSSecureCoding$Methods on NSSecureCoding {
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$28 = object$.ref;
+    final _$$ref$29 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$28.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$29.pointer,
     );
   }
 
   /// initWithCoder:
   NSSecureCoding? initWithCoder(NSCoder coder) {
+    final _$$ref$44 = object$.ref;
+    final _$$ref$45 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$44.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$45.pointer,
     );
     return $ret.address == 0
         ? null
@@ -18870,30 +20019,33 @@ extension type NSSet._(objc.ObjCObject object$)
 
   /// setWithArray:
   static NSSet setWithArray(NSArray array) {
+    final _$$ref$1 = array.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSSet,
       _sel_setWithArray_,
-      array.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// setWithObject:
   static NSSet setWithObject(objc.ObjCObject object) {
+    final _$$ref$1 = object.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSSet,
       _sel_setWithObject_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
 
   /// setWithObjects:
   static NSSet setWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref$1 = firstObj.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSSet,
       _sel_setWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
@@ -18914,10 +20066,11 @@ extension type NSSet._(objc.ObjCObject object$)
 
   /// setWithSet:
   static NSSet setWithSet(NSSet set) {
+    final _$$ref$1 = set.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSSet,
       _sel_setWithSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSSet.fromPointer($ret, retain: true, release: true);
   }
@@ -18934,7 +20087,8 @@ extension type NSSet._(objc.ObjCObject object$)
 extension NSSet$Methods on NSSet {
   /// count
   int get count {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_count);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_count);
   }
 
   /// countByEnumeratingWithState:objects:count:
@@ -18943,8 +20097,9 @@ extension NSSet$Methods on NSSet {
     required ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects,
     required int count,
   }) {
+    final _$$ref$6 = object$.ref;
     return _objc_msgSend_1b5ysjl(
-      object$.ref.pointer,
+      _$$ref$6.pointer,
       _sel_countByEnumeratingWithState_objects_count_,
       state,
       objects,
@@ -18954,22 +20109,25 @@ extension NSSet$Methods on NSSet {
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$30 = object$.ref;
+    final _$$ref$31 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$30.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$31.pointer,
     );
   }
 
   /// init
   NSSet init() {
+    final _$$ref$39 = object$.ref;
     objc.checkOsVersionInternal(
       'NSSet.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$39.retainAndReturnPointer(),
       _sel_init,
     );
     return NSSet.fromPointer($ret, retain: false, release: true);
@@ -18977,20 +20135,24 @@ extension NSSet$Methods on NSSet {
 
   /// initWithArray:
   NSSet initWithArray(NSArray array) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = array.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithArray_,
-      array.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSSet? initWithCoder(NSCoder coder) {
+    final _$$ref$46 = object$.ref;
+    final _$$ref$47 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$46.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$47.pointer,
     );
     return $ret.address == 0
         ? null
@@ -18999,10 +20161,12 @@ extension NSSet$Methods on NSSet {
 
   /// initWithObjects:
   NSSet initWithObjects(objc.ObjCObject firstObj) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = firstObj.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithObjects_,
-      firstObj.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSSet.fromPointer($ret, retain: false, release: true);
   }
@@ -19012,8 +20176,9 @@ extension NSSet$Methods on NSSet {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> objects, {
     required int count,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_zmbtbd(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithObjects_count_,
       objects,
       count,
@@ -19023,20 +20188,24 @@ extension NSSet$Methods on NSSet {
 
   /// initWithSet:
   NSSet initWithSet(NSSet set) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithSet_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSSet.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
   NSSet initWithSet$1(NSSet set, {required bool copyItems}) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = set.ref;
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithSet_copyItems_,
-      set.ref.pointer,
+      _$$ref$3.pointer,
       copyItems,
     );
     return NSSet.fromPointer($ret, retain: false, release: true);
@@ -19044,10 +20213,12 @@ extension NSSet$Methods on NSSet {
 
   /// member:
   objc.ObjCObject? member(objc.ObjCObject object) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = object.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_member_,
-      object.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -19056,10 +20227,8 @@ extension NSSet$Methods on NSSet {
 
   /// objectEnumerator
   NSEnumerator objectEnumerator() {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_objectEnumerator,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_objectEnumerator);
     return NSEnumerator.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -19124,12 +20293,14 @@ extension type NSStream._(objc.ObjCObject object$)
 extension NSStream$Methods on NSStream {
   /// close
   void close() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_close);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_close);
   }
 
   /// delegate
   NSStreamDelegate? get delegate {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_delegate);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_delegate);
     return $ret.address == 0
         ? null
         : NSStreamDelegate.fromPointer($ret, retain: true, release: true);
@@ -19137,13 +20308,14 @@ extension NSStream$Methods on NSStream {
 
   /// init
   NSStream init() {
+    final _$$ref$40 = object$.ref;
     objc.checkOsVersionInternal(
       'NSStream.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$40.retainAndReturnPointer(),
       _sel_init,
     );
     return NSStream.fromPointer($ret, retain: false, release: true);
@@ -19151,15 +20323,18 @@ extension NSStream$Methods on NSStream {
 
   /// open
   void open() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_open);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_open);
   }
 
   /// propertyForKey:
   objc.ObjCObject? propertyForKey(NSString key) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = key.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_propertyForKey_,
-      key.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -19168,46 +20343,58 @@ extension NSStream$Methods on NSStream {
 
   /// removeFromRunLoop:forMode:
   void removeFromRunLoop(NSRunLoop aRunLoop, {required NSString forMode}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aRunLoop.ref;
+    final _$$ref$2 = forMode.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeFromRunLoop_forMode_,
-      aRunLoop.ref.pointer,
-      forMode.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// scheduleInRunLoop:forMode:
   void scheduleInRunLoop(NSRunLoop aRunLoop, {required NSString forMode}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aRunLoop.ref;
+    final _$$ref$2 = forMode.ref;
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_scheduleInRunLoop_forMode_,
-      aRunLoop.ref.pointer,
-      forMode.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
   /// setDelegate:
   set delegate(NSStreamDelegate? value) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setDelegate_,
-      value?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
   }
 
   /// setProperty:forKey:
   bool setProperty(objc.ObjCObject? property, {required NSString forKey}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = property?.ref;
+    final _$$ref$2 = forKey.ref;
     return _objc_msgSend_1lsax7n(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setProperty_forKey_,
-      property?.ref.pointer ?? ffi.nullptr,
-      forKey.ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2.pointer,
     );
   }
 
   /// streamError
   NSError? get streamError {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_streamError);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_streamError);
     return $ret.address == 0
         ? null
         : NSError.fromPointer($ret, retain: true, release: true);
@@ -19215,7 +20402,8 @@ extension NSStream$Methods on NSStream {
 
   /// streamStatus
   NSStreamStatus get streamStatus {
-    final $ret = _objc_msgSend_1efxbd8(object$.ref.pointer, _sel_streamStatus);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_1efxbd8(_$$ref.pointer, _sel_streamStatus);
     return NSStreamStatus.fromValue($ret);
   }
 }
@@ -19246,19 +20434,18 @@ extension type NSStreamDelegate._(objc.ObjCProtocol object$)
 extension NSStreamDelegate$Methods on NSStreamDelegate {
   /// stream:handleEvent:
   void stream(NSStream aStream, {required int handleEvent}) {
-    if (!objc.respondsToSelector(
-      object$.ref.pointer,
-      _sel_stream_handleEvent_,
-    )) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = aStream.ref;
+    if (!objc.respondsToSelector(_$$ref$2.pointer, _sel_stream_handleEvent_)) {
       throw objc.UnimplementedOptionalMethodException(
         'NSStreamDelegate',
         'stream:handleEvent:',
       );
     }
     _objc_msgSend_3l8zum(
-      object$.ref.pointer,
+      _$$ref$2.pointer,
       _sel_stream_handleEvent_,
-      aStream.ref.pointer,
+      _$$ref$3.pointer,
       handleEvent,
     );
   }
@@ -19514,10 +20701,11 @@ extension type NSString._(objc.ObjCObject object$)
 
   /// localizedStringWithFormat:
   static NSString localizedStringWithFormat(NSString format) {
+    final _$$ref$1 = format.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSString,
       _sel_localizedStringWithFormat_,
-      format.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -19527,6 +20715,8 @@ extension type NSString._(objc.ObjCObject object$)
     NSString format, {
     required NSString validFormatSpecifiers,
   }) {
+    final _$$ref$2 = format.ref;
+    final _$$ref$3 = validFormatSpecifiers.ref;
     objc.checkOsVersionInternal(
       'NSString.localizedStringWithValidatedFormat:validFormatSpecifiers:error:',
       iOS: (false, (11, 0, 0)),
@@ -19537,8 +20727,8 @@ extension type NSString._(objc.ObjCObject object$)
       final $ret = _objc_msgSend_1pnyuds(
         _class_NSString,
         _sel_localizedStringWithValidatedFormat_validFormatSpecifiers_error_,
-        format.ref.pointer,
-        validFormatSpecifiers.ref.pointer,
+        _$$ref$2.pointer,
+        _$$ref$3.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -19597,12 +20787,13 @@ extension type NSString._(objc.ObjCObject object$)
     NSString path, {
     required int encoding,
   }) {
+    final _$$ref$1 = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1nomli1(
         _class_NSString,
         _sel_stringWithContentsOfFile_encoding_error_,
-        path.ref.pointer,
+        _$$ref$1.pointer,
         encoding,
         $err,
       );
@@ -19620,12 +20811,13 @@ extension type NSString._(objc.ObjCObject object$)
     NSString path, {
     required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
   }) {
+    final _$$ref$1 = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1alewu7(
         _class_NSString,
         _sel_stringWithContentsOfFile_usedEncoding_error_,
-        path.ref.pointer,
+        _$$ref$1.pointer,
         usedEncoding,
         $err,
       );
@@ -19640,12 +20832,13 @@ extension type NSString._(objc.ObjCObject object$)
 
   /// stringWithContentsOfURL:encoding:error:
   static NSString? stringWithContentsOfURL(NSURL url, {required int encoding}) {
+    final _$$ref$1 = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1nomli1(
         _class_NSString,
         _sel_stringWithContentsOfURL_encoding_error_,
-        url.ref.pointer,
+        _$$ref$1.pointer,
         encoding,
         $err,
       );
@@ -19663,12 +20856,13 @@ extension type NSString._(objc.ObjCObject object$)
     NSURL url, {
     required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
   }) {
+    final _$$ref$1 = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1alewu7(
         _class_NSString,
         _sel_stringWithContentsOfURL_usedEncoding_error_,
-        url.ref.pointer,
+        _$$ref$1.pointer,
         usedEncoding,
         $err,
       );
@@ -19683,20 +20877,22 @@ extension type NSString._(objc.ObjCObject object$)
 
   /// stringWithFormat:
   static NSString stringWithFormat(NSString format) {
+    final _$$ref$1 = format.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSString,
       _sel_stringWithFormat_,
-      format.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// stringWithString:
   static NSString stringWithString(NSString string) {
+    final _$$ref$1 = string.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSString,
       _sel_stringWithString_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -19720,6 +20916,8 @@ extension type NSString._(objc.ObjCObject object$)
     NSString format, {
     required NSString validFormatSpecifiers,
   }) {
+    final _$$ref$2 = format.ref;
+    final _$$ref$3 = validFormatSpecifiers.ref;
     objc.checkOsVersionInternal(
       'NSString.stringWithValidatedFormat:validFormatSpecifiers:error:',
       iOS: (false, (11, 0, 0)),
@@ -19730,8 +20928,8 @@ extension type NSString._(objc.ObjCObject object$)
       final $ret = _objc_msgSend_1pnyuds(
         _class_NSString,
         _sel_stringWithValidatedFormat_validFormatSpecifiers_error_,
-        format.ref.pointer,
-        validFormatSpecifiers.ref.pointer,
+        _$$ref$2.pointer,
+        _$$ref$3.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -19752,31 +20950,31 @@ extension type NSString._(objc.ObjCObject object$)
 extension NSString$Methods on NSString {
   /// characterAtIndex:
   int characterAtIndex(int index) {
-    return _objc_msgSend_1deg8x(
-      object$.ref.pointer,
-      _sel_characterAtIndex_,
-      index,
-    );
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1deg8x(_$$ref.pointer, _sel_characterAtIndex_, index);
   }
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$32 = object$.ref;
+    final _$$ref$33 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$32.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$33.pointer,
     );
   }
 
   /// init
   NSString init() {
+    final _$$ref$41 = object$.ref;
     objc.checkOsVersionInternal(
       'NSString.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$41.retainAndReturnPointer(),
       _sel_init,
     );
     return NSString.fromPointer($ret, retain: false, release: true);
@@ -19788,8 +20986,9 @@ extension NSString$Methods on NSString {
     required int length,
     required int encoding,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_9b3h4v(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithBytes_length_encoding_,
       bytes,
       length,
@@ -19808,13 +21007,15 @@ extension NSString$Methods on NSString {
     objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.UnsignedLong)>?
     deallocator,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = deallocator?.ref;
     final $ret = _objc_msgSend_1lbgrac(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_encoding_deallocator_,
       bytes,
       length,
       encoding,
-      deallocator?.ref.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -19828,8 +21029,9 @@ extension NSString$Methods on NSString {
     required int encoding,
     required bool freeWhenDone,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_k4j8m3(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithBytesNoCopy_length_encoding_freeWhenDone_,
       bytes,
       length,
@@ -19846,8 +21048,9 @@ extension NSString$Methods on NSString {
     ffi.Pointer<ffi.Char> nullTerminatedCString, {
     required int encoding,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_erqryg(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithCString_encoding_,
       nullTerminatedCString,
       encoding,
@@ -19862,8 +21065,9 @@ extension NSString$Methods on NSString {
     ffi.Pointer<ffi.UnsignedShort> characters, {
     required int length,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_9x4k8x(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithCharacters_length_,
       characters,
       length,
@@ -19880,12 +21084,14 @@ extension NSString$Methods on NSString {
     >?
     deallocator,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = deallocator?.ref;
     final $ret = _objc_msgSend_talwei(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithCharactersNoCopy_length_deallocator_,
       chars,
       length,
-      deallocator?.ref.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: false, release: true);
   }
@@ -19896,8 +21102,9 @@ extension NSString$Methods on NSString {
     required int length,
     required bool freeWhenDone,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_lh0jh5(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithCharactersNoCopy_length_freeWhenDone_,
       characters,
       length,
@@ -19908,10 +21115,12 @@ extension NSString$Methods on NSString {
 
   /// initWithCoder:
   NSString? initWithCoder(NSCoder coder) {
+    final _$$ref$48 = object$.ref;
+    final _$$ref$49 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$48.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$49.pointer,
     );
     return $ret.address == 0
         ? null
@@ -19920,12 +21129,14 @@ extension NSString$Methods on NSString {
 
   /// initWithContentsOfFile:encoding:error:
   NSString? initWithContentsOfFile(NSString path, {required int encoding}) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1nomli1(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref$2.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_encoding_error_,
-        path.ref.pointer,
+        _$$ref$3.pointer,
         encoding,
         $err,
       );
@@ -19943,12 +21154,14 @@ extension NSString$Methods on NSString {
     NSString path, {
     required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1alewu7(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref$2.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_usedEncoding_error_,
-        path.ref.pointer,
+        _$$ref$3.pointer,
         usedEncoding,
         $err,
       );
@@ -19963,12 +21176,14 @@ extension NSString$Methods on NSString {
 
   /// initWithContentsOfURL:encoding:error:
   NSString? initWithContentsOfURL(NSURL url, {required int encoding}) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1nomli1(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref$2.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_encoding_error_,
-        url.ref.pointer,
+        _$$ref$3.pointer,
         encoding,
         $err,
       );
@@ -19986,12 +21201,14 @@ extension NSString$Methods on NSString {
     NSURL url, {
     required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
   }) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1alewu7(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref$2.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_usedEncoding_error_,
-        url.ref.pointer,
+        _$$ref$3.pointer,
         usedEncoding,
         $err,
       );
@@ -20006,10 +21223,12 @@ extension NSString$Methods on NSString {
 
   /// initWithData:encoding:
   NSString? initWithData(NSData data, {required int encoding}) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = data.ref;
     final $ret = _objc_msgSend_1k4kd9s(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithData_encoding_,
-      data.ref.pointer,
+      _$$ref$3.pointer,
       encoding,
     );
     return $ret.address == 0
@@ -20019,39 +21238,47 @@ extension NSString$Methods on NSString {
 
   /// initWithFormat:
   NSString initWithFormat(NSString format) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = format.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithFormat_,
-      format.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSString.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithFormat:locale:
   NSString initWithFormat$1(NSString format, {objc.ObjCObject? locale}) {
+    final _$$ref$3 = object$.ref;
+    final _$$ref$4 = format.ref;
+    final _$$ref$5 = locale?.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$3.retainAndReturnPointer(),
       _sel_initWithFormat_locale_,
-      format.ref.pointer,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$4.pointer,
+      _$$ref$5?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithString:
   NSString initWithString(NSString aString) {
+    final _$$ref$2 = object$.ref;
+    final _$$ref$3 = aString.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$2.retainAndReturnPointer(),
       _sel_initWithString_,
-      aString.ref.pointer,
+      _$$ref$3.pointer,
     );
     return NSString.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithUTF8String:
   NSString? initWithUTF8String(ffi.Pointer<ffi.Char> nullTerminatedCString) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_56zxyn(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithUTF8String_,
       nullTerminatedCString,
     );
@@ -20068,6 +21295,9 @@ extension NSString$Methods on NSString {
     NSString format, {
     required NSString validFormatSpecifiers,
   }) {
+    final _$$ref$3 = object$.ref;
+    final _$$ref$4 = format.ref;
+    final _$$ref$5 = validFormatSpecifiers.ref;
     objc.checkOsVersionInternal(
       'NSString.initWithValidatedFormat:validFormatSpecifiers:error:',
       iOS: (false, (16, 0, 0)),
@@ -20076,10 +21306,10 @@ extension NSString$Methods on NSString {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1pnyuds(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref$3.retainAndReturnPointer(),
         _sel_initWithValidatedFormat_validFormatSpecifiers_error_,
-        format.ref.pointer,
-        validFormatSpecifiers.ref.pointer,
+        _$$ref$4.pointer,
+        _$$ref$5.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -20100,6 +21330,10 @@ extension NSString$Methods on NSString {
     required NSString validFormatSpecifiers,
     objc.ObjCObject? locale,
   }) {
+    final _$$ref$4 = object$.ref;
+    final _$$ref$5 = format.ref;
+    final _$$ref$6 = validFormatSpecifiers.ref;
+    final _$$ref$7 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSString.initWithValidatedFormat:validFormatSpecifiers:locale:error:',
       iOS: (false, (16, 0, 0)),
@@ -20108,11 +21342,11 @@ extension NSString$Methods on NSString {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1k0ezzm(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref$4.retainAndReturnPointer(),
         _sel_initWithValidatedFormat_validFormatSpecifiers_locale_error_,
-        format.ref.pointer,
-        validFormatSpecifiers.ref.pointer,
-        locale?.ref.pointer ?? ffi.nullptr,
+        _$$ref$5.pointer,
+        _$$ref$6.pointer,
+        _$$ref$7?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -20126,7 +21360,8 @@ extension NSString$Methods on NSString {
 
   /// length
   int get length {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_length);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_length);
   }
 }
 
@@ -20164,23 +21399,26 @@ sealed class NSStringEnumerationOptions {
 extension NSStringExtensionMethods on NSString {
   /// UTF8String
   ffi.Pointer<ffi.Char> get UTF8String {
-    return _objc_msgSend_1fuqfwb(object$.ref.pointer, _sel_UTF8String);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1fuqfwb(_$$ref.pointer, _sel_UTF8String);
   }
 
   /// boolValue
   bool get boolValue {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSString.boolValue',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_boolValue);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_boolValue);
   }
 
   /// cStringUsingEncoding:
   ffi.Pointer<ffi.Char> cStringUsingEncoding(int encoding) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_1jtxufi(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_cStringUsingEncoding_,
       encoding,
     );
@@ -20188,8 +21426,9 @@ extension NSStringExtensionMethods on NSString {
 
   /// canBeConvertedToEncoding:
   bool canBeConvertedToEncoding(int encoding) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_6peh6o(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_canBeConvertedToEncoding_,
       encoding,
     );
@@ -20197,44 +21436,48 @@ extension NSStringExtensionMethods on NSString {
 
   /// capitalizedString
   NSString get capitalizedString {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_capitalizedString,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_capitalizedString);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// capitalizedStringWithLocale:
   NSString capitalizedStringWithLocale(NSLocale? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSString.capitalizedStringWithLocale:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_capitalizedStringWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// caseInsensitiveCompare:
   NSComparisonResult caseInsensitiveCompare(NSString string) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
     final $ret = _objc_msgSend_1ym6zyw(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_caseInsensitiveCompare_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSComparisonResult.fromValue($ret);
   }
 
   /// commonPrefixWithString:options:
   NSString commonPrefixWithString(NSString str, {required int options}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
     final $ret = _objc_msgSend_diypgk(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_commonPrefixWithString_options_,
-      str.ref.pointer,
+      _$$ref$1.pointer,
       options,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -20242,20 +21485,24 @@ extension NSStringExtensionMethods on NSString {
 
   /// compare:
   NSComparisonResult compare(NSString string) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
     final $ret = _objc_msgSend_1ym6zyw(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_compare_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSComparisonResult.fromValue($ret);
   }
 
   /// compare:options:
   NSComparisonResult compare$1(NSString string, {required int options}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
     final $ret = _objc_msgSend_pg1fnv(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_compare_options_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
       options,
     );
     return NSComparisonResult.fromValue($ret);
@@ -20267,10 +21514,12 @@ extension NSStringExtensionMethods on NSString {
     required int options,
     required NSRange range,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
     final $ret = _objc_msgSend_xrqic1(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_compare_options_range_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
       options,
       range,
     );
@@ -20284,60 +21533,70 @@ extension NSStringExtensionMethods on NSString {
     required NSRange range,
     objc.ObjCObject? locale,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
+    final _$$ref$2 = locale?.ref;
     final $ret = _objc_msgSend_1895u4n(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_compare_options_range_locale_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
       options,
       range,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSComparisonResult.fromValue($ret);
   }
 
   /// componentsSeparatedByCharactersInSet:
   NSArray componentsSeparatedByCharactersInSet(NSCharacterSet separator) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = separator.ref;
     objc.checkOsVersionInternal(
       'NSString.componentsSeparatedByCharactersInSet:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_componentsSeparatedByCharactersInSet_,
-      separator.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// componentsSeparatedByString:
   NSArray componentsSeparatedByString(NSString separator) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = separator.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_componentsSeparatedByString_,
-      separator.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSArray.fromPointer($ret, retain: true, release: true);
   }
 
   /// containsString:
   bool containsString(NSString str) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
     objc.checkOsVersionInternal(
       'NSString.containsString:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_containsString_,
-      str.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// dataUsingEncoding:
   NSData? dataUsingEncoding(int encoding) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_dataUsingEncoding_,
       encoding,
     );
@@ -20351,8 +21610,9 @@ extension NSStringExtensionMethods on NSString {
     int encoding, {
     required bool allowLossyConversion,
   }) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_hiwitm(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_dataUsingEncoding_allowLossyConversion_,
       encoding,
       allowLossyConversion,
@@ -20364,8 +21624,9 @@ extension NSStringExtensionMethods on NSString {
 
   /// decomposedStringWithCanonicalMapping
   NSString get decomposedStringWithCanonicalMapping {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_decomposedStringWithCanonicalMapping,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -20373,8 +21634,9 @@ extension NSStringExtensionMethods on NSString {
 
   /// decomposedStringWithCompatibilityMapping
   NSString get decomposedStringWithCompatibilityMapping {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_decomposedStringWithCompatibilityMapping,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -20382,30 +21644,34 @@ extension NSStringExtensionMethods on NSString {
 
   /// description
   NSString get description$1 {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_description);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_description);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// doubleValue
   double get doubleValue {
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_doubleValue)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_doubleValue);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_doubleValue)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_doubleValue);
   }
 
   /// enumerateLinesUsingBlock:
   void enumerateLinesUsingBlock(
     objc.ObjCBlock<ffi.Void Function(NSString, ffi.Pointer<ffi.Bool>)> block,
   ) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = block.ref;
     objc.checkOsVersionInternal(
       'NSString.enumerateLinesUsingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_f167m6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateLinesUsingBlock_,
-      block.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -20418,30 +21684,34 @@ extension NSStringExtensionMethods on NSString {
     >
     usingBlock,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = usingBlock.ref;
     objc.checkOsVersionInternal(
       'NSString.enumerateSubstringsInRange:options:usingBlock:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     _objc_msgSend_14ew8zr(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_enumerateSubstringsInRange_options_usingBlock_,
       range,
       options,
-      usingBlock.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// fastestEncoding
   int get fastestEncoding {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_fastestEncoding);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_fastestEncoding);
   }
 
   /// floatValue
   double get floatValue {
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_2cgrxlFpret(object$.ref.pointer, _sel_floatValue)
-        : _objc_msgSend_2cgrxl(object$.ref.pointer, _sel_floatValue);
+        ? _objc_msgSend_2cgrxlFpret(_$$ref.pointer, _sel_floatValue)
+        : _objc_msgSend_2cgrxl(_$$ref.pointer, _sel_floatValue);
   }
 
   /// getBytes:maxLength:usedLength:encoding:options:range:remainingRange:
@@ -20454,8 +21724,9 @@ extension NSStringExtensionMethods on NSString {
     required NSRange range,
     required ffi.Pointer<NSRange> remainingRange,
   }) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_i30zh3(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getBytes_maxLength_usedLength_encoding_options_range_remainingRange_,
       buffer,
       maxLength,
@@ -20473,8 +21744,9 @@ extension NSStringExtensionMethods on NSString {
     required int maxLength,
     required int encoding,
   }) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_1lv8yz3(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getCString_maxLength_encoding_,
       buffer,
       maxLength,
@@ -20487,8 +21759,9 @@ extension NSStringExtensionMethods on NSString {
     ffi.Pointer<ffi.UnsignedShort> buffer, {
     required NSRange range,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_898fog(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getCharacters_range_,
       buffer,
       range,
@@ -20502,8 +21775,9 @@ extension NSStringExtensionMethods on NSString {
     required ffi.Pointer<ffi.UnsignedLong> contentsEnd,
     required NSRange forRange,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_ourvf2(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getLineStart_end_contentsEnd_forRange_,
       startPtr,
       end,
@@ -20519,8 +21793,9 @@ extension NSStringExtensionMethods on NSString {
     required ffi.Pointer<ffi.UnsignedLong> contentsEnd,
     required NSRange forRange,
   }) {
+    final _$$ref = object$.ref;
     _objc_msgSend_ourvf2(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getParagraphStart_end_contentsEnd_forRange_,
       startPtr,
       end,
@@ -20531,55 +21806,65 @@ extension NSStringExtensionMethods on NSString {
 
   /// hasPrefix:
   bool hasPrefix(NSString str) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_hasPrefix_,
-      str.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// hasSuffix:
   bool hasSuffix(NSString str) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_hasSuffix_,
-      str.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// hash
   int get hash$1 {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_hash);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_hash);
   }
 
   /// intValue
   int get intValue {
-    return _objc_msgSend_13yqbb6(object$.ref.pointer, _sel_intValue);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_13yqbb6(_$$ref.pointer, _sel_intValue);
   }
 
   /// integerValue
   int get integerValue {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSString.integerValue',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_1hz7y9r(object$.ref.pointer, _sel_integerValue);
+    return _objc_msgSend_1hz7y9r(_$$ref.pointer, _sel_integerValue);
   }
 
   /// isEqualToString:
   bool isEqualToString(NSString aString) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aString.ref;
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_isEqualToString_,
-      aString.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// lengthOfBytesUsingEncoding:
   int lengthOfBytesUsingEncoding(int enc) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_12py2ux(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_lengthOfBytesUsingEncoding_,
       enc,
     );
@@ -20587,16 +21872,17 @@ extension NSStringExtensionMethods on NSString {
 
   /// lineRangeForRange:
   NSRange lineRangeForRange(NSRange range) {
+    final _$$ref = object$.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_uimyc7Stret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_lineRangeForRange_,
             range,
           )
         : $ptr.ref = _objc_msgSend_uimyc7(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_lineRangeForRange_,
             range,
           );
@@ -20609,13 +21895,14 @@ extension NSStringExtensionMethods on NSString {
 
   /// localizedCapitalizedString
   NSString get localizedCapitalizedString {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSString.localizedCapitalizedString',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedCapitalizedString,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -20623,47 +21910,54 @@ extension NSStringExtensionMethods on NSString {
 
   /// localizedCaseInsensitiveCompare:
   NSComparisonResult localizedCaseInsensitiveCompare(NSString string) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
     final $ret = _objc_msgSend_1ym6zyw(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedCaseInsensitiveCompare_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSComparisonResult.fromValue($ret);
   }
 
   /// localizedCaseInsensitiveContainsString:
   bool localizedCaseInsensitiveContainsString(NSString str) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
     objc.checkOsVersionInternal(
       'NSString.localizedCaseInsensitiveContainsString:',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 10, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedCaseInsensitiveContainsString_,
-      str.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// localizedCompare:
   NSComparisonResult localizedCompare(NSString string) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
     final $ret = _objc_msgSend_1ym6zyw(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedCompare_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSComparisonResult.fromValue($ret);
   }
 
   /// localizedLowercaseString
   NSString get localizedLowercaseString {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSString.localizedLowercaseString',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedLowercaseString,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -20671,35 +21965,41 @@ extension NSStringExtensionMethods on NSString {
 
   /// localizedStandardCompare:
   NSComparisonResult localizedStandardCompare(NSString string) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = string.ref;
     objc.checkOsVersionInternal(
       'NSString.localizedStandardCompare:',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
     final $ret = _objc_msgSend_1ym6zyw(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedStandardCompare_,
-      string.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSComparisonResult.fromValue($ret);
   }
 
   /// localizedStandardContainsString:
   bool localizedStandardContainsString(NSString str) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
     objc.checkOsVersionInternal(
       'NSString.localizedStandardContainsString:',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     return _objc_msgSend_19nvye5(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedStandardContainsString_,
-      str.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// localizedStandardRangeOfString:
   NSRange localizedStandardRangeOfString(NSString str) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = str.ref;
     objc.checkOsVersionInternal(
       'NSString.localizedStandardRangeOfString:',
       iOS: (false, (9, 0, 0)),
@@ -20709,14 +22009,14 @@ extension NSStringExtensionMethods on NSString {
     objc.useMsgSendVariants
         ? _objc_msgSend_182fzonStret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_localizedStandardRangeOfString_,
-            str.ref.pointer,
+            _$$ref$1.pointer,
           )
         : $ptr.ref = _objc_msgSend_182fzon(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_localizedStandardRangeOfString_,
-            str.ref.pointer,
+            _$$ref$1.pointer,
           );
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<NSRange>(),
@@ -20727,13 +22027,14 @@ extension NSStringExtensionMethods on NSString {
 
   /// localizedUppercaseString
   NSString get localizedUppercaseString {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSString.localizedUppercaseString',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_localizedUppercaseString,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -20741,42 +22042,44 @@ extension NSStringExtensionMethods on NSString {
 
   /// longLongValue
   int get longLongValue {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSString.longLongValue',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
-    return _objc_msgSend_1k101e3(object$.ref.pointer, _sel_longLongValue);
+    return _objc_msgSend_1k101e3(_$$ref.pointer, _sel_longLongValue);
   }
 
   /// lowercaseString
   NSString get lowercaseString {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_lowercaseString,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_lowercaseString);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// lowercaseStringWithLocale:
   NSString lowercaseStringWithLocale(NSLocale? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSString.lowercaseStringWithLocale:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_lowercaseStringWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// maximumLengthOfBytesUsingEncoding:
   int maximumLengthOfBytesUsingEncoding(int enc) {
+    final _$$ref = object$.ref;
     return _objc_msgSend_12py2ux(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_maximumLengthOfBytesUsingEncoding_,
       enc,
     );
@@ -20784,16 +22087,17 @@ extension NSStringExtensionMethods on NSString {
 
   /// paragraphRangeForRange:
   NSRange paragraphRangeForRange(NSRange range) {
+    final _$$ref = object$.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_uimyc7Stret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_paragraphRangeForRange_,
             range,
           )
         : $ptr.ref = _objc_msgSend_uimyc7(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_paragraphRangeForRange_,
             range,
           );
@@ -20806,8 +22110,9 @@ extension NSStringExtensionMethods on NSString {
 
   /// precomposedStringWithCanonicalMapping
   NSString get precomposedStringWithCanonicalMapping {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_precomposedStringWithCanonicalMapping,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -20815,8 +22120,9 @@ extension NSStringExtensionMethods on NSString {
 
   /// precomposedStringWithCompatibilityMapping
   NSString get precomposedStringWithCompatibilityMapping {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_precomposedStringWithCompatibilityMapping,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -20824,18 +22130,20 @@ extension NSStringExtensionMethods on NSString {
 
   /// rangeOfCharacterFromSet:
   NSRange rangeOfCharacterFromSet(NSCharacterSet searchSet) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = searchSet.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_182fzonStret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfCharacterFromSet_,
-            searchSet.ref.pointer,
+            _$$ref$1.pointer,
           )
         : $ptr.ref = _objc_msgSend_182fzon(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfCharacterFromSet_,
-            searchSet.ref.pointer,
+            _$$ref$1.pointer,
           );
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<NSRange>(),
@@ -20849,19 +22157,21 @@ extension NSStringExtensionMethods on NSString {
     NSCharacterSet searchSet, {
     required int options,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = searchSet.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_102xxo4Stret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfCharacterFromSet_options_,
-            searchSet.ref.pointer,
+            _$$ref$1.pointer,
             options,
           )
         : $ptr.ref = _objc_msgSend_102xxo4(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfCharacterFromSet_options_,
-            searchSet.ref.pointer,
+            _$$ref$1.pointer,
             options,
           );
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
@@ -20877,20 +22187,22 @@ extension NSStringExtensionMethods on NSString {
     required int options,
     required NSRange range,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = searchSet.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_1nmlvqcStret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfCharacterFromSet_options_range_,
-            searchSet.ref.pointer,
+            _$$ref$1.pointer,
             options,
             range,
           )
         : $ptr.ref = _objc_msgSend_1nmlvqc(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfCharacterFromSet_options_range_,
-            searchSet.ref.pointer,
+            _$$ref$1.pointer,
             options,
             range,
           );
@@ -20903,16 +22215,17 @@ extension NSStringExtensionMethods on NSString {
 
   /// rangeOfComposedCharacterSequenceAtIndex:
   NSRange rangeOfComposedCharacterSequenceAtIndex(int index) {
+    final _$$ref = object$.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_d3i1uyStret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfComposedCharacterSequenceAtIndex_,
             index,
           )
         : $ptr.ref = _objc_msgSend_d3i1uy(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfComposedCharacterSequenceAtIndex_,
             index,
           );
@@ -20925,6 +22238,7 @@ extension NSStringExtensionMethods on NSString {
 
   /// rangeOfComposedCharacterSequencesForRange:
   NSRange rangeOfComposedCharacterSequencesForRange(NSRange range) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSString.rangeOfComposedCharacterSequencesForRange:',
       iOS: (false, (2, 0, 0)),
@@ -20934,12 +22248,12 @@ extension NSStringExtensionMethods on NSString {
     objc.useMsgSendVariants
         ? _objc_msgSend_uimyc7Stret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfComposedCharacterSequencesForRange_,
             range,
           )
         : $ptr.ref = _objc_msgSend_uimyc7(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfComposedCharacterSequencesForRange_,
             range,
           );
@@ -20952,18 +22266,20 @@ extension NSStringExtensionMethods on NSString {
 
   /// rangeOfString:
   NSRange rangeOfString(NSString searchString) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = searchString.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_182fzonStret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfString_,
-            searchString.ref.pointer,
+            _$$ref$1.pointer,
           )
         : $ptr.ref = _objc_msgSend_182fzon(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfString_,
-            searchString.ref.pointer,
+            _$$ref$1.pointer,
           );
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<NSRange>(),
@@ -20974,19 +22290,21 @@ extension NSStringExtensionMethods on NSString {
 
   /// rangeOfString:options:
   NSRange rangeOfString$1(NSString searchString, {required int options}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = searchString.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_102xxo4Stret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfString_options_,
-            searchString.ref.pointer,
+            _$$ref$1.pointer,
             options,
           )
         : $ptr.ref = _objc_msgSend_102xxo4(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfString_options_,
-            searchString.ref.pointer,
+            _$$ref$1.pointer,
             options,
           );
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
@@ -21002,20 +22320,22 @@ extension NSStringExtensionMethods on NSString {
     required int options,
     required NSRange range,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = searchString.ref;
     final $ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_1nmlvqcStret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfString_options_range_,
-            searchString.ref.pointer,
+            _$$ref$1.pointer,
             options,
             range,
           )
         : $ptr.ref = _objc_msgSend_1nmlvqc(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfString_options_range_,
-            searchString.ref.pointer,
+            _$$ref$1.pointer,
             options,
             range,
           );
@@ -21033,6 +22353,9 @@ extension NSStringExtensionMethods on NSString {
     required NSRange range,
     NSLocale? locale,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = searchString.ref;
+    final _$$ref$2 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSString.rangeOfString:options:range:locale:',
       iOS: (false, (2, 0, 0)),
@@ -21042,20 +22365,20 @@ extension NSStringExtensionMethods on NSString {
     objc.useMsgSendVariants
         ? _objc_msgSend_gg0462Stret(
             $ptr,
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfString_options_range_locale_,
-            searchString.ref.pointer,
+            _$$ref$1.pointer,
             options,
             range,
-            locale?.ref.pointer ?? ffi.nullptr,
+            _$$ref$2?.pointer ?? ffi.nullptr,
           )
         : $ptr.ref = _objc_msgSend_gg0462(
-            object$.ref.pointer,
+            _$$ref.pointer,
             _sel_rangeOfString_options_range_locale_,
-            searchString.ref.pointer,
+            _$$ref$1.pointer,
             options,
             range,
-            locale?.ref.pointer ?? ffi.nullptr,
+            _$$ref$2?.pointer ?? ffi.nullptr,
           );
     final $finalizable = $ptr.cast<ffi.Uint8>().asTypedList(
       ffi.sizeOf<NSRange>(),
@@ -21066,25 +22389,30 @@ extension NSStringExtensionMethods on NSString {
 
   /// smallestEncoding
   int get smallestEncoding {
-    return _objc_msgSend_xw2lbc(object$.ref.pointer, _sel_smallestEncoding);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_xw2lbc(_$$ref.pointer, _sel_smallestEncoding);
   }
 
   /// stringByAppendingFormat:
   NSString stringByAppendingFormat(NSString format) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = format.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByAppendingFormat_,
-      format.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// stringByAppendingString:
   NSString stringByAppendingString(NSString aString) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = aString.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByAppendingString_,
-      aString.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -21094,15 +22422,17 @@ extension NSStringExtensionMethods on NSString {
     NSString transform, {
     required bool reverse,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = transform.ref;
     objc.checkOsVersionInternal(
       'NSString.stringByApplyingTransform:reverse:',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByApplyingTransform_reverse_,
-      transform.ref.pointer,
+      _$$ref$1.pointer,
       reverse,
     );
     return $ret.address == 0
@@ -21112,16 +22442,18 @@ extension NSStringExtensionMethods on NSString {
 
   /// stringByFoldingWithOptions:locale:
   NSString stringByFoldingWithOptions(int options, {NSLocale? locale}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSString.stringByFoldingWithOptions:locale:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_11cbyu0(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByFoldingWithOptions_locale_,
       options,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -21132,11 +22464,13 @@ extension NSStringExtensionMethods on NSString {
     required NSString withString,
     required int startingAtIndex,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withString.ref;
     final $ret = _objc_msgSend_1tfztp(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByPaddingToLength_withString_startingAtIndex_,
       newLength,
-      withString.ref.pointer,
+      _$$ref$1.pointer,
       startingAtIndex,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
@@ -21147,16 +22481,18 @@ extension NSStringExtensionMethods on NSString {
     NSRange range, {
     required NSString withString,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = withString.ref;
     objc.checkOsVersionInternal(
       'NSString.stringByReplacingCharactersInRange:withString:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_bstjp9(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByReplacingCharactersInRange_withString_,
       range,
-      withString.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -21166,16 +22502,19 @@ extension NSStringExtensionMethods on NSString {
     NSString target, {
     required NSString withString,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = target.ref;
+    final _$$ref$2 = withString.ref;
     objc.checkOsVersionInternal(
       'NSString.stringByReplacingOccurrencesOfString:withString:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByReplacingOccurrencesOfString_withString_,
-      target.ref.pointer,
-      withString.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -21187,16 +22526,19 @@ extension NSStringExtensionMethods on NSString {
     required int options,
     required NSRange range,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = target.ref;
+    final _$$ref$2 = withString.ref;
     objc.checkOsVersionInternal(
       'NSString.stringByReplacingOccurrencesOfString:withString:options:range:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_2u4jm6(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByReplacingOccurrencesOfString_withString_options_range_,
-      target.ref.pointer,
-      withString.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
       options,
       range,
     );
@@ -21205,18 +22547,21 @@ extension NSStringExtensionMethods on NSString {
 
   /// stringByTrimmingCharactersInSet:
   NSString stringByTrimmingCharactersInSet(NSCharacterSet set) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = set.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stringByTrimmingCharactersInSet_,
-      set.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// substringFromIndex:
   NSString substringFromIndex(int from) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_substringFromIndex_,
       from,
     );
@@ -21225,8 +22570,9 @@ extension NSStringExtensionMethods on NSString {
 
   /// substringToIndex:
   NSString substringToIndex(int to) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_14hpxwa(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_substringToIndex_,
       to,
     );
@@ -21235,8 +22581,9 @@ extension NSStringExtensionMethods on NSString {
 
   /// substringWithRange:
   NSString substringWithRange(NSRange range) {
+    final _$$ref = object$.ref;
     final $ret = _objc_msgSend_1k1o1s7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_substringWithRange_,
       range,
     );
@@ -21245,24 +22592,24 @@ extension NSStringExtensionMethods on NSString {
 
   /// uppercaseString
   NSString get uppercaseString {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_uppercaseString,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_uppercaseString);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// uppercaseStringWithLocale:
   NSString uppercaseStringWithLocale(NSLocale? locale) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = locale?.ref;
     objc.checkOsVersionInternal(
       'NSString.uppercaseStringWithLocale:',
       iOS: (false, (6, 0, 0)),
       macOS: (false, (10, 8, 0)),
     );
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_uppercaseStringWithLocale_,
-      locale?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSString.fromPointer($ret, retain: true, release: true);
   }
@@ -21273,12 +22620,14 @@ extension NSStringExtensionMethods on NSString {
     required bool atomically,
     required int encoding,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_dv3z6r(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_writeToFile_atomically_encoding_error_,
-        path.ref.pointer,
+        _$$ref$1.pointer,
         atomically,
         encoding,
         $err,
@@ -21296,12 +22645,14 @@ extension NSStringExtensionMethods on NSString {
     required bool atomically,
     required int encoding,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = url.ref;
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_dv3z6r(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_writeToURL_atomically_encoding_error_,
-        url.ref.pointer,
+        _$$ref$1.pointer,
         atomically,
         encoding,
         $err,
@@ -21391,11 +22742,12 @@ extension type NSTimer._(objc.ObjCObject object$)
     required NSInvocation invocation,
     required bool repeats,
   }) {
+    final _$$ref = invocation.ref;
     final $ret = _objc_msgSend_r49ehc(
       _class_NSTimer,
       _sel_scheduledTimerWithTimeInterval_invocation_repeats_,
       ti,
-      invocation.ref.pointer,
+      _$$ref.pointer,
       repeats,
     );
     return NSTimer.fromPointer($ret, retain: true, release: true);
@@ -21407,6 +22759,7 @@ extension type NSTimer._(objc.ObjCObject object$)
     required bool repeats,
     required objc.ObjCBlock<ffi.Void Function(NSTimer)> block,
   }) {
+    final _$$ref = block.ref;
     objc.checkOsVersionInternal(
       'NSTimer.scheduledTimerWithTimeInterval:repeats:block:',
       iOS: (false, (10, 0, 0)),
@@ -21417,7 +22770,7 @@ extension type NSTimer._(objc.ObjCObject object$)
       _sel_scheduledTimerWithTimeInterval_repeats_block_,
       interval,
       repeats,
-      block.ref.pointer,
+      _$$ref.pointer,
     );
     return NSTimer.fromPointer($ret, retain: true, release: true);
   }
@@ -21430,13 +22783,15 @@ extension type NSTimer._(objc.ObjCObject object$)
     objc.ObjCObject? userInfo,
     required bool repeats,
   }) {
+    final _$$ref = target.ref;
+    final _$$ref$1 = userInfo?.ref;
     final $ret = _objc_msgSend_ot6jdx(
       _class_NSTimer,
       _sel_scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_,
       ti,
-      target.ref.pointer,
+      _$$ref.pointer,
       selector,
-      userInfo?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
       repeats,
     );
     return NSTimer.fromPointer($ret, retain: true, release: true);
@@ -21448,11 +22803,12 @@ extension type NSTimer._(objc.ObjCObject object$)
     required NSInvocation invocation,
     required bool repeats,
   }) {
+    final _$$ref = invocation.ref;
     final $ret = _objc_msgSend_r49ehc(
       _class_NSTimer,
       _sel_timerWithTimeInterval_invocation_repeats_,
       ti,
-      invocation.ref.pointer,
+      _$$ref.pointer,
       repeats,
     );
     return NSTimer.fromPointer($ret, retain: true, release: true);
@@ -21464,6 +22820,7 @@ extension type NSTimer._(objc.ObjCObject object$)
     required bool repeats,
     required objc.ObjCBlock<ffi.Void Function(NSTimer)> block,
   }) {
+    final _$$ref = block.ref;
     objc.checkOsVersionInternal(
       'NSTimer.timerWithTimeInterval:repeats:block:',
       iOS: (false, (10, 0, 0)),
@@ -21474,7 +22831,7 @@ extension type NSTimer._(objc.ObjCObject object$)
       _sel_timerWithTimeInterval_repeats_block_,
       interval,
       repeats,
-      block.ref.pointer,
+      _$$ref.pointer,
     );
     return NSTimer.fromPointer($ret, retain: true, release: true);
   }
@@ -21487,13 +22844,15 @@ extension type NSTimer._(objc.ObjCObject object$)
     objc.ObjCObject? userInfo,
     required bool repeats,
   }) {
+    final _$$ref = target.ref;
+    final _$$ref$1 = userInfo?.ref;
     final $ret = _objc_msgSend_ot6jdx(
       _class_NSTimer,
       _sel_timerWithTimeInterval_target_selector_userInfo_repeats_,
       ti,
-      target.ref.pointer,
+      _$$ref.pointer,
       selector,
-      userInfo?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
       repeats,
     );
     return NSTimer.fromPointer($ret, retain: true, release: true);
@@ -21506,24 +22865,27 @@ extension type NSTimer._(objc.ObjCObject object$)
 extension NSTimer$Methods on NSTimer {
   /// fire
   void fire() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_fire);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_fire);
   }
 
   /// fireDate
   NSDate get fireDate {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_fireDate);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_fireDate);
     return NSDate.fromPointer($ret, retain: true, release: true);
   }
 
   /// init
   NSTimer init() {
+    final _$$ref$42 = object$.ref;
     objc.checkOsVersionInternal(
       'NSTimer.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$42.retainAndReturnPointer(),
       _sel_init,
     );
     return NSTimer.fromPointer($ret, retain: false, release: true);
@@ -21536,18 +22898,21 @@ extension NSTimer$Methods on NSTimer {
     required bool repeats,
     required objc.ObjCBlock<ffi.Void Function(NSTimer)> block,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = date.ref;
+    final _$$ref$2 = block.ref;
     objc.checkOsVersionInternal(
       'NSTimer.initWithFireDate:interval:repeats:block:',
       iOS: (false, (10, 0, 0)),
       macOS: (false, (10, 12, 0)),
     );
     final $ret = _objc_msgSend_1s0rfm3(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithFireDate_interval_repeats_block_,
-      date.ref.pointer,
+      _$$ref$1.pointer,
       interval,
       repeats,
-      block.ref.pointer,
+      _$$ref$2.pointer,
     );
     return NSTimer.fromPointer($ret, retain: false, release: true);
   }
@@ -21561,14 +22926,18 @@ extension NSTimer$Methods on NSTimer {
     objc.ObjCObject? userInfo,
     required bool repeats,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = date.ref;
+    final _$$ref$2 = target.ref;
+    final _$$ref$3 = userInfo?.ref;
     final $ret = _objc_msgSend_14wwtbv(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithFireDate_interval_target_selector_userInfo_repeats_,
-      date.ref.pointer,
+      _$$ref$1.pointer,
       interval,
-      target.ref.pointer,
+      _$$ref$2.pointer,
       selector,
-      userInfo?.ref.pointer ?? ffi.nullptr,
+      _$$ref$3?.pointer ?? ffi.nullptr,
       repeats,
     );
     return NSTimer.fromPointer($ret, retain: false, release: true);
@@ -21576,55 +22945,59 @@ extension NSTimer$Methods on NSTimer {
 
   /// invalidate
   void invalidate() {
-    _objc_msgSend_1pl9qdv(object$.ref.pointer, _sel_invalidate);
+    final _$$ref = object$.ref;
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_invalidate);
   }
 
   /// isValid
   bool get isValid {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isValid);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isValid);
   }
 
   /// setFireDate:
   set fireDate(NSDate value) {
-    _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
-      _sel_setFireDate_,
-      value.ref.pointer,
-    );
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value.ref;
+    _objc_msgSend_xtuoz7(_$$ref.pointer, _sel_setFireDate_, _$$ref$1.pointer);
   }
 
   /// setTolerance:
   set tolerance(double value) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSTimer.setTolerance:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_hwm8nu(object$.ref.pointer, _sel_setTolerance_, value);
+    _objc_msgSend_hwm8nu(_$$ref.pointer, _sel_setTolerance_, value);
   }
 
   /// timeInterval
   double get timeInterval {
+    final _$$ref = object$.ref;
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_timeInterval)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_timeInterval);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_timeInterval)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_timeInterval);
   }
 
   /// tolerance
   double get tolerance {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSTimer.tolerance',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     return objc.useMsgSendVariants
-        ? _objc_msgSend_1ukqyt8Fpret(object$.ref.pointer, _sel_tolerance)
-        : _objc_msgSend_1ukqyt8(object$.ref.pointer, _sel_tolerance);
+        ? _objc_msgSend_1ukqyt8Fpret(_$$ref.pointer, _sel_tolerance)
+        : _objc_msgSend_1ukqyt8(_$$ref.pointer, _sel_tolerance);
   }
 
   /// userInfo
   objc.ObjCObject? get userInfo {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_userInfo);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_userInfo);
     return $ret.address == 0
         ? null
         : objc.ObjCObject($ret, retain: true, release: true);
@@ -21662,6 +23035,7 @@ extension type NSURL._(objc.ObjCObject object$)
     NSURL url, {
     required int options,
   }) {
+    final _$$ref = url.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByResolvingAliasFileAtURL:options:error:',
       iOS: (false, (8, 0, 0)),
@@ -21672,7 +23046,7 @@ extension type NSURL._(objc.ObjCObject object$)
       final $ret = _objc_msgSend_1tiux5i(
         _class_NSURL,
         _sel_URLByResolvingAliasFileAtURL_options_error_,
-        url.ref.pointer,
+        _$$ref.pointer,
         options,
         $err,
       );
@@ -21692,6 +23066,8 @@ extension type NSURL._(objc.ObjCObject object$)
     NSURL? relativeToURL,
     required ffi.Pointer<ffi.Bool> bookmarkDataIsStale,
   }) {
+    final _$$ref = bookmarkData.ref;
+    final _$$ref$1 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:',
       iOS: (false, (4, 0, 0)),
@@ -21702,9 +23078,9 @@ extension type NSURL._(objc.ObjCObject object$)
       final $ret = _objc_msgSend_1ceswyu(
         _class_NSURL,
         _sel_URLByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_,
-        bookmarkData.ref.pointer,
+        _$$ref.pointer,
         options,
-        relativeToURL?.ref.pointer ?? ffi.nullptr,
+        _$$ref$1?.pointer ?? ffi.nullptr,
         bookmarkDataIsStale,
         $err,
       );
@@ -21719,6 +23095,8 @@ extension type NSURL._(objc.ObjCObject object$)
 
   /// URLWithDataRepresentation:relativeToURL:
   static NSURL URLWithDataRepresentation(NSData data, {NSURL? relativeToURL}) {
+    final _$$ref = data.ref;
+    final _$$ref$1 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLWithDataRepresentation:relativeToURL:',
       iOS: (false, (9, 0, 0)),
@@ -21727,18 +23105,19 @@ extension type NSURL._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_15qeuct(
       _class_NSURL,
       _sel_URLWithDataRepresentation_relativeToURL_,
-      data.ref.pointer,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: true, release: true);
   }
 
   /// URLWithString:
   static NSURL? URLWithString(NSString URLString) {
+    final _$$ref = URLString.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSURL,
       _sel_URLWithString_,
-      URLString.ref.pointer,
+      _$$ref.pointer,
     );
     return $ret.address == 0
         ? null
@@ -21753,6 +23132,7 @@ extension type NSURL._(objc.ObjCObject object$)
     NSString URLString, {
     required bool encodingInvalidCharacters,
   }) {
+    final _$$ref = URLString.ref;
     objc.checkOsVersionInternal(
       'NSURL.URLWithString:encodingInvalidCharacters:',
       iOS: (false, (17, 0, 0)),
@@ -21761,7 +23141,7 @@ extension type NSURL._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_17amj0z(
       _class_NSURL,
       _sel_URLWithString_encodingInvalidCharacters_,
-      URLString.ref.pointer,
+      _$$ref.pointer,
       encodingInvalidCharacters,
     );
     return $ret.address == 0
@@ -21771,11 +23151,13 @@ extension type NSURL._(objc.ObjCObject object$)
 
   /// URLWithString:relativeToURL:
   static NSURL? URLWithString$2(NSString URLString, {NSURL? relativeToURL}) {
+    final _$$ref = URLString.ref;
+    final _$$ref$1 = relativeToURL?.ref;
     final $ret = _objc_msgSend_15qeuct(
       _class_NSURL,
       _sel_URLWithString_relativeToURL_,
-      URLString.ref.pointer,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -21787,6 +23169,8 @@ extension type NSURL._(objc.ObjCObject object$)
     NSData data, {
     NSURL? relativeToURL,
   }) {
+    final _$$ref = data.ref;
+    final _$$ref$1 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.absoluteURLWithDataRepresentation:relativeToURL:',
       iOS: (false, (9, 0, 0)),
@@ -21795,8 +23179,8 @@ extension type NSURL._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_15qeuct(
       _class_NSURL,
       _sel_absoluteURLWithDataRepresentation_relativeToURL_,
-      data.ref.pointer,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: true, release: true);
   }
@@ -21815,6 +23199,7 @@ extension type NSURL._(objc.ObjCObject object$)
 
   /// bookmarkDataWithContentsOfURL:error:
   static NSData? bookmarkDataWithContentsOfURL(NSURL bookmarkFileURL) {
+    final _$$ref = bookmarkFileURL.ref;
     objc.checkOsVersionInternal(
       'NSURL.bookmarkDataWithContentsOfURL:error:',
       iOS: (false, (4, 0, 0)),
@@ -21825,7 +23210,7 @@ extension type NSURL._(objc.ObjCObject object$)
       final $ret = _objc_msgSend_1lhpu4m(
         _class_NSURL,
         _sel_bookmarkDataWithContentsOfURL_error_,
-        bookmarkFileURL.ref.pointer,
+        _$$ref.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -21843,6 +23228,7 @@ extension type NSURL._(objc.ObjCObject object$)
     required bool isDirectory,
     NSURL? relativeToURL,
   }) {
+    final _$$ref = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:',
       iOS: (false, (7, 0, 0)),
@@ -21853,23 +23239,25 @@ extension type NSURL._(objc.ObjCObject object$)
       _sel_fileURLWithFileSystemRepresentation_isDirectory_relativeToURL_,
       path,
       isDirectory,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:
   static NSURL fileURLWithPath(NSString path) {
+    final _$$ref = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
       _class_NSURL,
       _sel_fileURLWithPath_,
-      path.ref.pointer,
+      _$$ref.pointer,
     );
     return NSURL.fromPointer($ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:isDirectory:
   static NSURL fileURLWithPath$1(NSString path, {required bool isDirectory}) {
+    final _$$ref = path.ref;
     objc.checkOsVersionInternal(
       'NSURL.fileURLWithPath:isDirectory:',
       iOS: (false, (2, 0, 0)),
@@ -21878,7 +23266,7 @@ extension type NSURL._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_17amj0z(
       _class_NSURL,
       _sel_fileURLWithPath_isDirectory_,
-      path.ref.pointer,
+      _$$ref.pointer,
       isDirectory,
     );
     return NSURL.fromPointer($ret, retain: true, release: true);
@@ -21890,6 +23278,8 @@ extension type NSURL._(objc.ObjCObject object$)
     required bool isDirectory,
     NSURL? relativeToURL,
   }) {
+    final _$$ref = path.ref;
+    final _$$ref$1 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.fileURLWithPath:isDirectory:relativeToURL:',
       iOS: (false, (9, 0, 0)),
@@ -21898,15 +23288,17 @@ extension type NSURL._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_1ged0jd(
       _class_NSURL,
       _sel_fileURLWithPath_isDirectory_relativeToURL_,
-      path.ref.pointer,
+      _$$ref.pointer,
       isDirectory,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:relativeToURL:
   static NSURL fileURLWithPath$3(NSString path, {NSURL? relativeToURL}) {
+    final _$$ref = path.ref;
+    final _$$ref$1 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.fileURLWithPath:relativeToURL:',
       iOS: (false, (9, 0, 0)),
@@ -21915,8 +23307,8 @@ extension type NSURL._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_15qeuct(
       _class_NSURL,
       _sel_fileURLWithPath_relativeToURL_,
-      path.ref.pointer,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: true, release: true);
   }
@@ -21932,6 +23324,8 @@ extension type NSURL._(objc.ObjCObject object$)
     NSArray keys, {
     required NSData fromBookmarkData,
   }) {
+    final _$$ref = keys.ref;
+    final _$$ref$1 = fromBookmarkData.ref;
     objc.checkOsVersionInternal(
       'NSURL.resourceValuesForKeys:fromBookmarkData:',
       iOS: (false, (4, 0, 0)),
@@ -21940,8 +23334,8 @@ extension type NSURL._(objc.ObjCObject object$)
     final $ret = _objc_msgSend_15qeuct(
       _class_NSURL,
       _sel_resourceValuesForKeys_fromBookmarkData_,
-      keys.ref.pointer,
-      fromBookmarkData.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -21959,6 +23353,8 @@ extension type NSURL._(objc.ObjCObject object$)
     required NSURL toURL,
     required int options,
   }) {
+    final _$$ref = bookmarkData.ref;
+    final _$$ref$1 = toURL.ref;
     objc.checkOsVersionInternal(
       'NSURL.writeBookmarkData:toURL:options:error:',
       iOS: (false, (4, 0, 0)),
@@ -21969,8 +23365,8 @@ extension type NSURL._(objc.ObjCObject object$)
       final $ret = _objc_msgSend_1vxoo9h(
         _class_NSURL,
         _sel_writeBookmarkData_toURL_options_error_,
-        bookmarkData.ref.pointer,
-        toURL.ref.pointer,
+        _$$ref.pointer,
+        _$$ref$1.pointer,
         options,
         $err,
       );
@@ -21988,10 +23384,8 @@ extension type NSURL._(objc.ObjCObject object$)
 extension NSURL$Methods on NSURL {
   /// absoluteString
   NSString? get absoluteString {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_absoluteString,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_absoluteString);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -21999,7 +23393,8 @@ extension NSURL$Methods on NSURL {
 
   /// absoluteURL
   NSURL? get absoluteURL {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_absoluteURL);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_absoluteURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -22007,7 +23402,8 @@ extension NSURL$Methods on NSURL {
 
   /// baseURL
   NSURL? get baseURL {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_baseURL);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_baseURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -22019,6 +23415,9 @@ extension NSURL$Methods on NSURL {
     NSArray? includingResourceValuesForKeys,
     NSURL? relativeToURL,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = includingResourceValuesForKeys?.ref;
+    final _$$ref$2 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.bookmarkDataWithOptions:includingResourceValuesForKeys:relativeToURL:error:',
       iOS: (false, (4, 0, 0)),
@@ -22027,11 +23426,11 @@ extension NSURL$Methods on NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1wt9a7r(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_bookmarkDataWithOptions_includingResourceValuesForKeys_relativeToURL_error_,
         options,
-        includingResourceValuesForKeys?.ref.pointer ?? ffi.nullptr,
-        relativeToURL?.ref.pointer ?? ffi.nullptr,
+        _$$ref$1?.pointer ?? ffi.nullptr,
+        _$$ref$2?.pointer ?? ffi.nullptr,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -22045,35 +23444,36 @@ extension NSURL$Methods on NSURL {
 
   /// dataRepresentation
   NSData get dataRepresentation {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.dataRepresentation',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_dataRepresentation,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_dataRepresentation);
     return NSData.fromPointer($ret, retain: true, release: true);
   }
 
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$34 = object$.ref;
+    final _$$ref$35 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$34.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$35.pointer,
     );
   }
 
   /// filePathURL
   NSURL? get filePathURL {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.filePathURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_filePathURL);
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_filePathURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -22081,15 +23481,13 @@ extension NSURL$Methods on NSURL {
 
   /// fileReferenceURL
   NSURL? fileReferenceURL() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.fileReferenceURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_fileReferenceURL,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_fileReferenceURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -22097,20 +23495,19 @@ extension NSURL$Methods on NSURL {
 
   /// fileSystemRepresentation
   ffi.Pointer<ffi.Char> get fileSystemRepresentation {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.fileSystemRepresentation',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    return _objc_msgSend_1fuqfwb(
-      object$.ref.pointer,
-      _sel_fileSystemRepresentation,
-    );
+    return _objc_msgSend_1fuqfwb(_$$ref.pointer, _sel_fileSystemRepresentation);
   }
 
   /// fragment
   NSString? get fragment {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_fragment);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_fragment);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22121,13 +23518,14 @@ extension NSURL$Methods on NSURL {
     ffi.Pointer<ffi.Char> buffer, {
     required int maxLength,
   }) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.getFileSystemRepresentation:maxLength:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     return _objc_msgSend_8cymbm(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_getFileSystemRepresentation_maxLength_,
       buffer,
       maxLength,
@@ -22139,6 +23537,8 @@ extension NSURL$Methods on NSURL {
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> value, {
     required NSString forKey,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = forKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.getResourceValue:forKey:error:',
       iOS: (false, (4, 0, 0)),
@@ -22147,10 +23547,10 @@ extension NSURL$Methods on NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1j9bhml(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_getResourceValue_forKey_error_,
         value,
-        forKey.ref.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -22162,17 +23562,19 @@ extension NSURL$Methods on NSURL {
 
   /// hasDirectoryPath
   bool get hasDirectoryPath {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.hasDirectoryPath',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_hasDirectoryPath);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_hasDirectoryPath);
   }
 
   /// host
   NSString? get host {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_host);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_host);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22180,13 +23582,14 @@ extension NSURL$Methods on NSURL {
 
   /// init
   NSURL init() {
+    final _$$ref$43 = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$43.retainAndReturnPointer(),
       _sel_init,
     );
     return NSURL.fromPointer($ret, retain: false, release: true);
@@ -22197,16 +23600,19 @@ extension NSURL$Methods on NSURL {
     NSData data, {
     NSURL? relativeToURL,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
+    final _$$ref$2 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.initAbsoluteURLWithDataRepresentation:relativeToURL:',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initAbsoluteURLWithDataRepresentation_relativeToURL_,
-      data.ref.pointer,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: false, release: true);
   }
@@ -22218,6 +23624,9 @@ extension NSURL$Methods on NSURL {
     NSURL? relativeToURL,
     required ffi.Pointer<ffi.Bool> bookmarkDataIsStale,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = bookmarkData.ref;
+    final _$$ref$2 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.initByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:',
       iOS: (false, (4, 0, 0)),
@@ -22226,11 +23635,11 @@ extension NSURL$Methods on NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1ceswyu(
-        object$.ref.retainAndReturnPointer(),
+        _$$ref.retainAndReturnPointer(),
         _sel_initByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_,
-        bookmarkData.ref.pointer,
+        _$$ref$1.pointer,
         options,
-        relativeToURL?.ref.pointer ?? ffi.nullptr,
+        _$$ref$2?.pointer ?? ffi.nullptr,
         bookmarkDataIsStale,
         $err,
       );
@@ -22249,42 +23658,48 @@ extension NSURL$Methods on NSURL {
     required bool isDirectory,
     NSURL? relativeToURL,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.initFileURLWithFileSystemRepresentation:isDirectory:relativeToURL:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     final $ret = _objc_msgSend_1n40f6p(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initFileURLWithFileSystemRepresentation_isDirectory_relativeToURL_,
       path,
       isDirectory,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:
   NSURL initFileURLWithPath(NSString path) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initFileURLWithPath_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
     );
     return NSURL.fromPointer($ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:isDirectory:
   NSURL initFileURLWithPath$1(NSString path, {required bool isDirectory}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
     objc.checkOsVersionInternal(
       'NSURL.initFileURLWithPath:isDirectory:',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 5, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initFileURLWithPath_isDirectory_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
       isDirectory,
     );
     return NSURL.fromPointer($ret, retain: false, release: true);
@@ -22296,43 +23711,51 @@ extension NSURL$Methods on NSURL {
     required bool isDirectory,
     NSURL? relativeToURL,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
+    final _$$ref$2 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.initFileURLWithPath:isDirectory:relativeToURL:',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     final $ret = _objc_msgSend_1ged0jd(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initFileURLWithPath_isDirectory_relativeToURL_,
-      path.ref.pointer,
+      _$$ref$1.pointer,
       isDirectory,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:relativeToURL:
   NSURL initFileURLWithPath$3(NSString path, {NSURL? relativeToURL}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = path.ref;
+    final _$$ref$2 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.initFileURLWithPath:relativeToURL:',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initFileURLWithPath_relativeToURL_,
-      path.ref.pointer,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSURL? initWithCoder(NSCoder coder) {
+    final _$$ref$50 = object$.ref;
+    final _$$ref$51 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$50.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$51.pointer,
     );
     return $ret.address == 0
         ? null
@@ -22341,26 +23764,31 @@ extension NSURL$Methods on NSURL {
 
   /// initWithDataRepresentation:relativeToURL:
   NSURL initWithDataRepresentation(NSData data, {NSURL? relativeToURL}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = data.ref;
+    final _$$ref$2 = relativeToURL?.ref;
     objc.checkOsVersionInternal(
       'NSURL.initWithDataRepresentation:relativeToURL:',
       iOS: (false, (9, 0, 0)),
       macOS: (false, (10, 11, 0)),
     );
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithDataRepresentation_relativeToURL_,
-      data.ref.pointer,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return NSURL.fromPointer($ret, retain: false, release: true);
   }
 
   /// initWithString:
   NSURL? initWithString(NSString URLString) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = URLString.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithString_,
-      URLString.ref.pointer,
+      _$$ref$1.pointer,
     );
     return $ret.address == 0
         ? null
@@ -22375,15 +23803,17 @@ extension NSURL$Methods on NSURL {
     NSString URLString, {
     required bool encodingInvalidCharacters,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = URLString.ref;
     objc.checkOsVersionInternal(
       'NSURL.initWithString:encodingInvalidCharacters:',
       iOS: (false, (17, 0, 0)),
       macOS: (false, (14, 0, 0)),
     );
     final $ret = _objc_msgSend_17amj0z(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithString_encodingInvalidCharacters_,
-      URLString.ref.pointer,
+      _$$ref$1.pointer,
       encodingInvalidCharacters,
     );
     return $ret.address == 0
@@ -22393,11 +23823,14 @@ extension NSURL$Methods on NSURL {
 
   /// initWithString:relativeToURL:
   NSURL? initWithString$2(NSString URLString, {NSURL? relativeToURL}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = URLString.ref;
+    final _$$ref$2 = relativeToURL?.ref;
     final $ret = _objc_msgSend_15qeuct(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_initWithString_relativeToURL_,
-      URLString.ref.pointer,
-      relativeToURL?.ref.pointer ?? ffi.nullptr,
+      _$$ref$1.pointer,
+      _$$ref$2?.pointer ?? ffi.nullptr,
     );
     return $ret.address == 0
         ? null
@@ -22406,17 +23839,19 @@ extension NSURL$Methods on NSURL {
 
   /// isFileReferenceURL
   bool isFileReferenceURL() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.isFileReferenceURL',
       iOS: (false, (4, 0, 0)),
       macOS: (false, (10, 6, 0)),
     );
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isFileReferenceURL);
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isFileReferenceURL);
   }
 
   /// isFileURL
   bool get isFileURL {
-    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isFileURL);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_91o635(_$$ref.pointer, _sel_isFileURL);
   }
 
   /// iOS: introduced 2.0.0, deprecated 13.0.0
@@ -22425,15 +23860,13 @@ extension NSURL$Methods on NSURL {
     'The parameterString method is deprecated. Post deprecation for applications linked with or after the macOS 10.15, and for all iOS, watchOS, and tvOS applications, parameterString will always return nil, and the path method will return the complete path including the semicolon separator and params component if the URL string contains them.',
   )
   NSString? get parameterString {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.parameterString',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 2, 0)),
     );
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_parameterString,
-    );
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_parameterString);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22441,7 +23874,8 @@ extension NSURL$Methods on NSURL {
 
   /// password
   NSString? get password {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_password);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_password);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22449,7 +23883,8 @@ extension NSURL$Methods on NSURL {
 
   /// path
   NSString? get path {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_path);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_path);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22457,7 +23892,8 @@ extension NSURL$Methods on NSURL {
 
   /// port
   NSNumber? get port {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_port);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_port);
     return $ret.address == 0
         ? null
         : NSNumber.fromPointer($ret, retain: true, release: true);
@@ -22465,7 +23901,8 @@ extension NSURL$Methods on NSURL {
 
   /// query
   NSString? get query {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_query);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_query);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22473,7 +23910,8 @@ extension NSURL$Methods on NSURL {
 
   /// relativePath
   NSString? get relativePath {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_relativePath);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_relativePath);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22481,46 +23919,42 @@ extension NSURL$Methods on NSURL {
 
   /// relativeString
   NSString get relativeString {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_relativeString,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_relativeString);
     return NSString.fromPointer($ret, retain: true, release: true);
   }
 
   /// removeAllCachedResourceValues
   void removeAllCachedResourceValues() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.removeAllCachedResourceValues',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
-    _objc_msgSend_1pl9qdv(
-      object$.ref.pointer,
-      _sel_removeAllCachedResourceValues,
-    );
+    _objc_msgSend_1pl9qdv(_$$ref.pointer, _sel_removeAllCachedResourceValues);
   }
 
   /// removeCachedResourceValueForKey:
   void removeCachedResourceValueForKey(NSString key) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = key.ref;
     objc.checkOsVersionInternal(
       'NSURL.removeCachedResourceValueForKey:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_removeCachedResourceValueForKey_,
-      key.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
   /// resourceSpecifier
   NSString? get resourceSpecifier {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_resourceSpecifier,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_resourceSpecifier);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22528,6 +23962,8 @@ extension NSURL$Methods on NSURL {
 
   /// resourceValuesForKeys:error:
   NSDictionary? resourceValuesForKeys(NSArray keys) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = keys.ref;
     objc.checkOsVersionInternal(
       'NSURL.resourceValuesForKeys:error:',
       iOS: (false, (4, 0, 0)),
@@ -22536,9 +23972,9 @@ extension NSURL$Methods on NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_1lhpu4m(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_resourceValuesForKeys_error_,
-        keys.ref.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -22552,7 +23988,8 @@ extension NSURL$Methods on NSURL {
 
   /// scheme
   NSString? get scheme {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_scheme);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_scheme);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22560,6 +23997,9 @@ extension NSURL$Methods on NSURL {
 
   /// setResourceValue:forKey:error:
   bool setResourceValue(objc.ObjCObject? value, {required NSString forKey}) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
+    final _$$ref$2 = forKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.setResourceValue:forKey:error:',
       iOS: (false, (4, 0, 0)),
@@ -22568,10 +24008,10 @@ extension NSURL$Methods on NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_6z4k82(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_setResourceValue_forKey_error_,
-        value?.ref.pointer ?? ffi.nullptr,
-        forKey.ref.pointer,
+        _$$ref$1?.pointer ?? ffi.nullptr,
+        _$$ref$2.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -22583,6 +24023,8 @@ extension NSURL$Methods on NSURL {
 
   /// setResourceValues:error:
   bool setResourceValues(NSDictionary keyedValues) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = keyedValues.ref;
     objc.checkOsVersionInternal(
       'NSURL.setResourceValues:error:',
       iOS: (false, (4, 0, 0)),
@@ -22591,9 +24033,9 @@ extension NSURL$Methods on NSURL {
     final $err = pkg_ffi.calloc<ffi.Pointer<objc.ObjCObjectImpl>>();
     try {
       final $ret = _objc_msgSend_l9p60w(
-        object$.ref.pointer,
+        _$$ref.pointer,
         _sel_setResourceValues_error_,
-        keyedValues.ref.pointer,
+        _$$ref$1.pointer,
         $err,
       );
       objc.NSErrorException.checkErrorPointer($err.value);
@@ -22608,25 +24050,26 @@ extension NSURL$Methods on NSURL {
     objc.ObjCObject? value, {
     required NSString forKey,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = value?.ref;
+    final _$$ref$2 = forKey.ref;
     objc.checkOsVersionInternal(
       'NSURL.setTemporaryResourceValue:forKey:',
       iOS: (false, (7, 0, 0)),
       macOS: (false, (10, 9, 0)),
     );
     _objc_msgSend_pfv6jd(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_setTemporaryResourceValue_forKey_,
-      value?.ref.pointer ?? ffi.nullptr,
-      forKey.ref.pointer,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+      _$$ref$2.pointer,
     );
   }
 
   /// standardizedURL
   NSURL? get standardizedURL {
-    final $ret = _objc_msgSend_151sglz(
-      object$.ref.pointer,
-      _sel_standardizedURL,
-    );
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_standardizedURL);
     return $ret.address == 0
         ? null
         : NSURL.fromPointer($ret, retain: true, release: true);
@@ -22634,33 +24077,36 @@ extension NSURL$Methods on NSURL {
 
   /// startAccessingSecurityScopedResource
   bool startAccessingSecurityScopedResource() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.startAccessingSecurityScopedResource',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     return _objc_msgSend_91o635(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_startAccessingSecurityScopedResource,
     );
   }
 
   /// stopAccessingSecurityScopedResource
   void stopAccessingSecurityScopedResource() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSURL.stopAccessingSecurityScopedResource',
       iOS: (false, (8, 0, 0)),
       macOS: (false, (10, 7, 0)),
     );
     _objc_msgSend_1pl9qdv(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_stopAccessingSecurityScopedResource,
     );
   }
 
   /// user
   NSString? get user {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_user);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_user);
     return $ret.address == 0
         ? null
         : NSString.fromPointer($ret, retain: true, release: true);
@@ -22738,13 +24184,14 @@ extension type NSURLHandle._(objc.ObjCObject object$)
 extension NSURLHandle$Methods on NSURLHandle {
   /// init
   NSURLHandle init() {
+    final _$$ref$44 = object$.ref;
     objc.checkOsVersionInternal(
       'NSURLHandle.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$44.retainAndReturnPointer(),
       _sel_init,
     );
     return NSURLHandle.fromPointer($ret, retain: false, release: true);
@@ -22829,32 +24276,36 @@ extension type NSValue._(objc.ObjCObject object$)
 extension NSValue$Methods on NSValue {
   /// encodeWithCoder:
   void encodeWithCoder(NSCoder coder) {
+    final _$$ref$36 = object$.ref;
+    final _$$ref$37 = coder.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref$36.pointer,
       _sel_encodeWithCoder_,
-      coder.ref.pointer,
+      _$$ref$37.pointer,
     );
   }
 
   /// getValue:size:
   void getValue(ffi.Pointer<ffi.Void> value, {required int size}) {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'NSValue.getValue:size:',
       iOS: (false, (11, 0, 0)),
       macOS: (false, (10, 13, 0)),
     );
-    _objc_msgSend_zuf90e(object$.ref.pointer, _sel_getValue_size_, value, size);
+    _objc_msgSend_zuf90e(_$$ref.pointer, _sel_getValue_size_, value, size);
   }
 
   /// init
   NSValue init() {
+    final _$$ref$45 = object$.ref;
     objc.checkOsVersionInternal(
       'NSValue.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$45.retainAndReturnPointer(),
       _sel_init,
     );
     return NSValue.fromPointer($ret, retain: false, release: true);
@@ -22865,8 +24316,9 @@ extension NSValue$Methods on NSValue {
     ffi.Pointer<ffi.Void> value, {
     required ffi.Pointer<ffi.Char> objCType,
   }) {
+    final _$$ref$1 = object$.ref;
     final $ret = _objc_msgSend_e9mncn(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_initWithBytes_objCType_,
       value,
       objCType,
@@ -22876,10 +24328,12 @@ extension NSValue$Methods on NSValue {
 
   /// initWithCoder:
   NSValue? initWithCoder(NSCoder coder) {
+    final _$$ref$52 = object$.ref;
+    final _$$ref$53 = coder.ref;
     final $ret = _objc_msgSend_1sotr3r(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$52.retainAndReturnPointer(),
       _sel_initWithCoder_,
-      coder.ref.pointer,
+      _$$ref$53.pointer,
     );
     return $ret.address == 0
         ? null
@@ -22888,7 +24342,8 @@ extension NSValue$Methods on NSValue {
 
   /// objCType
   ffi.Pointer<ffi.Char> get objCType {
-    return _objc_msgSend_1fuqfwb(object$.ref.pointer, _sel_objCType);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_1fuqfwb(_$$ref.pointer, _sel_objCType);
   }
 }
 
@@ -22939,8 +24394,8 @@ abstract final class ObjCBlock_NSArray_ffiVoid {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<NSArray Function(ffi.Pointer<ffi.Void>)>(
     objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-      final _$obj = fn(arg0);
-      return _$obj.ref.retainAndAutorelease();
+      final _$$ref = fn(arg0).ref;
+      return _$$ref.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -22987,25 +24442,27 @@ abstract final class ObjCBlock_NSArray_ffiVoid {
 /// Call operator for `objc.ObjCBlock<NSArray Function(ffi.Pointer<ffi.Void>)>`.
 extension ObjCBlock_NSArray_ffiVoid$CallExtension
     on objc.ObjCBlock<NSArray Function(ffi.Pointer<ffi.Void>)> {
-  NSArray call(ffi.Pointer<ffi.Void> arg0) => NSArray.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  NSArray call(ffi.Pointer<ffi.Void> arg0) {
+    return NSArray.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >()(ref.pointer, arg0),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Long Function(ffi.Pointer<objc.ObjCObjectImpl>, ffi.Pointer<objc.ObjCObjectImpl>)>`.
@@ -23086,17 +24543,15 @@ abstract final class ObjCBlock_NSComparisonResult_objcObjCObjectImpl_objcObjCObj
           ffi.Pointer<objc.ObjCObjectImpl>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          return fn(
             objc.ObjCObject(arg0, retain: true, release: true),
             objc.ObjCObject(arg1, retain: true, release: true),
-          ).value,
-          keepIsolateAlive,
-        ),
+          ).value;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -23159,26 +24614,29 @@ extension ObjCBlock_NSComparisonResult_objcObjCObjectImpl_objcObjCObjectImpl$Cal
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
         > {
-  NSComparisonResult call(objc.ObjCObject arg0, objc.ObjCObject arg1) =>
-      NSComparisonResult.fromValue(
-        ref.pointer.ref.invoke
-            .cast<
-              ffi.NativeFunction<
-                ffi.Long Function(
-                  ffi.Pointer<objc.ObjCBlockImpl> block,
-                  ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                  ffi.Pointer<objc.ObjCObjectImpl> arg1,
-                )
-              >
-            >()
-            .asFunction<
-              int Function(
-                ffi.Pointer<objc.ObjCBlockImpl>,
-                ffi.Pointer<objc.ObjCObjectImpl>,
-                ffi.Pointer<objc.ObjCObjectImpl>,
+  NSComparisonResult call(objc.ObjCObject arg0, objc.ObjCObject arg1) {
+    final _$$ref = arg0.ref;
+    final _$$ref$1 = arg1.ref;
+    return NSComparisonResult.fromValue(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Long Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                ffi.Pointer<objc.ObjCObjectImpl> arg1,
               )
-            >()(ref.pointer, arg0.ref.pointer, arg1.ref.pointer),
-      );
+            >
+          >()
+          .asFunction<
+            int Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
+            )
+          >()(ref.pointer, _$$ref.pointer, _$$ref$1.pointer),
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Long Function(ffi.Pointer<ffi.Void>, NSString)>`.
@@ -23234,14 +24692,15 @@ abstract final class ObjCBlock_NSItemProviderRepresentationVisibility_ffiVoid_NS
     fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Long Function(ffi.Pointer<ffi.Void>, NSString)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0,
         NSString.fromPointer(arg1, retain: true, release: true),
-      ).value,
-      keepIsolateAlive,
-    ),
+      ).value;
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -23298,25 +24757,28 @@ extension ObjCBlock_NSItemProviderRepresentationVisibility_ffiVoid_NSString$Call
   NSItemProviderRepresentationVisibility call(
     ffi.Pointer<ffi.Void> arg0,
     NSString arg1,
-  ) => NSItemProviderRepresentationVisibility.fromValue(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
-            ffi.Long Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
-              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  ) {
+    final _$$ref = arg1.ref;
+    return NSItemProviderRepresentationVisibility.fromValue(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Long Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+                ffi.Pointer<objc.ObjCObjectImpl> arg1,
+              )
+            >
+          >()
+          .asFunction<
+            int Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >
-        >()
-        .asFunction<
-          int Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<objc.ObjCObjectImpl>,
-          )
-        >()(ref.pointer, arg0, arg1.ref.pointer),
-  );
+          >()(ref.pointer, arg0, _$$ref.pointer),
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<NSOrderedCollectionChange Function(NSOrderedCollectionChange)>`.
@@ -23381,14 +24843,14 @@ abstract final class ObjCBlock_NSOrderedCollectionChange_NSOrderedCollectionChan
         objc.newClosureBlock(_closureCallable, (
           ffi.Pointer<objc.ObjCObjectImpl> arg0,
         ) {
-          final _$obj = fn(
+          final _$$ref = fn(
             NSOrderedCollectionChange.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
-          );
-          return _$obj.ref.retainAndAutorelease();
+          ).ref;
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -23442,26 +24904,28 @@ extension ObjCBlock_NSOrderedCollectionChange_NSOrderedCollectionChange$CallExte
         objc.ObjCBlock<
           NSOrderedCollectionChange Function(NSOrderedCollectionChange)
         > {
-  NSOrderedCollectionChange call(NSOrderedCollectionChange arg0) =>
-      NSOrderedCollectionChange.fromPointer(
-        ref.pointer.ref.invoke
-            .cast<
-              ffi.NativeFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl> block,
-                  ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                )
-              >
-            >()
-            .asFunction<
+  NSOrderedCollectionChange call(NSOrderedCollectionChange arg0) {
+    final _$$ref$1 = arg0.ref;
+    return NSOrderedCollectionChange.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
               ffi.Pointer<objc.ObjCObjectImpl> Function(
-                ffi.Pointer<objc.ObjCBlockImpl>,
-                ffi.Pointer<objc.ObjCObjectImpl>,
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<objc.ObjCObjectImpl> arg0,
               )
-            >()(ref.pointer, arg0.ref.pointer),
-        retain: true,
-        release: true,
-      );
+            >
+          >()
+          .asFunction<
+            ffi.Pointer<objc.ObjCObjectImpl> Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
+            )
+          >()(ref.pointer, _$$ref$1.pointer),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<objc.ObjCBlock<ffi.Void Function()>? Function(NSProgress)>`.
@@ -23524,10 +24988,10 @@ abstract final class ObjCBlock_NSProgressUnpublishingHandler_NSProgress {
         objc.newClosureBlock(_closureCallable, (
           ffi.Pointer<objc.ObjCObjectImpl> arg0,
         ) {
-          final _$nullableObj = fn(
+          final _$$ref = fn(
             NSProgress.fromPointer(arg0, retain: true, release: true),
-          );
-          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+          )?.ref;
+          return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -23581,44 +25045,46 @@ extension ObjCBlock_NSProgressUnpublishingHandler_NSProgress$CallExtension
         objc.ObjCBlock<
           objc.ObjCBlock<ffi.Void Function()>? Function(NSProgress)
         > {
-  objc.ObjCBlock<ffi.Void Function()>? call(NSProgress arg0) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  objc.ObjCBlock<ffi.Void Function()>? call(NSProgress arg0) {
+    final _$$ref$1 = arg0.ref;
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCBlockImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCBlockImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCBlockImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer)
-              .address ==
-          0
-      ? null
-      : ObjCBlock_ffiVoid.fromPointer(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, _$$ref$1.pointer)
+                .address ==
+            0
+        ? null
+        : ObjCBlock_ffiVoid.fromPointer(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCBlockImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCBlockImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCBlockImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, _$$ref$1.pointer),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<NSProgress? Function(objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>)>`.
@@ -23690,14 +25156,14 @@ abstract final class ObjCBlock_NSProgress_ffiVoidNSDataNSError {
         objc.newClosureBlock(_closureCallable, (
           ffi.Pointer<objc.ObjCBlockImpl> arg0,
         ) {
-          final _$nullableObj = fn(
+          final _$$ref = fn(
             ObjCBlock_ffiVoid_NSData_NSError.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
-          );
-          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+          )?.ref;
+          return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -23753,44 +25219,46 @@ extension ObjCBlock_NSProgress_ffiVoidNSDataNSError$CallExtension
             objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>,
           )
         > {
-  NSProgress? call(objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)> arg0) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  NSProgress? call(objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)> arg0) {
+    final _$$ref$1 = arg0.ref;
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer)
-              .address ==
-          0
-      ? null
-      : NSProgress.fromPointer(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, _$$ref$1.pointer)
+                .address ==
+            0
+        ? null
+        : NSProgress.fromPointer(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, _$$ref$1.pointer),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<NSProgress? Function(objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)>)>`.
@@ -23870,14 +25338,14 @@ abstract final class ObjCBlock_NSProgress_ffiVoidNSURLboolNSError {
         objc.newClosureBlock(_closureCallable, (
           ffi.Pointer<objc.ObjCBlockImpl> arg0,
         ) {
-          final _$nullableObj = fn(
+          final _$$ref = fn(
             ObjCBlock_ffiVoid_NSURL_bool_NSError.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
-          );
-          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+          )?.ref;
+          return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -23935,44 +25403,46 @@ extension ObjCBlock_NSProgress_ffiVoidNSURLboolNSError$CallExtension
         > {
   NSProgress? call(
     objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)> arg0,
-  ) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  ) {
+    final _$$ref$1 = arg0.ref;
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer)
-              .address ==
-          0
-      ? null
-      : NSProgress.fromPointer(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, _$$ref$1.pointer)
+                .address ==
+            0
+        ? null
+        : NSProgress.fromPointer(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, _$$ref$1.pointer),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<NSProgress? Function(ffi.Pointer<ffi.Void>, NSString, objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>)>`.
@@ -24070,7 +25540,7 @@ abstract final class ObjCBlock_NSProgress_ffiVoid_NSString_ffiVoidNSDataNSError 
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
           ffi.Pointer<objc.ObjCBlockImpl> arg2,
         ) {
-          final _$nullableObj = fn(
+          final _$$ref = fn(
             arg0,
             NSString.fromPointer(arg1, retain: true, release: true),
             ObjCBlock_ffiVoid_NSData_NSError.fromPointer(
@@ -24078,8 +25548,8 @@ abstract final class ObjCBlock_NSProgress_ffiVoid_NSString_ffiVoidNSDataNSError 
               retain: true,
               release: true,
             ),
-          );
-          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+          )?.ref;
+          return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -24155,52 +25625,55 @@ extension ObjCBlock_NSProgress_ffiVoid_NSString_ffiVoidNSDataNSError$CallExtensi
     ffi.Pointer<ffi.Void> arg0,
     NSString arg1,
     objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)> arg2,
-  ) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  ) {
+    final _$$ref$1 = arg1.ref;
+    final _$$ref$2 = arg2.ref;
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<ffi.Void> arg0,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                      ffi.Pointer<objc.ObjCBlockImpl> arg2,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<ffi.Void> arg0,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg1,
-                    ffi.Pointer<objc.ObjCBlockImpl> arg2,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<ffi.Void>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<ffi.Void>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                )
-              >()(ref.pointer, arg0, arg1.ref.pointer, arg2.ref.pointer)
-              .address ==
-          0
-      ? null
-      : NSProgress.fromPointer(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, arg0, _$$ref$1.pointer, _$$ref$2.pointer)
+                .address ==
+            0
+        ? null
+        : NSProgress.fromPointer(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<ffi.Void> arg0,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                      ffi.Pointer<objc.ObjCBlockImpl> arg2,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<ffi.Void> arg0,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg1,
-                    ffi.Pointer<objc.ObjCBlockImpl> arg2,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<ffi.Void>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<ffi.Void>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                )
-              >()(ref.pointer, arg0, arg1.ref.pointer, arg2.ref.pointer),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, arg0, _$$ref$1.pointer, _$$ref$2.pointer),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<NSProgress? Function(objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError?)>)>`.
@@ -24294,14 +25767,14 @@ abstract final class ObjCBlock_NSProgress_ffiVoididNSItemProviderWritingNSError 
         objc.newClosureBlock(_closureCallable, (
           ffi.Pointer<objc.ObjCBlockImpl> arg0,
         ) {
-          final _$nullableObj = fn(
+          final _$$ref = fn(
             ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
-          );
-          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+          )?.ref;
+          return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -24364,44 +25837,46 @@ extension ObjCBlock_NSProgress_ffiVoididNSItemProviderWritingNSError$CallExtensi
       ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError?)
     >
     arg0,
-  ) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  ) {
+    final _$$ref$1 = arg0.ref;
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer)
-              .address ==
-          0
-      ? null
-      : NSProgress.fromPointer(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, _$$ref$1.pointer)
+                .address ==
+            0
+        ? null
+        : NSProgress.fromPointer(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCBlockImpl> arg0,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, _$$ref$1.pointer),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<NSString Function(ffi.Pointer<ffi.Void>)>`.
@@ -24449,8 +25924,8 @@ abstract final class ObjCBlock_NSString_ffiVoid {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<NSString Function(ffi.Pointer<ffi.Void>)>(
     objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-      final _$obj = fn(arg0);
-      return _$obj.ref.retainAndAutorelease();
+      final _$$ref = fn(arg0).ref;
+      return _$$ref.retainAndAutorelease();
     }, keepIsolateAlive),
     retain: false,
     release: true,
@@ -24497,25 +25972,27 @@ abstract final class ObjCBlock_NSString_ffiVoid {
 /// Call operator for `objc.ObjCBlock<NSString Function(ffi.Pointer<ffi.Void>)>`.
 extension ObjCBlock_NSString_ffiVoid$CallExtension
     on objc.ObjCBlock<NSString Function(ffi.Pointer<ffi.Void>)> {
-  NSString call(ffi.Pointer<ffi.Void> arg0) => NSString.fromPointer(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  NSString call(ffi.Pointer<ffi.Void> arg0) {
+    return NSString.fromPointer(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >()(ref.pointer, arg0),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>`.
@@ -24562,11 +26039,9 @@ abstract final class ObjCBlock_NSUInteger_ffiVoid {
     int Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -24608,18 +26083,20 @@ abstract final class ObjCBlock_NSUInteger_ffiVoid {
 /// Call operator for `objc.ObjCBlock<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)>`.
 extension ObjCBlock_NSUInteger_ffiVoid$CallExtension
     on objc.ObjCBlock<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>)> {
-  int call(ffi.Pointer<ffi.Void> arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.UnsignedLong Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-          )
-        >
-      >()
-      .asFunction<
-        int Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)
-      >()(ref.pointer, arg0);
+  int call(ffi.Pointer<ffi.Void> arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.UnsignedLong Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          int Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)
+        >()(ref.pointer, arg0);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.UnsignedLong Function(ffi.Pointer<ffi.Void>, ffi.Pointer<NSFastEnumerationState>, ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>>, ffi.UnsignedLong)>`.
@@ -24720,16 +26197,14 @@ abstract final class ObjCBlock_NSUInteger_ffiVoid_NSFastEnumerationState_objcObj
           ffi.UnsignedLong,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<NSFastEnumerationState> arg1,
-            ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> arg2,
-            int arg3,
-          ) => fn(arg0, arg1, arg2, arg3),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<NSFastEnumerationState> arg1,
+          ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> arg2,
+          int arg3,
+        ) {
+          return fn(arg0, arg1, arg2, arg3);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -24813,27 +26288,29 @@ extension ObjCBlock_NSUInteger_ffiVoid_NSFastEnumerationState_objcObjCObjectImpl
     ffi.Pointer<NSFastEnumerationState> arg1,
     ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> arg2,
     int arg3,
-  ) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.UnsignedLong Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<NSFastEnumerationState> arg1,
-            ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> arg2,
-            ffi.UnsignedLong arg3,
+  ) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.UnsignedLong Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<NSFastEnumerationState> arg1,
+              ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>> arg2,
+              ffi.UnsignedLong arg3,
+            )
+          >
+        >()
+        .asFunction<
+          int Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<NSFastEnumerationState>,
+            ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>>,
+            int,
           )
-        >
-      >()
-      .asFunction<
-        int Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<NSFastEnumerationState>,
-          ffi.Pointer<ffi.Pointer<objc.ObjCObjectImpl>>,
-          int,
-        )
-      >()(ref.pointer, arg0, arg1, arg2, arg3);
+        >()(ref.pointer, arg0, arg1, arg2, arg3);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<NSZone> Function(ffi.Pointer<ffi.Void>)>`.
@@ -24882,11 +26359,9 @@ abstract final class ObjCBlock_NSZone_ffiVoid {
     ffi.Pointer<NSZone> Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Pointer<NSZone> Function(ffi.Pointer<ffi.Void>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -24928,21 +26403,23 @@ abstract final class ObjCBlock_NSZone_ffiVoid {
 /// Call operator for `objc.ObjCBlock<ffi.Pointer<NSZone> Function(ffi.Pointer<ffi.Void>)>`.
 extension ObjCBlock_NSZone_ffiVoid$CallExtension
     on objc.ObjCBlock<ffi.Pointer<NSZone> Function(ffi.Pointer<ffi.Void>)> {
-  ffi.Pointer<NSZone> call(ffi.Pointer<ffi.Void> arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
+  ffi.Pointer<NSZone> call(ffi.Pointer<ffi.Void> arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Pointer<NSZone> Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+            )
+          >
+        >()
+        .asFunction<
           ffi.Pointer<NSZone> Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
           )
-        >
-      >()
-      .asFunction<
-        ffi.Pointer<NSZone> Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-        )
-      >()(ref.pointer, arg0);
+        >()(ref.pointer, arg0);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<objc.ObjCObjectImpl>, ffi.Pointer<objc.ObjCObjectImpl>, ffi.Pointer<ffi.Bool>)>`.
@@ -25030,19 +26507,17 @@ abstract final class ObjCBlock_bool_KeyType_ObjectType_bool {
           ffi.Pointer<ffi.Bool>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<ffi.Bool> arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<ffi.Bool> arg2,
+        ) {
+          return fn(
             objc.ObjCObject(arg0, retain: true, release: true),
             objc.ObjCObject(arg1, retain: true, release: true),
             arg2,
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -25117,25 +26592,29 @@ extension ObjCBlock_bool_KeyType_ObjectType_bool$CallExtension
     objc.ObjCObject arg0,
     objc.ObjCObject arg1,
     ffi.Pointer<ffi.Bool> arg2,
-  ) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<ffi.Bool> arg2,
+  ) {
+    final _$$ref = arg0.ref;
+    final _$$ref$1 = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+              ffi.Pointer<ffi.Bool> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        bool Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0.ref.pointer, arg1.ref.pointer, arg2);
+        >()(ref.pointer, _$$ref.pointer, _$$ref$1.pointer, arg2);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)>`.
@@ -25195,11 +26674,12 @@ abstract final class ObjCBlock_bool_NSUInteger_bool {
       objc.ObjCBlock<
         ffi.Bool Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (int arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          int arg0,
+          ffi.Pointer<ffi.Bool> arg1,
+        ) {
+          return fn(arg0, arg1);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -25248,23 +26728,25 @@ extension ObjCBlock_bool_NSUInteger_bool$CallExtension
         objc.ObjCBlock<
           ffi.Bool Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)
         > {
-  bool call(int arg0, ffi.Pointer<ffi.Bool> arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.UnsignedLong arg0,
-            ffi.Pointer<ffi.Bool> arg1,
+  bool call(int arg0, ffi.Pointer<ffi.Bool> arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.UnsignedLong arg0,
+              ffi.Pointer<ffi.Bool> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            int,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        bool Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          int,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0, arg1);
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<objc.ObjCObjectImpl>, ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)>`.
@@ -25352,19 +26834,17 @@ abstract final class ObjCBlock_bool_ObjectType_NSUInteger_bool {
           ffi.Pointer<ffi.Bool>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            int arg1,
-            ffi.Pointer<ffi.Bool> arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          int arg1,
+          ffi.Pointer<ffi.Bool> arg2,
+        ) {
+          return fn(
             objc.ObjCObject(arg0, retain: true, release: true),
             arg1,
             arg2,
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -25435,28 +26915,28 @@ extension ObjCBlock_bool_ObjectType_NSUInteger_bool$CallExtension
             ffi.Pointer<ffi.Bool>,
           )
         > {
-  bool call(objc.ObjCObject arg0, int arg1, ffi.Pointer<ffi.Bool> arg2) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.UnsignedLong arg1,
-            ffi.Pointer<ffi.Bool> arg2,
+  bool call(objc.ObjCObject arg0, int arg1, ffi.Pointer<ffi.Bool> arg2) {
+    final _$$ref = arg0.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.UnsignedLong arg1,
+              ffi.Pointer<ffi.Bool> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            int,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        bool Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          int,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0.ref.pointer, arg1, arg2);
+        >()(ref.pointer, _$$ref.pointer, arg1, arg2);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<objc.ObjCObjectImpl>, ffi.Pointer<ffi.Bool>)>`.
@@ -25528,12 +27008,12 @@ abstract final class ObjCBlock_bool_ObjectType_bool {
           ffi.Pointer<ffi.Bool>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-              fn(objc.ObjCObject(arg0, retain: true, release: true), arg1),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<ffi.Bool> arg1,
+        ) {
+          return fn(objc.ObjCObject(arg0, retain: true, release: true), arg1);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -25593,26 +27073,26 @@ extension ObjCBlock_bool_ObjectType_bool$CallExtension
             ffi.Pointer<ffi.Bool>,
           )
         > {
-  bool call(objc.ObjCObject arg0, ffi.Pointer<ffi.Bool> arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<ffi.Bool> arg1,
+  bool call(objc.ObjCObject arg0, ffi.Pointer<ffi.Bool> arg1) {
+    final _$$ref = arg0.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<ffi.Bool> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        bool Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0.ref.pointer, arg1);
+        >()(ref.pointer, _$$ref.pointer, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>)>`.
@@ -25657,11 +27137,9 @@ abstract final class ObjCBlock_bool_ffiVoid {
     bool Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -25699,18 +27177,20 @@ abstract final class ObjCBlock_bool_ffiVoid {
 /// Call operator for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>)>`.
 extension ObjCBlock_bool_ffiVoid$CallExtension
     on objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>)> {
-  bool call(ffi.Pointer<ffi.Void> arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-          )
-        >
-      >()
-      .asFunction<
-        bool Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)
-      >()(ref.pointer, arg0);
+  bool call(ffi.Pointer<ffi.Void> arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)
+        >()(ref.pointer, arg0);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>, Protocol)>`.
@@ -25762,12 +27242,12 @@ abstract final class ObjCBlock_bool_ffiVoid_Protocol {
     bool Function(ffi.Pointer<ffi.Void>, Protocol) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>, Protocol)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, Protocol.fromPointer(arg1, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(arg0, Protocol.fromPointer(arg1, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -25821,23 +27301,26 @@ abstract final class ObjCBlock_bool_ffiVoid_Protocol {
 /// Call operator for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>, Protocol)>`.
 extension ObjCBlock_bool_ffiVoid_Protocol$CallExtension
     on objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>, Protocol)> {
-  bool call(ffi.Pointer<ffi.Void> arg0, Protocol arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  bool call(ffi.Pointer<ffi.Void> arg0, Protocol arg1) {
+    final _$$ref = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        bool Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0, arg1.ref.pointer);
+        >()(ref.pointer, arg0, _$$ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>, ffi.Pointer<objc.ObjCObjectImpl>)>`.
@@ -25909,12 +27392,12 @@ abstract final class ObjCBlock_bool_ffiVoid_objcObjCObjectImpl {
           ffi.Pointer<objc.ObjCObjectImpl>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-              fn(arg0, objc.ObjCObject(arg1, retain: true, release: true)),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          return fn(arg0, objc.ObjCObject(arg1, retain: true, release: true));
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -25974,26 +27457,26 @@ extension ObjCBlock_bool_ffiVoid_objcObjCObjectImpl$CallExtension
             ffi.Pointer<objc.ObjCObjectImpl>,
           )
         > {
-  bool call(ffi.Pointer<ffi.Void> arg0, objc.ObjCObject arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Bool Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  bool call(ffi.Pointer<ffi.Void> arg0, objc.ObjCObject arg1) {
+    final _$$ref = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        bool Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0, arg1.ref.pointer);
+        >()(ref.pointer, arg0, _$$ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Bool Function(ffi.Pointer<ffi.Void>, ffi.Pointer<objc.ObjCSelector>)>`.
@@ -26056,12 +27539,12 @@ abstract final class ObjCBlock_bool_ffiVoid_objcObjCSelector {
       objc.ObjCBlock<
         ffi.Bool Function(ffi.Pointer<ffi.Void>, ffi.Pointer<objc.ObjCSelector>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCSelector> arg1) =>
-              fn(arg0, arg1),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCSelector> arg1,
+        ) {
+          return fn(arg0, arg1);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -26121,24 +27604,25 @@ extension ObjCBlock_bool_ffiVoid_objcObjCSelector$CallExtension
             ffi.Pointer<objc.ObjCSelector>,
           )
         > {
-  bool call(ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCSelector> arg1) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Bool Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Pointer<ffi.Void> arg0,
-                ffi.Pointer<objc.ObjCSelector> arg1,
-              )
-            >
-          >()
-          .asFunction<
-            bool Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<ffi.Void>,
-              ffi.Pointer<objc.ObjCSelector>,
+  bool call(ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCSelector> arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Bool Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCSelector> arg1,
             )
-          >()(ref.pointer, arg0, arg1);
+          >
+        >()
+        .asFunction<
+          bool Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCSelector>,
+          )
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function()>`.
@@ -26179,7 +27663,9 @@ abstract final class ObjCBlock_ffiVoid {
     void Function() fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function()>(
-    objc.newClosureBlock(_closureCallable, () => fn(), keepIsolateAlive),
+    objc.newClosureBlock(_closureCallable, () {
+      return fn();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -26199,7 +27685,9 @@ abstract final class ObjCBlock_ffiVoid {
   }) {
     final raw = objc.newClosureBlock(
       _listenerCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapListenerBlock_1pl9qdv(raw);
@@ -26227,12 +27715,16 @@ abstract final class ObjCBlock_ffiVoid {
   }) {
     final raw = objc.newClosureBlock(
       _blockingCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      () => fn(),
+      () {
+        return fn();
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_1pl9qdv(
@@ -26317,16 +27809,17 @@ abstract final class ObjCBlock_ffiVoid {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function()>`.
 extension ObjCBlock_ffiVoid$CallExtension
     on objc.ObjCBlock<ffi.Void Function()> {
-  void call() =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<objc.ObjCBlockImpl> block)
-            >
-          >()
-          .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>)>()(
-        ref.pointer,
-      );
+  void call() {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(ffi.Pointer<objc.ObjCBlockImpl> block)
+          >
+        >()
+        .asFunction<void Function(ffi.Pointer<objc.ObjCBlockImpl>)>()(
+      ref.pointer,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>, ffi.Pointer<objc.ObjCObjectImpl>, ffi.Pointer<ffi.Bool>)>`.
@@ -26414,19 +27907,17 @@ abstract final class ObjCBlock_ffiVoid_KeyType_ObjectType_bool {
           ffi.Pointer<ffi.Bool>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<ffi.Bool> arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<ffi.Bool> arg2,
+        ) {
+          return fn(
             objc.ObjCObject(arg0, retain: true, release: true),
             objc.ObjCObject(arg1, retain: true, release: true),
             arg2,
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -26451,19 +27942,17 @@ abstract final class ObjCBlock_ffiVoid_KeyType_ObjectType_bool {
     void Function(objc.ObjCObject, objc.ObjCObject, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<ffi.Bool> arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      ffi.Pointer<ffi.Bool> arg2,
+    ) {
+      return fn(
         objc.ObjCObject(arg0, retain: false, release: true),
         objc.ObjCObject(arg1, retain: false, release: true),
         arg2,
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_1o83rbn(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -26496,32 +27985,29 @@ abstract final class ObjCBlock_ffiVoid_KeyType_ObjectType_bool {
     void Function(objc.ObjCObject, objc.ObjCObject, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<ffi.Bool> arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      ffi.Pointer<ffi.Bool> arg2,
+    ) {
+      return fn(
         objc.ObjCObject(arg0, retain: false, release: true),
         objc.ObjCObject(arg1, retain: false, release: true),
         arg2,
-      ),
-      keepIsolateAlive,
-    );
-    final rawListener = objc.newClosureBlock(
-      _blockingListenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<ffi.Bool> arg2,
-      ) => fn(
-        objc.ObjCObject(arg0, retain: false, release: true),
-        objc.ObjCObject(arg1, retain: false, release: true),
-        arg2,
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
+    final rawListener = objc
+        .newClosureBlock(_blockingListenerCallable.nativeFunction.cast(), (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<ffi.Bool> arg2,
+        ) {
+          return fn(
+            objc.ObjCObject(arg0, retain: false, release: true),
+            objc.ObjCObject(arg1, retain: false, release: true),
+            arg2,
+          );
+        }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapBlockingBlock_1o83rbn(
       raw,
       rawListener,
@@ -26702,25 +28188,29 @@ extension ObjCBlock_ffiVoid_KeyType_ObjectType_bool$CallExtension
     objc.ObjCObject arg0,
     objc.ObjCObject arg1,
     ffi.Pointer<ffi.Bool> arg2,
-  ) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<ffi.Bool> arg2,
+  ) {
+    final _$$ref = arg0.ref;
+    final _$$ref$1 = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+              ffi.Pointer<ffi.Bool> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0.ref.pointer, arg1.ref.pointer, arg2);
+        >()(ref.pointer, _$$ref.pointer, _$$ref$1.pointer, arg2);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>`.
@@ -26770,21 +28260,19 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
     void Function(NSData?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSData.fromPointer(arg0, retain: true, release: true),
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -26802,21 +28290,19 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
     void Function(NSData?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSData.fromPointer(arg0, retain: false, release: true),
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_pfv6jd(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>(
@@ -26840,34 +28326,34 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
     void Function(NSData?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSData.fromPointer(arg0, retain: false, release: true),
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
       (
         ffi.Pointer<objc.ObjCObjectImpl> arg0,
         ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
-        arg0.address == 0
-            ? null
-            : NSData.fromPointer(arg0, retain: false, release: true),
-        arg1.address == 0
-            ? null
-            : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
+      ) {
+        return fn(
+          arg0.address == 0
+              ? null
+              : NSData.fromPointer(arg0, retain: false, release: true),
+          arg1.address == 0
+              ? null
+              : NSError.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_pfv6jd(
@@ -27020,28 +28506,31 @@ abstract final class ObjCBlock_ffiVoid_NSData_NSError {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>`.
 extension ObjCBlock_ffiVoid_NSData_NSError$CallExtension
     on objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)> {
-  void call(NSData? arg0, NSError? arg1) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                ffi.Pointer<objc.ObjCObjectImpl> arg1,
-              )
-            >
-          >()
-          .asFunction<
-            void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
+  void call(NSData? arg0, NSError? arg1) {
+    final _$$ref = arg0?.ref;
+    final _$$ref$1 = arg1?.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
             )
-          >()(
-        ref.pointer,
-        arg0?.ref.pointer ?? ffi.nullptr,
-        arg1?.ref.pointer ?? ffi.nullptr,
-      );
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+          )
+        >()(
+      ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError)>, ffi.Pointer<objc.ObjCObjectImpl>, NSDictionary)>`.
@@ -27148,13 +28637,12 @@ abstract final class ObjCBlock_ffiVoid_NSItemProviderCompletionHandler_objcObjCO
           NSDictionary,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCBlockImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<objc.ObjCObjectImpl> arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCBlockImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<objc.ObjCObjectImpl> arg2,
+        ) {
+          return fn(
             ObjCBlock_ffiVoid_idNSSecureCoding_NSError.fromPointer(
               arg0,
               retain: true,
@@ -27162,9 +28650,8 @@ abstract final class ObjCBlock_ffiVoid_NSItemProviderCompletionHandler_objcObjCO
             ),
             objc.ObjCObject(arg1, retain: true, release: true),
             NSDictionary.fromPointer(arg2, retain: true, release: true),
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -27198,13 +28685,12 @@ abstract final class ObjCBlock_ffiVoid_NSItemProviderCompletionHandler_objcObjCO
     fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCBlockImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCBlockImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+    ) {
+      return fn(
         ObjCBlock_ffiVoid_idNSSecureCoding_NSError.fromPointer(
           arg0,
           retain: false,
@@ -27212,9 +28698,8 @@ abstract final class ObjCBlock_ffiVoid_NSItemProviderCompletionHandler_objcObjCO
         ),
         objc.ObjCObject(arg1, retain: false, release: true),
         NSDictionary.fromPointer(arg2, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_1b3bb6a(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -27258,13 +28743,12 @@ abstract final class ObjCBlock_ffiVoid_NSItemProviderCompletionHandler_objcObjCO
     fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCBlockImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCBlockImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+    ) {
+      return fn(
         ObjCBlock_ffiVoid_idNSSecureCoding_NSError.fromPointer(
           arg0,
           retain: false,
@@ -27272,26 +28756,24 @@ abstract final class ObjCBlock_ffiVoid_NSItemProviderCompletionHandler_objcObjCO
         ),
         objc.ObjCObject(arg1, retain: false, release: true),
         NSDictionary.fromPointer(arg2, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
-    final rawListener = objc.newClosureBlock(
-      _blockingListenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCBlockImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-      ) => fn(
-        ObjCBlock_ffiVoid_idNSSecureCoding_NSError.fromPointer(
-          arg0,
-          retain: false,
-          release: true,
-        ),
-        objc.ObjCObject(arg1, retain: false, release: true),
-        NSDictionary.fromPointer(arg2, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
+    final rawListener = objc
+        .newClosureBlock(_blockingListenerCallable.nativeFunction.cast(), (
+          ffi.Pointer<objc.ObjCBlockImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<objc.ObjCObjectImpl> arg2,
+        ) {
+          return fn(
+            ObjCBlock_ffiVoid_idNSSecureCoding_NSError.fromPointer(
+              arg0,
+              retain: false,
+              release: true,
+            ),
+            objc.ObjCObject(arg1, retain: false, release: true),
+            NSDictionary.fromPointer(arg2, retain: false, release: true),
+          );
+        }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapBlockingBlock_1b3bb6a(
       raw,
       rawListener,
@@ -27479,25 +28961,30 @@ extension ObjCBlock_ffiVoid_NSItemProviderCompletionHandler_objcObjCObjectImpl_N
     arg0,
     objc.ObjCObject arg1,
     NSDictionary arg2,
-  ) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCBlockImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<objc.ObjCObjectImpl> arg2,
+  ) {
+    final _$$ref = arg0.ref;
+    final _$$ref$1 = arg1.ref;
+    final _$$ref$2 = arg2.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCBlockImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+              ffi.Pointer<objc.ObjCObjectImpl> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0.ref.pointer, arg1.ref.pointer, arg2.ref.pointer);
+        >()(ref.pointer, _$$ref.pointer, _$$ref$1.pointer, _$$ref$2.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(NSRange, ffi.Pointer<ffi.Bool>)>`.
@@ -27546,11 +29033,12 @@ abstract final class ObjCBlock_ffiVoid_NSRange_bool {
     void Function(NSRange, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(NSRange, ffi.Pointer<ffi.Bool>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (NSRange arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      NSRange arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -27569,11 +29057,12 @@ abstract final class ObjCBlock_ffiVoid_NSRange_bool {
     void Function(NSRange, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (NSRange arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      NSRange arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_zkjmn1(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(NSRange, ffi.Pointer<ffi.Bool>)>(
@@ -27598,14 +29087,17 @@ abstract final class ObjCBlock_ffiVoid_NSRange_bool {
     void Function(NSRange, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (NSRange arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      NSRange arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (NSRange arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
+      (NSRange arg0, ffi.Pointer<ffi.Bool> arg1) {
+        return fn(arg0, arg1);
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_zkjmn1(
@@ -27741,23 +29233,25 @@ abstract final class ObjCBlock_ffiVoid_NSRange_bool {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(NSRange, ffi.Pointer<ffi.Bool>)>`.
 extension ObjCBlock_ffiVoid_NSRange_bool$CallExtension
     on objc.ObjCBlock<ffi.Void Function(NSRange, ffi.Pointer<ffi.Bool>)> {
-  void call(NSRange arg0, ffi.Pointer<ffi.Bool> arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            NSRange arg0,
-            ffi.Pointer<ffi.Bool> arg1,
+  void call(NSRange arg0, ffi.Pointer<ffi.Bool> arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              NSRange arg0,
+              ffi.Pointer<ffi.Bool> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            NSRange,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          NSRange,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0, arg1);
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(NSString?, NSRange, NSRange, ffi.Pointer<ffi.Bool>)>`.
@@ -27822,23 +29316,21 @@ abstract final class ObjCBlock_ffiVoid_NSString_NSRange_NSRange_bool {
       objc.ObjCBlock<
         ffi.Void Function(NSString?, NSRange, NSRange, ffi.Pointer<ffi.Bool>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            NSRange arg1,
-            NSRange arg2,
-            ffi.Pointer<ffi.Bool> arg3,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          NSRange arg1,
+          NSRange arg2,
+          ffi.Pointer<ffi.Bool> arg3,
+        ) {
+          return fn(
             arg0.address == 0
                 ? null
                 : NSString.fromPointer(arg0, retain: true, release: true),
             arg1,
             arg2,
             arg3,
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -27859,23 +29351,21 @@ abstract final class ObjCBlock_ffiVoid_NSString_NSRange_NSRange_bool {
     void Function(NSString?, NSRange, NSRange, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        NSRange arg1,
-        NSRange arg2,
-        ffi.Pointer<ffi.Bool> arg3,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      NSRange arg1,
+      NSRange arg2,
+      ffi.Pointer<ffi.Bool> arg3,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSString.fromPointer(arg0, retain: false, release: true),
         arg1,
         arg2,
         arg3,
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_lmc3p5(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -27900,40 +29390,37 @@ abstract final class ObjCBlock_ffiVoid_NSString_NSRange_NSRange_bool {
     void Function(NSString?, NSRange, NSRange, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        NSRange arg1,
-        NSRange arg2,
-        ffi.Pointer<ffi.Bool> arg3,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      NSRange arg1,
+      NSRange arg2,
+      ffi.Pointer<ffi.Bool> arg3,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSString.fromPointer(arg0, retain: false, release: true),
         arg1,
         arg2,
         arg3,
-      ),
-      keepIsolateAlive,
-    );
-    final rawListener = objc.newClosureBlock(
-      _blockingListenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        NSRange arg1,
-        NSRange arg2,
-        ffi.Pointer<ffi.Bool> arg3,
-      ) => fn(
-        arg0.address == 0
-            ? null
-            : NSString.fromPointer(arg0, retain: false, release: true),
-        arg1,
-        arg2,
-        arg3,
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
+    final rawListener = objc
+        .newClosureBlock(_blockingListenerCallable.nativeFunction.cast(), (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          NSRange arg1,
+          NSRange arg2,
+          ffi.Pointer<ffi.Bool> arg3,
+        ) {
+          return fn(
+            arg0.address == 0
+                ? null
+                : NSString.fromPointer(arg0, retain: false, release: true),
+            arg1,
+            arg2,
+            arg3,
+          );
+        }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapBlockingBlock_lmc3p5(
       raw,
       rawListener,
@@ -28124,27 +29611,30 @@ extension ObjCBlock_ffiVoid_NSString_NSRange_NSRange_bool$CallExtension
     NSRange arg1,
     NSRange arg2,
     ffi.Pointer<ffi.Bool> arg3,
-  ) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            NSRange arg1,
-            NSRange arg2,
-            ffi.Pointer<ffi.Bool> arg3,
+  ) {
+    final _$$ref = arg0?.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              NSRange arg1,
+              NSRange arg2,
+              ffi.Pointer<ffi.Bool> arg3,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            NSRange,
+            NSRange,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          NSRange,
-          NSRange,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr, arg1, arg2, arg3);
+        >()(ref.pointer, _$$ref?.pointer ?? ffi.nullptr, arg1, arg2, arg3);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(NSString, ffi.Pointer<ffi.Bool>)>`.
@@ -28196,12 +29686,12 @@ abstract final class ObjCBlock_ffiVoid_NSString_bool {
     void Function(NSString, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(NSString, ffi.Pointer<ffi.Bool>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-          fn(NSString.fromPointer(arg0, retain: true, release: true), arg1),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(NSString.fromPointer(arg0, retain: true, release: true), arg1);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -28220,12 +29710,12 @@ abstract final class ObjCBlock_ffiVoid_NSString_bool {
     void Function(NSString, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-          fn(NSString.fromPointer(arg0, retain: false, release: true), arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(NSString.fromPointer(arg0, retain: false, release: true), arg1);
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_t8l8el(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(NSString, ffi.Pointer<ffi.Bool>)>(
@@ -28250,16 +29740,20 @@ abstract final class ObjCBlock_ffiVoid_NSString_bool {
     void Function(NSString, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-          fn(NSString.fromPointer(arg0, retain: false, release: true), arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(NSString.fromPointer(arg0, retain: false, release: true), arg1);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-          fn(NSString.fromPointer(arg0, retain: false, release: true), arg1),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) {
+        return fn(
+          NSString.fromPointer(arg0, retain: false, release: true),
+          arg1,
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_t8l8el(
@@ -28409,23 +29903,26 @@ abstract final class ObjCBlock_ffiVoid_NSString_bool {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(NSString, ffi.Pointer<ffi.Bool>)>`.
 extension ObjCBlock_ffiVoid_NSString_bool$CallExtension
     on objc.ObjCBlock<ffi.Void Function(NSString, ffi.Pointer<ffi.Bool>)> {
-  void call(NSString arg0, ffi.Pointer<ffi.Bool> arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<ffi.Bool> arg1,
+  void call(NSString arg0, ffi.Pointer<ffi.Bool> arg1) {
+    final _$$ref = arg0.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<ffi.Bool> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0.ref.pointer, arg1);
+        >()(ref.pointer, _$$ref.pointer, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(NSTimer)>`.
@@ -28471,12 +29968,11 @@ abstract final class ObjCBlock_ffiVoid_NSTimer {
     void Function(NSTimer) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(NSTimer)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(NSTimer.fromPointer(arg0, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(NSTimer.fromPointer(arg0, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -28494,12 +29990,11 @@ abstract final class ObjCBlock_ffiVoid_NSTimer {
     void Function(NSTimer) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(NSTimer.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(NSTimer.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_xtuoz7(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(NSTimer)>(
@@ -28523,16 +30018,16 @@ abstract final class ObjCBlock_ffiVoid_NSTimer {
     void Function(NSTimer) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(NSTimer.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(NSTimer.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(NSTimer.fromPointer(arg0, retain: false, release: true)),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0) {
+        return fn(NSTimer.fromPointer(arg0, retain: false, release: true));
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_xtuoz7(
@@ -28656,21 +30151,24 @@ abstract final class ObjCBlock_ffiVoid_NSTimer {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(NSTimer)>`.
 extension ObjCBlock_ffiVoid_NSTimer$CallExtension
     on objc.ObjCBlock<ffi.Void Function(NSTimer)> {
-  void call(NSTimer arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  void call(NSTimer arg0) {
+    final _$$ref = arg0.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, _$$ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)>`.
@@ -28730,11 +30228,12 @@ abstract final class ObjCBlock_ffiVoid_NSUInteger_bool {
       objc.ObjCBlock<
         ffi.Void Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (int arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          int arg0,
+          ffi.Pointer<ffi.Bool> arg1,
+        ) {
+          return fn(arg0, arg1);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -28755,11 +30254,12 @@ abstract final class ObjCBlock_ffiVoid_NSUInteger_bool {
     void Function(int, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (int arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      int arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_q5jeyk(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -28784,14 +30284,17 @@ abstract final class ObjCBlock_ffiVoid_NSUInteger_bool {
     void Function(int, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (int arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      int arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (int arg0, ffi.Pointer<ffi.Bool> arg1) => fn(arg0, arg1),
+      (int arg0, ffi.Pointer<ffi.Bool> arg1) {
+        return fn(arg0, arg1);
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_q5jeyk(
@@ -28930,23 +30433,25 @@ extension ObjCBlock_ffiVoid_NSUInteger_bool$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)
         > {
-  void call(int arg0, ffi.Pointer<ffi.Bool> arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.UnsignedLong arg0,
-            ffi.Pointer<ffi.Bool> arg1,
+  void call(int arg0, ffi.Pointer<ffi.Bool> arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.UnsignedLong arg0,
+              ffi.Pointer<ffi.Bool> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            int,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          int,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0, arg1);
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(NSURL?, NSError?)>`.
@@ -28996,21 +30501,19 @@ abstract final class ObjCBlock_ffiVoid_NSURL_NSError {
     void Function(NSURL?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(NSURL?, NSError?)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSURL.fromPointer(arg0, retain: true, release: true),
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -29028,21 +30531,19 @@ abstract final class ObjCBlock_ffiVoid_NSURL_NSError {
     void Function(NSURL?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSURL.fromPointer(arg0, retain: false, release: true),
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_pfv6jd(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(NSURL?, NSError?)>(
@@ -29066,34 +30567,34 @@ abstract final class ObjCBlock_ffiVoid_NSURL_NSError {
     void Function(NSURL?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSURL.fromPointer(arg0, retain: false, release: true),
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
       (
         ffi.Pointer<objc.ObjCObjectImpl> arg0,
         ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
-        arg0.address == 0
-            ? null
-            : NSURL.fromPointer(arg0, retain: false, release: true),
-        arg1.address == 0
-            ? null
-            : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
+      ) {
+        return fn(
+          arg0.address == 0
+              ? null
+              : NSURL.fromPointer(arg0, retain: false, release: true),
+          arg1.address == 0
+              ? null
+              : NSError.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_pfv6jd(
@@ -29246,28 +30747,31 @@ abstract final class ObjCBlock_ffiVoid_NSURL_NSError {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(NSURL?, NSError?)>`.
 extension ObjCBlock_ffiVoid_NSURL_NSError$CallExtension
     on objc.ObjCBlock<ffi.Void Function(NSURL?, NSError?)> {
-  void call(NSURL? arg0, NSError? arg1) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                ffi.Pointer<objc.ObjCObjectImpl> arg1,
-              )
-            >
-          >()
-          .asFunction<
-            void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
+  void call(NSURL? arg0, NSError? arg1) {
+    final _$$ref = arg0?.ref;
+    final _$$ref$1 = arg1?.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
             )
-          >()(
-        ref.pointer,
-        arg0?.ref.pointer ?? ffi.nullptr,
-        arg1?.ref.pointer ?? ffi.nullptr,
-      );
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+          )
+        >()(
+      ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)>`.
@@ -29320,13 +30824,12 @@ abstract final class ObjCBlock_ffiVoid_NSURL_bool_NSError {
     void Function(NSURL?, bool, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        bool arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-      ) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      bool arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSURL.fromPointer(arg0, retain: true, release: true),
@@ -29334,9 +30837,8 @@ abstract final class ObjCBlock_ffiVoid_NSURL_bool_NSError {
         arg2.address == 0
             ? null
             : NSError.fromPointer(arg2, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -29354,13 +30856,12 @@ abstract final class ObjCBlock_ffiVoid_NSURL_bool_NSError {
     void Function(NSURL?, bool, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        bool arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      bool arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSURL.fromPointer(arg0, retain: false, release: true),
@@ -29368,9 +30869,8 @@ abstract final class ObjCBlock_ffiVoid_NSURL_bool_NSError {
         arg2.address == 0
             ? null
             : NSError.fromPointer(arg2, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_rnu2c5(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)>(
@@ -29394,13 +30894,12 @@ abstract final class ObjCBlock_ffiVoid_NSURL_bool_NSError {
     void Function(NSURL?, bool, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        bool arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      bool arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSURL.fromPointer(arg0, retain: false, release: true),
@@ -29408,26 +30907,24 @@ abstract final class ObjCBlock_ffiVoid_NSURL_bool_NSError {
         arg2.address == 0
             ? null
             : NSError.fromPointer(arg2, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
-    final rawListener = objc.newClosureBlock(
-      _blockingListenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        bool arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-      ) => fn(
-        arg0.address == 0
-            ? null
-            : NSURL.fromPointer(arg0, retain: false, release: true),
-        arg1,
-        arg2.address == 0
-            ? null
-            : NSError.fromPointer(arg2, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
+    final rawListener = objc
+        .newClosureBlock(_blockingListenerCallable.nativeFunction.cast(), (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          bool arg1,
+          ffi.Pointer<objc.ObjCObjectImpl> arg2,
+        ) {
+          return fn(
+            arg0.address == 0
+                ? null
+                : NSURL.fromPointer(arg0, retain: false, release: true),
+            arg1,
+            arg2.address == 0
+                ? null
+                : NSError.fromPointer(arg2, retain: false, release: true),
+          );
+        }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapBlockingBlock_rnu2c5(
       raw,
       rawListener,
@@ -29595,31 +31092,34 @@ abstract final class ObjCBlock_ffiVoid_NSURL_bool_NSError {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)>`.
 extension ObjCBlock_ffiVoid_NSURL_bool_NSError$CallExtension
     on objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)> {
-  void call(NSURL? arg0, bool arg1, NSError? arg2) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                ffi.Bool arg1,
-                ffi.Pointer<objc.ObjCObjectImpl> arg2,
-              )
-            >
-          >()
-          .asFunction<
-            void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              bool,
-              ffi.Pointer<objc.ObjCObjectImpl>,
+  void call(NSURL? arg0, bool arg1, NSError? arg2) {
+    final _$$ref = arg0?.ref;
+    final _$$ref$1 = arg2?.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Bool arg1,
+              ffi.Pointer<objc.ObjCObjectImpl> arg2,
             )
-          >()(
-        ref.pointer,
-        arg0?.ref.pointer ?? ffi.nullptr,
-        arg1,
-        arg2?.ref.pointer ?? ffi.nullptr,
-      );
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            bool,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+          )
+        >()(
+      ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      arg1,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>, ffi.Pointer<ffi.Bool>)>`.
@@ -29691,12 +31191,12 @@ abstract final class ObjCBlock_ffiVoid_ObjectType_bool {
           ffi.Pointer<ffi.Bool>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-              fn(objc.ObjCObject(arg0, retain: true, release: true), arg1),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<ffi.Bool> arg1,
+        ) {
+          return fn(objc.ObjCObject(arg0, retain: true, release: true), arg1);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -29717,12 +31217,12 @@ abstract final class ObjCBlock_ffiVoid_ObjectType_bool {
     void Function(objc.ObjCObject, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-          fn(objc.ObjCObject(arg0, retain: false, release: true), arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(objc.ObjCObject(arg0, retain: false, release: true), arg1);
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_t8l8el(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -29747,16 +31247,17 @@ abstract final class ObjCBlock_ffiVoid_ObjectType_bool {
     void Function(objc.ObjCObject, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-          fn(objc.ObjCObject(arg0, retain: false, release: true), arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<ffi.Bool> arg1,
+    ) {
+      return fn(objc.ObjCObject(arg0, retain: false, release: true), arg1);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) =>
-          fn(objc.ObjCObject(arg0, retain: false, release: true), arg1),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0, ffi.Pointer<ffi.Bool> arg1) {
+        return fn(objc.ObjCObject(arg0, retain: false, release: true), arg1);
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_t8l8el(
@@ -29910,26 +31411,26 @@ extension ObjCBlock_ffiVoid_ObjectType_bool$CallExtension
             ffi.Pointer<ffi.Bool>,
           )
         > {
-  void call(objc.ObjCObject arg0, ffi.Pointer<ffi.Bool> arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<ffi.Bool> arg1,
+  void call(objc.ObjCObject arg0, ffi.Pointer<ffi.Bool> arg1) {
+    final _$$ref = arg0.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<ffi.Bool> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0.ref.pointer, arg1);
+        >()(ref.pointer, _$$ref.pointer, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>)>`.
@@ -29974,11 +31475,9 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid {
     void Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+      return fn(arg0);
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -29996,11 +31495,11 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid {
     void Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_ovsamd(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>)>(
@@ -30024,14 +31523,16 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid {
     void Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+    ) {
+      return fn(arg0);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
+      (ffi.Pointer<ffi.Void> arg0) {
+        return fn(arg0);
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_ovsamd(
@@ -30148,18 +31649,20 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>)>`.
 extension ObjCBlock_ffiVoid_ffiVoid$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>)> {
-  void call(ffi.Pointer<ffi.Void> arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-          )
-        >
-      >()
-      .asFunction<
-        void Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)
-      >()(ref.pointer, arg0);
+  void call(ffi.Pointer<ffi.Void> arg0) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)
+        >()(ref.pointer, arg0);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSCoder)>`.
@@ -30211,12 +31714,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSCoder {
     void Function(ffi.Pointer<ffi.Void>, NSCoder) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSCoder)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, NSCoder.fromPointer(arg1, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(arg0, NSCoder.fromPointer(arg1, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -30235,12 +31738,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSCoder {
     void Function(ffi.Pointer<ffi.Void>, NSCoder) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, NSCoder.fromPointer(arg1, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(arg0, NSCoder.fromPointer(arg1, retain: false, release: true));
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_18v1jvf(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSCoder)>(
@@ -30265,16 +31768,20 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSCoder {
     void Function(ffi.Pointer<ffi.Void>, NSCoder) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, NSCoder.fromPointer(arg1, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(arg0, NSCoder.fromPointer(arg1, retain: false, release: true));
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-          fn(arg0, NSCoder.fromPointer(arg1, retain: false, release: true)),
+      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) {
+        return fn(
+          arg0,
+          NSCoder.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_18v1jvf(
@@ -30424,23 +31931,26 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSCoder {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSCoder)>`.
 extension ObjCBlock_ffiVoid_ffiVoid_NSCoder$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSCoder)> {
-  void call(ffi.Pointer<ffi.Void> arg0, NSCoder arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  void call(ffi.Pointer<ffi.Void> arg0, NSCoder arg1) {
+    final _$$ref = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0, arg1.ref.pointer);
+        >()(ref.pointer, arg0, _$$ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSPortMessage)>`.
@@ -30492,14 +32002,15 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSPortMessage {
     void Function(ffi.Pointer<ffi.Void>, NSPortMessage) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSPortMessage)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0,
         NSPortMessage.fromPointer(arg1, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -30518,14 +32029,15 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSPortMessage {
     void Function(ffi.Pointer<ffi.Void>, NSPortMessage) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0,
         NSPortMessage.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_18v1jvf(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -30548,20 +32060,23 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSPortMessage {
     void Function(ffi.Pointer<ffi.Void>, NSPortMessage) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0,
         NSPortMessage.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
-        arg0,
-        NSPortMessage.fromPointer(arg1, retain: false, release: true),
-      ),
+      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) {
+        return fn(
+          arg0,
+          NSPortMessage.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_18v1jvf(
@@ -30709,26 +32224,26 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSPortMessage {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSPortMessage)>`.
 extension ObjCBlock_ffiVoid_ffiVoid_NSPortMessage$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSPortMessage)> {
-  void call(ffi.Pointer<ffi.Void> arg0, NSPortMessage arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  void call(ffi.Pointer<ffi.Void> arg0, NSPortMessage arg1) {
+    final _$$ref = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0, arg1.ref.pointer);
+        >()(ref.pointer, arg0, _$$ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSRange, ffi.Pointer<ffi.Bool>)>`.
@@ -30792,15 +32307,13 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSRange_bool {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<ffi.Void>, NSRange, ffi.Pointer<ffi.Bool>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            NSRange arg1,
-            ffi.Pointer<ffi.Bool> arg2,
-          ) => fn(arg0, arg1, arg2),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          NSRange arg1,
+          ffi.Pointer<ffi.Bool> arg2,
+        ) {
+          return fn(arg0, arg1, arg2);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -30821,12 +32334,13 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSRange_bool {
     void Function(ffi.Pointer<ffi.Void>, NSRange, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, NSRange arg1, ffi.Pointer<ffi.Bool> arg2) =>
-          fn(arg0, arg1, arg2),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      NSRange arg1,
+      ffi.Pointer<ffi.Bool> arg2,
+    ) {
+      return fn(arg0, arg1, arg2);
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_1q8ia8l(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -30851,16 +32365,18 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSRange_bool {
     void Function(ffi.Pointer<ffi.Void>, NSRange, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, NSRange arg1, ffi.Pointer<ffi.Bool> arg2) =>
-          fn(arg0, arg1, arg2),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      NSRange arg1,
+      ffi.Pointer<ffi.Bool> arg2,
+    ) {
+      return fn(arg0, arg1, arg2);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, NSRange arg1, ffi.Pointer<ffi.Bool> arg2) =>
-          fn(arg0, arg1, arg2),
+      (ffi.Pointer<ffi.Void> arg0, NSRange arg1, ffi.Pointer<ffi.Bool> arg2) {
+        return fn(arg0, arg1, arg2);
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_1q8ia8l(
@@ -31035,25 +32551,27 @@ extension ObjCBlock_ffiVoid_ffiVoid_NSRange_bool$CallExtension
     ffi.Pointer<ffi.Void> arg0,
     NSRange arg1,
     ffi.Pointer<ffi.Bool> arg2,
-  ) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            NSRange arg1,
-            ffi.Pointer<ffi.Bool> arg2,
+  ) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              NSRange arg1,
+              ffi.Pointer<ffi.Bool> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            NSRange,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          NSRange,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0, arg1, arg2);
+        >()(ref.pointer, arg0, arg1, arg2);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSStream, ffi.UnsignedLong)>`.
@@ -31117,19 +32635,17 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSStream_NSStreamEvent {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<ffi.Void>, NSStream, ffi.UnsignedLong)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            int arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          int arg2,
+        ) {
+          return fn(
             arg0,
             NSStream.fromPointer(arg1, retain: true, release: true),
             arg2,
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -31150,19 +32666,17 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSStream_NSStreamEvent {
     void Function(ffi.Pointer<ffi.Void>, NSStream, int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<ffi.Void> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        int arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      int arg2,
+    ) {
+      return fn(
         arg0,
         NSStream.fromPointer(arg1, retain: false, release: true),
         arg2,
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_hoampi(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -31187,30 +32701,30 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSStream_NSStreamEvent {
     void Function(ffi.Pointer<ffi.Void>, NSStream, int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<ffi.Void> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        int arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      int arg2,
+    ) {
+      return fn(
         arg0,
         NSStream.fromPointer(arg1, retain: false, release: true),
         arg2,
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
       (
         ffi.Pointer<ffi.Void> arg0,
         ffi.Pointer<objc.ObjCObjectImpl> arg1,
         int arg2,
-      ) => fn(
-        arg0,
-        NSStream.fromPointer(arg1, retain: false, release: true),
-        arg2,
-      ),
+      ) {
+        return fn(
+          arg0,
+          NSStream.fromPointer(arg1, retain: false, release: true),
+          arg2,
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_hoampi(
@@ -31381,28 +32895,28 @@ extension ObjCBlock_ffiVoid_ffiVoid_NSStream_NSStreamEvent$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<ffi.Void>, NSStream, ffi.UnsignedLong)
         > {
-  void call(ffi.Pointer<ffi.Void> arg0, NSStream arg1, int arg2) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.UnsignedLong arg2,
+  void call(ffi.Pointer<ffi.Void> arg0, NSStream arg1, int arg2) {
+    final _$$ref = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+              ffi.UnsignedLong arg2,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            int,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          int,
-        )
-      >()(ref.pointer, arg0, arg1.ref.pointer, arg2);
+        >()(ref.pointer, arg0, _$$ref.pointer, arg2);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSString, ffi.Pointer<objc.ObjCObjectImpl>, NSDictionary, ffi.Pointer<ffi.Void>)>`.
@@ -31511,23 +33025,21 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_objcObjCObjectImpl_NSDic
           ffi.Pointer<ffi.Void>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<objc.ObjCObjectImpl> arg2,
-            ffi.Pointer<objc.ObjCObjectImpl> arg3,
-            ffi.Pointer<ffi.Void> arg4,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<objc.ObjCObjectImpl> arg2,
+          ffi.Pointer<objc.ObjCObjectImpl> arg3,
+          ffi.Pointer<ffi.Void> arg4,
+        ) {
+          return fn(
             arg0,
             NSString.fromPointer(arg1, retain: true, release: true),
             objc.ObjCObject(arg2, retain: true, release: true),
             NSDictionary.fromPointer(arg3, retain: true, release: true),
             arg4,
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -31561,23 +33073,21 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_objcObjCObjectImpl_NSDic
     fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<ffi.Void> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-        ffi.Pointer<objc.ObjCObjectImpl> arg3,
-        ffi.Pointer<ffi.Void> arg4,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+      ffi.Pointer<objc.ObjCObjectImpl> arg3,
+      ffi.Pointer<ffi.Void> arg4,
+    ) {
+      return fn(
         arg0,
         NSString.fromPointer(arg1, retain: false, release: true),
         objc.ObjCObject(arg2, retain: false, release: true),
         NSDictionary.fromPointer(arg3, retain: false, release: true),
         arg4,
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_1sr3ozv(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -31621,40 +33131,37 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_objcObjCObjectImpl_NSDic
     fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<ffi.Void> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-        ffi.Pointer<objc.ObjCObjectImpl> arg3,
-        ffi.Pointer<ffi.Void> arg4,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      ffi.Pointer<objc.ObjCObjectImpl> arg2,
+      ffi.Pointer<objc.ObjCObjectImpl> arg3,
+      ffi.Pointer<ffi.Void> arg4,
+    ) {
+      return fn(
         arg0,
         NSString.fromPointer(arg1, retain: false, release: true),
         objc.ObjCObject(arg2, retain: false, release: true),
         NSDictionary.fromPointer(arg3, retain: false, release: true),
         arg4,
-      ),
-      keepIsolateAlive,
-    );
-    final rawListener = objc.newClosureBlock(
-      _blockingListenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<ffi.Void> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCObjectImpl> arg2,
-        ffi.Pointer<objc.ObjCObjectImpl> arg3,
-        ffi.Pointer<ffi.Void> arg4,
-      ) => fn(
-        arg0,
-        NSString.fromPointer(arg1, retain: false, release: true),
-        objc.ObjCObject(arg2, retain: false, release: true),
-        NSDictionary.fromPointer(arg3, retain: false, release: true),
-        arg4,
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
+    final rawListener = objc
+        .newClosureBlock(_blockingListenerCallable.nativeFunction.cast(), (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<objc.ObjCObjectImpl> arg2,
+          ffi.Pointer<objc.ObjCObjectImpl> arg3,
+          ffi.Pointer<ffi.Void> arg4,
+        ) {
+          return fn(
+            arg0,
+            NSString.fromPointer(arg1, retain: false, release: true),
+            objc.ObjCObject(arg2, retain: false, release: true),
+            NSDictionary.fromPointer(arg3, retain: false, release: true),
+            arg4,
+          );
+        }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapBlockingBlock_1sr3ozv(
       raw,
       rawListener,
@@ -31875,37 +33382,41 @@ extension ObjCBlock_ffiVoid_ffiVoid_NSString_objcObjCObjectImpl_NSDictionary_ffi
     objc.ObjCObject arg2,
     NSDictionary arg3,
     ffi.Pointer<ffi.Void> arg4,
-  ) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Pointer<ffi.Void> arg0,
-                ffi.Pointer<objc.ObjCObjectImpl> arg1,
-                ffi.Pointer<objc.ObjCObjectImpl> arg2,
-                ffi.Pointer<objc.ObjCObjectImpl> arg3,
-                ffi.Pointer<ffi.Void> arg4,
-              )
-            >
-          >()
-          .asFunction<
-            void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<ffi.Void>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              ffi.Pointer<ffi.Void>,
+  ) {
+    final _$$ref = arg1.ref;
+    final _$$ref$1 = arg2.ref;
+    final _$$ref$2 = arg3.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+              ffi.Pointer<objc.ObjCObjectImpl> arg2,
+              ffi.Pointer<objc.ObjCObjectImpl> arg3,
+              ffi.Pointer<ffi.Void> arg4,
             )
-          >()(
-        ref.pointer,
-        arg0,
-        arg1.ref.pointer,
-        arg2.ref.pointer,
-        arg3.ref.pointer,
-        arg4,
-      );
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<ffi.Void>,
+          )
+        >()(
+      ref.pointer,
+      arg0,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
+      arg4,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.UnsignedLong)>`.
@@ -31965,11 +33476,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSUInteger {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.UnsignedLong)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, int arg1) => fn(arg0, arg1),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          int arg1,
+        ) {
+          return fn(arg0, arg1);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -31990,11 +33502,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSUInteger {
     void Function(ffi.Pointer<ffi.Void>, int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, int arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_zuf90e(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -32019,14 +33532,17 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSUInteger {
     void Function(ffi.Pointer<ffi.Void>, int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, int arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, int arg1) => fn(arg0, arg1),
+      (ffi.Pointer<ffi.Void> arg0, int arg1) {
+        return fn(arg0, arg1);
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_zuf90e(
@@ -32165,23 +33681,25 @@ extension ObjCBlock_ffiVoid_ffiVoid_NSUInteger$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.UnsignedLong)
         > {
-  void call(ffi.Pointer<ffi.Void> arg0, int arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.UnsignedLong arg1,
+  void call(ffi.Pointer<ffi.Void> arg0, int arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.UnsignedLong arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            int,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          int,
-        )
-      >()(ref.pointer, arg0, arg1);
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError?)>`.
@@ -32244,12 +33762,11 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderReading_NSError {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError?)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          return fn(
             arg0.address == 0
                 ? null
                 : NSItemProviderReading.fromPointer(
@@ -32260,9 +33777,8 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderReading_NSError {
             arg1.address == 0
                 ? null
                 : NSError.fromPointer(arg1, retain: true, release: true),
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -32283,12 +33799,11 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderReading_NSError {
     void Function(NSItemProviderReading?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSItemProviderReading.fromPointer(
@@ -32299,9 +33814,8 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderReading_NSError {
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_pfv6jd(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -32326,12 +33840,11 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderReading_NSError {
     void Function(NSItemProviderReading?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSItemProviderReading.fromPointer(
@@ -32342,26 +33855,27 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderReading_NSError {
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
       (
         ffi.Pointer<objc.ObjCObjectImpl> arg0,
         ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
-        arg0.address == 0
-            ? null
-            : NSItemProviderReading.fromPointer(
-                arg0,
-                retain: false,
-                release: true,
-              ),
-        arg1.address == 0
-            ? null
-            : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
+      ) {
+        return fn(
+          arg0.address == 0
+              ? null
+              : NSItemProviderReading.fromPointer(
+                  arg0,
+                  retain: false,
+                  release: true,
+                ),
+          arg1.address == 0
+              ? null
+              : NSError.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_pfv6jd(
@@ -32515,28 +34029,31 @@ extension ObjCBlock_ffiVoid_idNSItemProviderReading_NSError$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError?)
         > {
-  void call(NSItemProviderReading? arg0, NSError? arg1) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                ffi.Pointer<objc.ObjCObjectImpl> arg1,
-              )
-            >
-          >()
-          .asFunction<
-            void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
+  void call(NSItemProviderReading? arg0, NSError? arg1) {
+    final _$$ref = arg0?.ref;
+    final _$$ref$1 = arg1?.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
             )
-          >()(
-        ref.pointer,
-        arg0?.ref.pointer ?? ffi.nullptr,
-        arg1?.ref.pointer ?? ffi.nullptr,
-      );
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+          )
+        >()(
+      ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError?)>`.
@@ -32599,12 +34116,11 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError?)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          return fn(
             arg0.address == 0
                 ? null
                 : NSItemProviderWriting.fromPointer(
@@ -32615,9 +34131,8 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError {
             arg1.address == 0
                 ? null
                 : NSError.fromPointer(arg1, retain: true, release: true),
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -32638,12 +34153,11 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError {
     void Function(NSItemProviderWriting?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSItemProviderWriting.fromPointer(
@@ -32654,9 +34168,8 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError {
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_pfv6jd(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -32681,12 +34194,11 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError {
     void Function(NSItemProviderWriting?, NSError?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSItemProviderWriting.fromPointer(
@@ -32697,26 +34209,27 @@ abstract final class ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError {
         arg1.address == 0
             ? null
             : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
       (
         ffi.Pointer<objc.ObjCObjectImpl> arg0,
         ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
-        arg0.address == 0
-            ? null
-            : NSItemProviderWriting.fromPointer(
-                arg0,
-                retain: false,
-                release: true,
-              ),
-        arg1.address == 0
-            ? null
-            : NSError.fromPointer(arg1, retain: false, release: true),
-      ),
+      ) {
+        return fn(
+          arg0.address == 0
+              ? null
+              : NSItemProviderWriting.fromPointer(
+                  arg0,
+                  retain: false,
+                  release: true,
+                ),
+          arg1.address == 0
+              ? null
+              : NSError.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_pfv6jd(
@@ -32870,28 +34383,31 @@ extension ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError?)
         > {
-  void call(NSItemProviderWriting? arg0, NSError? arg1) =>
-      ref.pointer.ref.invoke
-          .cast<
-            ffi.NativeFunction<
-              ffi.Void Function(
-                ffi.Pointer<objc.ObjCBlockImpl> block,
-                ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                ffi.Pointer<objc.ObjCObjectImpl> arg1,
-              )
-            >
-          >()
-          .asFunction<
-            void Function(
-              ffi.Pointer<objc.ObjCBlockImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
-              ffi.Pointer<objc.ObjCObjectImpl>,
+  void call(NSItemProviderWriting? arg0, NSError? arg1) {
+    final _$$ref = arg0?.ref;
+    final _$$ref$1 = arg1?.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
             )
-          >()(
-        ref.pointer,
-        arg0?.ref.pointer ?? ffi.nullptr,
-        arg1?.ref.pointer ?? ffi.nullptr,
-      );
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+          )
+        >()(
+      ref.pointer,
+      _$$ref?.pointer ?? ffi.nullptr,
+      _$$ref$1?.pointer ?? ffi.nullptr,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError)>`.
@@ -32954,19 +34470,17 @@ abstract final class ObjCBlock_ffiVoid_idNSSecureCoding_NSError {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          return fn(
             arg0.address == 0
                 ? null
                 : NSSecureCoding.fromPointer(arg0, retain: true, release: true),
             NSError.fromPointer(arg1, retain: true, release: true),
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -32987,19 +34501,17 @@ abstract final class ObjCBlock_ffiVoid_idNSSecureCoding_NSError {
     void Function(NSSecureCoding?, NSError) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSSecureCoding.fromPointer(arg0, retain: false, release: true),
         NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_pfv6jd(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -33024,30 +34536,30 @@ abstract final class ObjCBlock_ffiVoid_idNSSecureCoding_NSError {
     void Function(NSSecureCoding?, NSError) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : NSSecureCoding.fromPointer(arg0, retain: false, release: true),
         NSError.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
       (
         ffi.Pointer<objc.ObjCObjectImpl> arg0,
         ffi.Pointer<objc.ObjCObjectImpl> arg1,
-      ) => fn(
-        arg0.address == 0
-            ? null
-            : NSSecureCoding.fromPointer(arg0, retain: false, release: true),
-        NSError.fromPointer(arg1, retain: false, release: true),
-      ),
+      ) {
+        return fn(
+          arg0.address == 0
+              ? null
+              : NSSecureCoding.fromPointer(arg0, retain: false, release: true),
+          NSError.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_pfv6jd(
@@ -33201,23 +34713,27 @@ extension ObjCBlock_ffiVoid_idNSSecureCoding_NSError$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>?, NSError)
         > {
-  void call(NSSecureCoding? arg0, NSError arg1) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  void call(NSSecureCoding? arg0, NSError arg1) {
+    final _$$ref = arg0?.ref;
+    final _$$ref$1 = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr, arg1.ref.pointer);
+        >()(ref.pointer, _$$ref?.pointer ?? ffi.nullptr, _$$ref$1.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObjectImpl>, ffi.UnsignedLong, ffi.Pointer<ffi.Bool>)>`.
@@ -33305,19 +34821,17 @@ abstract final class ObjCBlock_ffiVoid_objcObjCObjectImpl_ffiUnsignedLong_bool {
           ffi.Pointer<ffi.Bool>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            int arg1,
-            ffi.Pointer<ffi.Bool> arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          int arg1,
+          ffi.Pointer<ffi.Bool> arg2,
+        ) {
+          return fn(
             objc.ObjCObject(arg0, retain: true, release: true),
             arg1,
             arg2,
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -33342,15 +34856,17 @@ abstract final class ObjCBlock_ffiVoid_objcObjCObjectImpl_ffiUnsignedLong_bool {
     void Function(objc.ObjCObject, int, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        int arg1,
-        ffi.Pointer<ffi.Bool> arg2,
-      ) => fn(objc.ObjCObject(arg0, retain: false, release: true), arg1, arg2),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      int arg1,
+      ffi.Pointer<ffi.Bool> arg2,
+    ) {
+      return fn(
+        objc.ObjCObject(arg0, retain: false, release: true),
+        arg1,
+        arg2,
+      );
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_1p9ui4q(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -33383,22 +34899,30 @@ abstract final class ObjCBlock_ffiVoid_objcObjCObjectImpl_ffiUnsignedLong_bool {
     void Function(objc.ObjCObject, int, ffi.Pointer<ffi.Bool>) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<objc.ObjCObjectImpl> arg0,
-        int arg1,
-        ffi.Pointer<ffi.Bool> arg2,
-      ) => fn(objc.ObjCObject(arg0, retain: false, release: true), arg1, arg2),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+      int arg1,
+      ffi.Pointer<ffi.Bool> arg2,
+    ) {
+      return fn(
+        objc.ObjCObject(arg0, retain: false, release: true),
+        arg1,
+        arg2,
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
       (
         ffi.Pointer<objc.ObjCObjectImpl> arg0,
         int arg1,
         ffi.Pointer<ffi.Bool> arg2,
-      ) => fn(objc.ObjCObject(arg0, retain: false, release: true), arg1, arg2),
+      ) {
+        return fn(
+          objc.ObjCObject(arg0, retain: false, release: true),
+          arg1,
+          arg2,
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_1p9ui4q(
@@ -33577,28 +35101,28 @@ extension ObjCBlock_ffiVoid_objcObjCObjectImpl_ffiUnsignedLong_bool$CallExtensio
             ffi.Pointer<ffi.Bool>,
           )
         > {
-  void call(objc.ObjCObject arg0, int arg1, ffi.Pointer<ffi.Bool> arg2) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.UnsignedLong arg1,
-            ffi.Pointer<ffi.Bool> arg2,
+  void call(objc.ObjCObject arg0, int arg1, ffi.Pointer<ffi.Bool> arg2) {
+    final _$$ref = arg0.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+              ffi.UnsignedLong arg1,
+              ffi.Pointer<ffi.Bool> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            int,
+            ffi.Pointer<ffi.Bool>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          int,
-          ffi.Pointer<ffi.Bool>,
-        )
-      >()(ref.pointer, arg0.ref.pointer, arg1, arg2);
+        >()(ref.pointer, _$$ref.pointer, arg1, arg2);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.UnsignedShort>, ffi.UnsignedLong)>`.
@@ -33661,11 +35185,12 @@ abstract final class ObjCBlock_ffiVoid_unichar_NSUInteger {
       objc.ObjCBlock<
         ffi.Void Function(ffi.Pointer<ffi.UnsignedShort>, ffi.UnsignedLong)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.UnsignedShort> arg0, int arg1) => fn(arg0, arg1),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.UnsignedShort> arg0,
+          int arg1,
+        ) {
+          return fn(arg0, arg1);
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -33686,11 +35211,12 @@ abstract final class ObjCBlock_ffiVoid_unichar_NSUInteger {
     void Function(ffi.Pointer<ffi.UnsignedShort>, int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.UnsignedShort> arg0, int arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.UnsignedShort> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final wrapper = _1wx624s_wrapListenerBlock_vhbh5h(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -33715,14 +35241,17 @@ abstract final class ObjCBlock_ffiVoid_unichar_NSUInteger {
     void Function(ffi.Pointer<ffi.UnsignedShort>, int) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.UnsignedShort> arg0, int arg1) => fn(arg0, arg1),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.UnsignedShort> arg0,
+      int arg1,
+    ) {
+      return fn(arg0, arg1);
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.UnsignedShort> arg0, int arg1) => fn(arg0, arg1),
+      (ffi.Pointer<ffi.UnsignedShort> arg0, int arg1) {
+        return fn(arg0, arg1);
+      },
       keepIsolateAlive,
     );
     final wrapper = _1wx624s_wrapBlockingBlock_vhbh5h(
@@ -33866,26 +35395,25 @@ extension ObjCBlock_ffiVoid_unichar_NSUInteger$CallExtension
         objc.ObjCBlock<
           ffi.Void Function(ffi.Pointer<ffi.UnsignedShort>, ffi.UnsignedLong)
         > {
-  void call(ffi.Pointer<ffi.UnsignedShort> arg0, int arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.UnsignedShort> arg0,
-            ffi.UnsignedLong arg1,
+  void call(ffi.Pointer<ffi.UnsignedShort> arg0, int arg1) {
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.UnsignedShort> arg0,
+              ffi.UnsignedLong arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.UnsignedShort>,
+            int,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.UnsignedShort>,
-          int,
-        )
-      >()(ref.pointer, arg0, arg1);
+        >()(ref.pointer, arg0, arg1);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<objc.Retained<ffi.Pointer<objc.ObjCObjectImpl>?> Function(ffi.Pointer<ffi.Void>, NSCoder)>`.
@@ -33970,11 +35498,11 @@ abstract final class ObjCBlock_instancetype_ffiVoid_NSCoder {
           ffi.Pointer<ffi.Void> arg0,
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
         ) {
-          final _$nullableObj = fn(
+          final _$$ref = fn(
             arg0,
             NSCoder.fromPointer(arg1, retain: true, release: true),
-          );
-          return _$nullableObj?.ref.retainAndReturnPointer() ?? ffi.nullptr;
+          )?.ref;
+          return _$$ref?.retainAndReturnPointer() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -34038,48 +35566,50 @@ extension ObjCBlock_instancetype_ffiVoid_NSCoder$CallExtension
             NSCoder,
           )
         > {
-  Dartinstancetype? call(ffi.Pointer<ffi.Void> arg0, NSCoder arg1) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  Dartinstancetype? call(ffi.Pointer<ffi.Void> arg0, NSCoder arg1) {
+    final _$$ref$1 = arg1.ref;
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    instancetype Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<ffi.Void> arg0,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                    )
+                  >
+                >()
+                .asFunction<
                   instancetype Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<ffi.Void> arg0,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<ffi.Void>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                instancetype Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<ffi.Void>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0, arg1.ref.pointer)
-              .address ==
-          0
-      ? null
-      : objc.ObjCObject(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, arg0, _$$ref$1.pointer)
+                .address ==
+            0
+        ? null
+        : objc.ObjCObject(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    instancetype Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<ffi.Void> arg0,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                    )
+                  >
+                >()
+                .asFunction<
                   instancetype Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<ffi.Void> arg0,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<ffi.Void>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                instancetype Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<ffi.Void>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0, arg1.ref.pointer),
-          retain: false,
-          release: true,
-        );
+                >()(ref.pointer, arg0, _$$ref$1.pointer),
+            retain: false,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObjectImpl>? Function(NSError, NSString)>`.
@@ -34146,11 +35676,11 @@ abstract final class ObjCBlock_objcObjCObjectImpl_NSError_NSErrorUserInfoKey {
           ffi.Pointer<objc.ObjCObjectImpl> arg0,
           ffi.Pointer<objc.ObjCObjectImpl> arg1,
         ) {
-          final _$nullableObj = fn(
+          final _$$ref = fn(
             NSError.fromPointer(arg0, retain: true, release: true),
             NSString.fromPointer(arg1, retain: true, release: true),
-          );
-          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+          )?.ref;
+          return _$$ref?.retainAndAutorelease() ?? ffi.nullptr;
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -34211,48 +35741,51 @@ extension ObjCBlock_objcObjCObjectImpl_NSError_NSErrorUserInfoKey$CallExtension
         objc.ObjCBlock<
           ffi.Pointer<objc.ObjCObjectImpl>? Function(NSError, NSString)
         > {
-  objc.ObjCObject? call(NSError arg0, NSString arg1) =>
-      ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+  objc.ObjCObject? call(NSError arg0, NSString arg1) {
+    final _$$ref$1 = arg0.ref;
+    final _$$ref$2 = arg1.ref;
+    return ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer, arg1.ref.pointer)
-              .address ==
-          0
-      ? null
-      : objc.ObjCObject(
-          ref.pointer.ref.invoke
-              .cast<
-                ffi.NativeFunction<
+                >()(ref.pointer, _$$ref$1.pointer, _$$ref$2.pointer)
+                .address ==
+            0
+        ? null
+        : objc.ObjCObject(
+            ref.pointer.ref.invoke
+                .cast<
+                  ffi.NativeFunction<
+                    ffi.Pointer<objc.ObjCObjectImpl> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+                      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                    )
+                  >
+                >()
+                .asFunction<
                   ffi.Pointer<objc.ObjCObjectImpl> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl> block,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg0,
-                    ffi.Pointer<objc.ObjCObjectImpl> arg1,
+                    ffi.Pointer<objc.ObjCBlockImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
+                    ffi.Pointer<objc.ObjCObjectImpl>,
                   )
-                >
-              >()
-              .asFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                  ffi.Pointer<objc.ObjCObjectImpl>,
-                )
-              >()(ref.pointer, arg0.ref.pointer, arg1.ref.pointer),
-          retain: true,
-          release: true,
-        );
+                >()(ref.pointer, _$$ref$1.pointer, _$$ref$2.pointer),
+            retain: true,
+            release: true,
+          );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)>`.
@@ -34313,8 +35846,8 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid {
         ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
       >(
         objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
-          final _$obj = fn(arg0);
-          return _$obj.ref.retainAndAutorelease();
+          final _$$ref = fn(arg0).ref;
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -34364,25 +35897,27 @@ extension ObjCBlock_objcObjCObjectImpl_ffiVoid$CallExtension
         objc.ObjCBlock<
           ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
         > {
-  objc.ObjCObject call(ffi.Pointer<ffi.Void> arg0) => objc.ObjCObject(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  objc.ObjCObject call(ffi.Pointer<ffi.Void> arg0) {
+    return objc.ObjCObject(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >()(ref.pointer, arg0),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<objc.Retained<ffi.Pointer<objc.ObjCObjectImpl>> Function(ffi.Pointer<ffi.Void>, ffi.Pointer<NSZone>)>`.
@@ -34467,8 +36002,8 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid_NSZone {
           ffi.Pointer<ffi.Void> arg0,
           ffi.Pointer<NSZone> arg1,
         ) {
-          final _$obj = fn(arg0, arg1);
-          return _$obj.ref.retainAndReturnPointer();
+          final _$$ref = fn(arg0, arg1).ref;
+          return _$$ref.retainAndReturnPointer();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -34532,28 +36067,29 @@ extension ObjCBlock_objcObjCObjectImpl_ffiVoid_NSZone$CallExtension
             ffi.Pointer<NSZone>,
           )
         > {
-  objc.ObjCObject call(ffi.Pointer<ffi.Void> arg0, ffi.Pointer<NSZone> arg1) =>
-      objc.ObjCObject(
-        ref.pointer.ref.invoke
-            .cast<
-              ffi.NativeFunction<
-                ffi.Pointer<objc.ObjCObjectImpl> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl> block,
-                  ffi.Pointer<ffi.Void> arg0,
-                  ffi.Pointer<NSZone> arg1,
-                )
-              >
-            >()
-            .asFunction<
+  objc.ObjCObject call(ffi.Pointer<ffi.Void> arg0, ffi.Pointer<NSZone> arg1) {
+    return objc.ObjCObject(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
               ffi.Pointer<objc.ObjCObjectImpl> Function(
-                ffi.Pointer<objc.ObjCBlockImpl>,
-                ffi.Pointer<ffi.Void>,
-                ffi.Pointer<NSZone>,
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+                ffi.Pointer<NSZone> arg1,
               )
-            >()(ref.pointer, arg0, arg1),
-        retain: false,
-        release: true,
-      );
+            >
+          >()
+          .asFunction<
+            ffi.Pointer<objc.ObjCObjectImpl> Function(
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<NSZone>,
+            )
+          >()(ref.pointer, arg0, arg1),
+      retain: false,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>, ffi.Pointer<objc.ObjCSelector>)>`.
@@ -34642,8 +36178,8 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector {
           ffi.Pointer<ffi.Void> arg0,
           ffi.Pointer<objc.ObjCSelector> arg1,
         ) {
-          final _$obj = fn(arg0, arg1);
-          return _$obj.ref.retainAndAutorelease();
+          final _$$ref = fn(arg0, arg1).ref;
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -34710,27 +36246,29 @@ extension ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector$CallExtension
   objc.ObjCObject call(
     ffi.Pointer<ffi.Void> arg0,
     ffi.Pointer<objc.ObjCSelector> arg1,
-  ) => objc.ObjCObject(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  ) {
+    return objc.ObjCObject(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+                ffi.Pointer<objc.ObjCSelector> arg1,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
-              ffi.Pointer<objc.ObjCSelector> arg1,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<objc.ObjCSelector>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<objc.ObjCSelector>,
-          )
-        >()(ref.pointer, arg0, arg1),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0, arg1),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>, ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObjectImpl>)>`.
@@ -34828,12 +36366,12 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector_objcO
           ffi.Pointer<objc.ObjCSelector> arg1,
           ffi.Pointer<objc.ObjCObjectImpl> arg2,
         ) {
-          final _$obj = fn(
+          final _$$ref = fn(
             arg0,
             arg1,
             objc.ObjCObject(arg2, retain: true, release: true),
-          );
-          return _$obj.ref.retainAndAutorelease();
+          ).ref;
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -34909,29 +36447,32 @@ extension ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector_objcObjCObjectIm
     ffi.Pointer<ffi.Void> arg0,
     ffi.Pointer<objc.ObjCSelector> arg1,
     objc.ObjCObject arg2,
-  ) => objc.ObjCObject(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  ) {
+    final _$$ref$1 = arg2.ref;
+    return objc.ObjCObject(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+                ffi.Pointer<objc.ObjCSelector> arg1,
+                ffi.Pointer<objc.ObjCObjectImpl> arg2,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
-              ffi.Pointer<objc.ObjCSelector> arg1,
-              ffi.Pointer<objc.ObjCObjectImpl> arg2,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<objc.ObjCSelector>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCObjectImpl>,
-          )
-        >()(ref.pointer, arg0, arg1, arg2.ref.pointer),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0, arg1, _$$ref$1.pointer),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>, ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObjectImpl>, ffi.Pointer<objc.ObjCObjectImpl>)>`.
@@ -35038,13 +36579,13 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector_objcO
           ffi.Pointer<objc.ObjCObjectImpl> arg2,
           ffi.Pointer<objc.ObjCObjectImpl> arg3,
         ) {
-          final _$obj = fn(
+          final _$$ref = fn(
             arg0,
             arg1,
             objc.ObjCObject(arg2, retain: true, release: true),
             objc.ObjCObject(arg3, retain: true, release: true),
-          );
-          return _$obj.ref.retainAndAutorelease();
+          ).ref;
+          return _$$ref.retainAndAutorelease();
         }, keepIsolateAlive),
         retain: false,
         release: true,
@@ -35129,31 +36670,35 @@ extension ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector_objcObjCObjectIm
     ffi.Pointer<objc.ObjCSelector> arg1,
     objc.ObjCObject arg2,
     objc.ObjCObject arg3,
-  ) => objc.ObjCObject(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
+  ) {
+    final _$$ref$1 = arg2.ref;
+    final _$$ref$2 = arg3.ref;
+    return objc.ObjCObject(
+      ref.pointer.ref.invoke
+          .cast<
+            ffi.NativeFunction<
+              ffi.Pointer<objc.ObjCObjectImpl> Function(
+                ffi.Pointer<objc.ObjCBlockImpl> block,
+                ffi.Pointer<ffi.Void> arg0,
+                ffi.Pointer<objc.ObjCSelector> arg1,
+                ffi.Pointer<objc.ObjCObjectImpl> arg2,
+                ffi.Pointer<objc.ObjCObjectImpl> arg3,
+              )
+            >
+          >()
+          .asFunction<
             ffi.Pointer<objc.ObjCObjectImpl> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
-              ffi.Pointer<objc.ObjCSelector> arg1,
-              ffi.Pointer<objc.ObjCObjectImpl> arg2,
-              ffi.Pointer<objc.ObjCObjectImpl> arg3,
+              ffi.Pointer<objc.ObjCBlockImpl>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<objc.ObjCSelector>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
+              ffi.Pointer<objc.ObjCObjectImpl>,
             )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObjectImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCObjectImpl>,
-            ffi.Pointer<objc.ObjCObjectImpl>,
-          )
-        >()(ref.pointer, arg0, arg1, arg2.ref.pointer, arg3.ref.pointer),
-    retain: true,
-    release: true,
-  );
+          >()(ref.pointer, arg0, arg1, _$$ref$1.pointer, _$$ref$2.pointer),
+      retain: true,
+      release: true,
+    );
+  }
 }
 
 /// Protocol for observing changes to values of objects.
@@ -35187,12 +36732,16 @@ extension Observer$Methods on Observer {
     required NSDictionary change,
     required ffi.Pointer<ffi.Void> context,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = keyPath.ref;
+    final _$$ref$2 = ofObject.ref;
+    final _$$ref$3 = change.ref;
     _objc_msgSend_1pl4k3n(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_observeValueForKeyPath_ofObject_change_context_,
-      keyPath.ref.pointer,
-      ofObject.ref.pointer,
-      change.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
+      _$$ref$3.pointer,
       context,
     );
   }

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -2106,8 +2106,7 @@ enum NSAttributedStringMarkdownParsingFailurePolicy {
 /// macOS: introduced 12.0.0
 extension type NSAttributedStringMarkdownParsingOptions._(
   objc.ObjCObject object$
-)
-    implements objc.ObjCObject, NSObject, NSCopying {
+) implements objc.ObjCObject, NSObject, NSCopying {
   /// Constructs a [NSAttributedStringMarkdownParsingOptions] that points to the same underlying object as [other].
   NSAttributedStringMarkdownParsingOptions.as(objc.ObjCObject other)
     : object$ = other {
@@ -22939,11 +22938,10 @@ abstract final class ObjCBlock_NSArray_ffiVoid {
     NSArray Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<NSArray Function(ffi.Pointer<ffi.Void>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+      final _$obj = fn(arg0);
+      return _$obj.ref.retainAndAutorelease();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -23380,17 +23378,18 @@ abstract final class ObjCBlock_NSOrderedCollectionChange_NSOrderedCollectionChan
       objc.ObjCBlock<
         NSOrderedCollectionChange Function(NSOrderedCollectionChange)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+        ) {
+          final _$obj = fn(
             NSOrderedCollectionChange.fromPointer(
               arg0,
               retain: true,
               release: true,
             ),
-          ).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+          );
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -23522,15 +23521,14 @@ abstract final class ObjCBlock_NSProgressUnpublishingHandler_NSProgress {
     bool keepIsolateAlive = true,
   }) =>
       objc.ObjCBlock<objc.ObjCBlock<ffi.Void Function()>? Function(NSProgress)>(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-              fn(
-                NSProgress.fromPointer(arg0, retain: true, release: true),
-              )?.ref.retainAndAutorelease() ??
-              ffi.nullptr,
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+        ) {
+          final _$nullableObj = fn(
+            NSProgress.fromPointer(arg0, retain: true, release: true),
+          );
+          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -23689,19 +23687,18 @@ abstract final class ObjCBlock_NSProgress_ffiVoidNSDataNSError {
           objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<objc.ObjCBlockImpl> arg0) =>
-              fn(
-                ObjCBlock_ffiVoid_NSData_NSError.fromPointer(
-                  arg0,
-                  retain: true,
-                  release: true,
-                ),
-              )?.ref.retainAndAutorelease() ??
-              ffi.nullptr,
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCBlockImpl> arg0,
+        ) {
+          final _$nullableObj = fn(
+            ObjCBlock_ffiVoid_NSData_NSError.fromPointer(
+              arg0,
+              retain: true,
+              release: true,
+            ),
+          );
+          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -23870,19 +23867,18 @@ abstract final class ObjCBlock_NSProgress_ffiVoidNSURLboolNSError {
           objc.ObjCBlock<ffi.Void Function(NSURL?, ffi.Bool, NSError?)>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<objc.ObjCBlockImpl> arg0) =>
-              fn(
-                ObjCBlock_ffiVoid_NSURL_bool_NSError.fromPointer(
-                  arg0,
-                  retain: true,
-                  release: true,
-                ),
-              )?.ref.retainAndAutorelease() ??
-              ffi.nullptr,
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCBlockImpl> arg0,
+        ) {
+          final _$nullableObj = fn(
+            ObjCBlock_ffiVoid_NSURL_bool_NSError.fromPointer(
+              arg0,
+              retain: true,
+              release: true,
+            ),
+          );
+          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -24069,25 +24065,22 @@ abstract final class ObjCBlock_NSProgress_ffiVoid_NSString_ffiVoidNSDataNSError 
           objc.ObjCBlock<ffi.Void Function(NSData?, NSError?)>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<objc.ObjCBlockImpl> arg2,
-          ) =>
-              fn(
-                arg0,
-                NSString.fromPointer(arg1, retain: true, release: true),
-                ObjCBlock_ffiVoid_NSData_NSError.fromPointer(
-                  arg2,
-                  retain: true,
-                  release: true,
-                ),
-              )?.ref.retainAndAutorelease() ??
-              ffi.nullptr,
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<objc.ObjCBlockImpl> arg2,
+        ) {
+          final _$nullableObj = fn(
+            arg0,
+            NSString.fromPointer(arg1, retain: true, release: true),
+            ObjCBlock_ffiVoid_NSData_NSError.fromPointer(
+              arg2,
+              retain: true,
+              release: true,
+            ),
+          );
+          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -24298,19 +24291,18 @@ abstract final class ObjCBlock_NSProgress_ffiVoididNSItemProviderWritingNSError 
           >,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<objc.ObjCBlockImpl> arg0) =>
-              fn(
-                ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError.fromPointer(
-                  arg0,
-                  retain: true,
-                  release: true,
-                ),
-              )?.ref.retainAndAutorelease() ??
-              ffi.nullptr,
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCBlockImpl> arg0,
+        ) {
+          final _$nullableObj = fn(
+            ObjCBlock_ffiVoid_idNSItemProviderWriting_NSError.fromPointer(
+              arg0,
+              retain: true,
+              release: true,
+            ),
+          );
+          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -24456,11 +24448,10 @@ abstract final class ObjCBlock_NSString_ffiVoid {
     NSString Function(ffi.Pointer<ffi.Void>) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<NSString Function(ffi.Pointer<ffi.Void>)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+      final _$obj = fn(arg0);
+      return _$obj.ref.retainAndAutorelease();
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -33975,16 +33966,16 @@ abstract final class ObjCBlock_instancetype_ffiVoid_NSCoder {
           NSCoder,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) =>
-              fn(
-                arg0,
-                NSCoder.fromPointer(arg1, retain: true, release: true),
-              )?.ref.retainAndReturnPointer() ??
-              ffi.nullptr,
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          final _$nullableObj = fn(
+            arg0,
+            NSCoder.fromPointer(arg1, retain: true, release: true),
+          );
+          return _$nullableObj?.ref.retainAndReturnPointer() ?? ffi.nullptr;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -34151,19 +34142,16 @@ abstract final class ObjCBlock_objcObjCObjectImpl_NSError_NSErrorUserInfoKey {
       objc.ObjCBlock<
         ffi.Pointer<objc.ObjCObjectImpl>? Function(NSError, NSString)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-          ) =>
-              fn(
-                NSError.fromPointer(arg0, retain: true, release: true),
-                NSString.fromPointer(arg1, retain: true, release: true),
-              )?.ref.retainAndAutorelease() ??
-              ffi.nullptr,
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<objc.ObjCObjectImpl> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+        ) {
+          final _$nullableObj = fn(
+            NSError.fromPointer(arg0, retain: true, release: true),
+            NSString.fromPointer(arg1, retain: true, release: true),
+          );
+          return _$nullableObj?.ref.retainAndAutorelease() ?? ffi.nullptr;
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -34324,11 +34312,10 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid {
       objc.ObjCBlock<
         ffi.Pointer<objc.ObjCObjectImpl> Function(ffi.Pointer<ffi.Void>)
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (ffi.Pointer<ffi.Void> arg0) {
+          final _$obj = fn(arg0);
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -34476,12 +34463,13 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid_NSZone {
           ffi.Pointer<NSZone>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<NSZone> arg1) =>
-              fn(arg0, arg1).ref.retainAndReturnPointer(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<NSZone> arg1,
+        ) {
+          final _$obj = fn(arg0, arg1);
+          return _$obj.ref.retainAndReturnPointer();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -34650,12 +34638,13 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector {
           ffi.Pointer<objc.ObjCSelector>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCSelector> arg1) =>
-              fn(arg0, arg1).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCSelector> arg1,
+        ) {
+          final _$obj = fn(arg0, arg1);
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -34834,19 +34823,18 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector_objcO
           ffi.Pointer<objc.ObjCObjectImpl>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCSelector> arg1,
-            ffi.Pointer<objc.ObjCObjectImpl> arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCSelector> arg1,
+          ffi.Pointer<objc.ObjCObjectImpl> arg2,
+        ) {
+          final _$obj = fn(
             arg0,
             arg1,
             objc.ObjCObject(arg2, retain: true, release: true),
-          ).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+          );
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -35044,21 +35032,20 @@ abstract final class ObjCBlock_objcObjCObjectImpl_ffiVoid_objcObjCSelector_objcO
           ffi.Pointer<objc.ObjCObjectImpl>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCSelector> arg1,
-            ffi.Pointer<objc.ObjCObjectImpl> arg2,
-            ffi.Pointer<objc.ObjCObjectImpl> arg3,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCSelector> arg1,
+          ffi.Pointer<objc.ObjCObjectImpl> arg2,
+          ffi.Pointer<objc.ObjCObjectImpl> arg3,
+        ) {
+          final _$obj = fn(
             arg0,
             arg1,
             objc.ObjCObject(arg2, retain: true, release: true),
             objc.ObjCObject(arg3, retain: true, release: true),
-          ).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
+          );
+          return _$obj.ref.retainAndAutorelease();
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -2192,7 +2192,8 @@ enum NSAttributedStringMarkdownParsingFailurePolicy {
 /// macOS: introduced 12.0.0
 extension type NSAttributedStringMarkdownParsingOptions._(
   objc.ObjCObject object$
-) implements objc.ObjCObject, NSObject, NSCopying {
+)
+    implements objc.ObjCObject, NSObject, NSCopying {
   /// Constructs a [NSAttributedStringMarkdownParsingOptions] that points to the same underlying object as [other].
   NSAttributedStringMarkdownParsingOptions.as(objc.ObjCObject other)
     : object$ = other {

--- a/pkgs/objective_c/test/main.c
+++ b/pkgs/objective_c/test/main.c
@@ -23,6 +23,6 @@ int main() {
   ASSERT_SYMBOL("OBJC_CLASS_$_DOBJCDartProtocol");    // protocol.m
   ASSERT_SYMBOL("OBJC_CLASS_$_DOBJCObservation");     // observer.m
   // objective_c_bindings_generated.m
-  ASSERT_SYMBOL("_ObjectiveCBindings_wrapListenerBlock_ovsamd");
+  ASSERT_SYMBOL("_1wx624s_wrapListenerBlock_ovsamd");
   return 0;
 }

--- a/pkgs/objective_c/test/setup.dart
+++ b/pkgs/objective_c/test/setup.dart
@@ -90,7 +90,7 @@ void main(List<String> arguments) {
   lib.lookup('OBJC_CLASS_\$_DOBJCDartProtocol'); // protocol.m
   lib.lookup('OBJC_CLASS_\$_DOBJCObservation'); // observer.m
   // objective_c_bindings_generated.m
-  lib.lookup('_ObjectiveCBindings_wrapListenerBlock_ovsamd');
+  lib.lookup('_1wx624s_wrapListenerBlock_ovsamd');
 
   // Sanity check that the executable can find FFI symbols.
   _linkMain([...objFiles, cMain], '$cMain.exe');

--- a/pkgs/swiftgen/test/integration/callbacks_bindings.dart
+++ b/pkgs/swiftgen/test/integration/callbacks_bindings.dart
@@ -75,15 +75,15 @@ abstract final class ObjCBlock_ffiVoid_NSObject {
     void Function(objc.NSObject?) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(objc.NSObject?)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : objc.NSObject.fromPointer(arg0, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -101,15 +101,15 @@ abstract final class ObjCBlock_ffiVoid_NSObject {
     void Function(objc.NSObject?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : objc.NSObject.fromPointer(arg0, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _17w5sbb_wrapListenerBlock_xtuoz7(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(objc.NSObject?)>(
@@ -133,22 +133,24 @@ abstract final class ObjCBlock_ffiVoid_NSObject {
     void Function(objc.NSObject?) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(
         arg0.address == 0
             ? null
             : objc.NSObject.fromPointer(arg0, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) => fn(
-        arg0.address == 0
-            ? null
-            : objc.NSObject.fromPointer(arg0, retain: false, release: true),
-      ),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0) {
+        return fn(
+          arg0.address == 0
+              ? null
+              : objc.NSObject.fromPointer(arg0, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _17w5sbb_wrapBlockingBlock_xtuoz7(
@@ -272,21 +274,24 @@ abstract final class ObjCBlock_ffiVoid_NSObject {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(objc.NSObject?)>`.
 extension ObjCBlock_ffiVoid_NSObject$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSObject?)> {
-  void call(objc.NSObject? arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  void call(objc.NSObject? arg0) {
+    final _$$ref = arg0?.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0?.ref.pointer ?? ffi.nullptr);
+        >()(ref.pointer, _$$ref?.pointer ?? ffi.nullptr);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(objc.NSString)>`.
@@ -332,12 +337,11 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(objc.NSString)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -355,12 +359,11 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final wrapper = _17w5sbb_wrapListenerBlock_xtuoz7(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(objc.NSString)>(
@@ -384,16 +387,18 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0) {
+        return fn(
+          objc.NSString.fromPointer(arg0, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _17w5sbb_wrapBlockingBlock_xtuoz7(
@@ -517,21 +522,24 @@ abstract final class ObjCBlock_ffiVoid_NSString {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(objc.NSString)>`.
 extension ObjCBlock_ffiVoid_NSString$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSString)> {
-  void call(objc.NSString arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  void call(objc.NSString arg0) {
+    final _$$ref = arg0.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, _$$ref.pointer);
+  }
 }
 
 /// TestMessageService
@@ -582,11 +590,13 @@ extension type TestMessageService._(objc.ObjCObject object$)
     required objc.ObjCBlock<ffi.Void Function(objc.NSObject?)>
     completionHandler,
   }) {
+    final _$$ref = anObject.ref;
+    final _$$ref$1 = completionHandler.ref;
     _objc_msgSend_o762yo(
       _class_TestMessageService,
       _sel_echoAsyncObjectWithAnObject_completionHandler_,
-      anObject.ref.pointer,
-      completionHandler.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 
@@ -594,10 +604,11 @@ extension type TestMessageService._(objc.ObjCObject object$)
   static void fetchGreetingAsyncWithCompletionHandler(
     objc.ObjCBlock<ffi.Void Function(objc.NSString)> completionHandler,
   ) {
+    final _$$ref = completionHandler.ref;
     _objc_msgSend_f167m6(
       _class_TestMessageService,
       _sel_fetchGreetingAsyncWithCompletionHandler_,
-      completionHandler.ref.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -605,10 +616,11 @@ extension type TestMessageService._(objc.ObjCObject object$)
   static void fetchGreetingWithCompletion(
     objc.ObjCBlock<ffi.Void Function(objc.NSString)> completion,
   ) {
+    final _$$ref = completion.ref;
     _objc_msgSend_f167m6(
       _class_TestMessageService,
       _sel_fetchGreetingWithCompletion_,
-      completion.ref.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -625,13 +637,14 @@ extension type TestMessageService._(objc.ObjCObject object$)
 extension TestMessageService$Methods on TestMessageService {
   /// init
   TestMessageService init() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'TestMessageService.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_init,
     );
     return TestMessageService.fromPointer($ret, retain: false, release: true);

--- a/pkgs/swiftgen/test/integration/classes_bindings.dart
+++ b/pkgs/swiftgen/test/integration/classes_bindings.dart
@@ -64,7 +64,8 @@ extension type TestClassWrapper._(objc.ObjCObject object$)
 extension TestClassWrapper$Methods on TestClassWrapper {
   /// myMethod
   TestOtherClassWrapper myMethod() {
-    final $ret = _objc_msgSend_151sglz(object$.ref.pointer, _sel_myMethod);
+    final _$$ref = object$.ref;
+    final $ret = _objc_msgSend_151sglz(_$$ref.pointer, _sel_myMethod);
     return TestOtherClassWrapper.fromPointer($ret, retain: true, release: true);
   }
 }
@@ -126,7 +127,8 @@ extension type TestOtherClassWrapper._(objc.ObjCObject object$)
 extension TestOtherClassWrapper$Methods on TestOtherClassWrapper {
   /// times10WithX:
   int times10WithX(int x) {
-    return _objc_msgSend_12hwf9n(object$.ref.pointer, _sel_times10WithX_, x);
+    final _$$ref = object$.ref;
+    return _objc_msgSend_12hwf9n(_$$ref.pointer, _sel_times10WithX_, x);
   }
 }
 

--- a/pkgs/swiftgen/test/integration/protocols_bindings.dart
+++ b/pkgs/swiftgen/test/integration/protocols_bindings.dart
@@ -143,12 +143,11 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(objc.NSString)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: true, release: true)),
-      keepIsolateAlive,
-    ),
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: true, release: true));
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -166,12 +165,11 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final wrapper = _1yx5rho_wrapListenerBlock_xtuoz7(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<ffi.Void Function(objc.NSString)>(
@@ -195,16 +193,18 @@ abstract final class ObjCBlock_ffiVoid_NSString {
     void Function(objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
-      keepIsolateAlive,
-    );
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<objc.ObjCObjectImpl> arg0,
+    ) {
+      return fn(objc.NSString.fromPointer(arg0, retain: false, release: true));
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<objc.ObjCObjectImpl> arg0) =>
-          fn(objc.NSString.fromPointer(arg0, retain: false, release: true)),
+      (ffi.Pointer<objc.ObjCObjectImpl> arg0) {
+        return fn(
+          objc.NSString.fromPointer(arg0, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1yx5rho_wrapBlockingBlock_xtuoz7(
@@ -328,21 +328,24 @@ abstract final class ObjCBlock_ffiVoid_NSString {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(objc.NSString)>`.
 extension ObjCBlock_ffiVoid_NSString$CallExtension
     on objc.ObjCBlock<ffi.Void Function(objc.NSString)> {
-  void call(objc.NSString arg0) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<objc.ObjCObjectImpl> arg0,
+  void call(objc.NSString arg0) {
+    final _$$ref = arg0.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<objc.ObjCObjectImpl> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0.ref.pointer);
+        >()(ref.pointer, _$$ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, objc.NSString)>`.
@@ -394,14 +397,15 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString {
     void Function(ffi.Pointer<ffi.Void>, objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) => objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, objc.NSString)>(
-    objc.newClosureBlock(
-      _closureCallable,
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
+    objc.newClosureBlock(_closureCallable, (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0,
         objc.NSString.fromPointer(arg1, retain: true, release: true),
-      ),
-      keepIsolateAlive,
-    ),
+      );
+    }, keepIsolateAlive),
     retain: false,
     release: true,
   );
@@ -420,14 +424,15 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString {
     void Function(ffi.Pointer<ffi.Void>, objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0,
         objc.NSString.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1yx5rho_wrapListenerBlock_18v1jvf(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -450,20 +455,23 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString {
     void Function(ffi.Pointer<ffi.Void>, objc.NSString) fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+    ) {
+      return fn(
         arg0,
         objc.NSString.fromPointer(arg1, retain: false, release: true),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final rawListener = objc.newClosureBlock(
       _blockingListenerCallable.nativeFunction.cast(),
-      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) => fn(
-        arg0,
-        objc.NSString.fromPointer(arg1, retain: false, release: true),
-      ),
+      (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObjectImpl> arg1) {
+        return fn(
+          arg0,
+          objc.NSString.fromPointer(arg1, retain: false, release: true),
+        );
+      },
       keepIsolateAlive,
     );
     final wrapper = _1yx5rho_wrapBlockingBlock_18v1jvf(
@@ -611,26 +619,26 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString {
 /// Call operator for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, objc.NSString)>`.
 extension ObjCBlock_ffiVoid_ffiVoid_NSString$CallExtension
     on objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, objc.NSString)> {
-  void call(ffi.Pointer<ffi.Void> arg0, objc.NSString arg1) => ref
-      .pointer
-      .ref
-      .invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
+  void call(ffi.Pointer<ffi.Void> arg0, objc.NSString arg1) {
+    final _$$ref = arg1.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-        )
-      >()(ref.pointer, arg0, arg1.ref.pointer);
+        >()(ref.pointer, arg0, _$$ref.pointer);
+  }
 }
 
 /// Construction methods for `objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, objc.NSString, objc.ObjCBlock<ffi.Void Function(objc.NSString)>)>`.
@@ -723,13 +731,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_ffiVoidNSString {
           objc.ObjCBlock<ffi.Void Function(objc.NSString)>,
         )
       >(
-        objc.newClosureBlock(
-          _closureCallable,
-          (
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<objc.ObjCBlockImpl> arg2,
-          ) => fn(
+        objc.newClosureBlock(_closureCallable, (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<objc.ObjCBlockImpl> arg2,
+        ) {
+          return fn(
             arg0,
             objc.NSString.fromPointer(arg1, retain: true, release: true),
             ObjCBlock_ffiVoid_NSString.fromPointer(
@@ -737,9 +744,8 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_ffiVoidNSString {
               retain: true,
               release: true,
             ),
-          ),
-          keepIsolateAlive,
-        ),
+          );
+        }, keepIsolateAlive),
         retain: false,
         release: true,
       );
@@ -769,13 +775,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_ffiVoidNSString {
     fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _listenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<ffi.Void> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCBlockImpl> arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_listenerCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      ffi.Pointer<objc.ObjCBlockImpl> arg2,
+    ) {
+      return fn(
         arg0,
         objc.NSString.fromPointer(arg1, retain: false, release: true),
         ObjCBlock_ffiVoid_NSString.fromPointer(
@@ -783,9 +788,8 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_ffiVoidNSString {
           retain: false,
           release: true,
         ),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
     final wrapper = _1yx5rho_wrapListenerBlock_jk1ljc(raw);
     objc.objectRelease(raw.cast());
     return objc.ObjCBlock<
@@ -823,13 +827,12 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_ffiVoidNSString {
     fn, {
     bool keepIsolateAlive = true,
   }) {
-    final raw = objc.newClosureBlock(
-      _blockingCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<ffi.Void> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCBlockImpl> arg2,
-      ) => fn(
+    final raw = objc.newClosureBlock(_blockingCallable.nativeFunction.cast(), (
+      ffi.Pointer<ffi.Void> arg0,
+      ffi.Pointer<objc.ObjCObjectImpl> arg1,
+      ffi.Pointer<objc.ObjCBlockImpl> arg2,
+    ) {
+      return fn(
         arg0,
         objc.NSString.fromPointer(arg1, retain: false, release: true),
         ObjCBlock_ffiVoid_NSString.fromPointer(
@@ -837,26 +840,24 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSString_ffiVoidNSString {
           retain: false,
           release: true,
         ),
-      ),
-      keepIsolateAlive,
-    );
-    final rawListener = objc.newClosureBlock(
-      _blockingListenerCallable.nativeFunction.cast(),
-      (
-        ffi.Pointer<ffi.Void> arg0,
-        ffi.Pointer<objc.ObjCObjectImpl> arg1,
-        ffi.Pointer<objc.ObjCBlockImpl> arg2,
-      ) => fn(
-        arg0,
-        objc.NSString.fromPointer(arg1, retain: false, release: true),
-        ObjCBlock_ffiVoid_NSString.fromPointer(
-          arg2,
-          retain: false,
-          release: true,
-        ),
-      ),
-      keepIsolateAlive,
-    );
+      );
+    }, keepIsolateAlive);
+    final rawListener = objc
+        .newClosureBlock(_blockingListenerCallable.nativeFunction.cast(), (
+          ffi.Pointer<ffi.Void> arg0,
+          ffi.Pointer<objc.ObjCObjectImpl> arg1,
+          ffi.Pointer<objc.ObjCBlockImpl> arg2,
+        ) {
+          return fn(
+            arg0,
+            objc.NSString.fromPointer(arg1, retain: false, release: true),
+            ObjCBlock_ffiVoid_NSString.fromPointer(
+              arg2,
+              retain: false,
+              release: true,
+            ),
+          );
+        }, keepIsolateAlive);
     final wrapper = _1yx5rho_wrapBlockingBlock_jk1ljc(
       raw,
       rawListener,
@@ -1037,25 +1038,29 @@ extension ObjCBlock_ffiVoid_ffiVoid_NSString_ffiVoidNSString$CallExtension
     ffi.Pointer<ffi.Void> arg0,
     objc.NSString arg1,
     objc.ObjCBlock<ffi.Void Function(objc.NSString)> arg2,
-  ) => ref.pointer.ref.invoke
-      .cast<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0,
-            ffi.Pointer<objc.ObjCObjectImpl> arg1,
-            ffi.Pointer<objc.ObjCBlockImpl> arg2,
+  ) {
+    final _$$ref = arg1.ref;
+    final _$$ref$1 = arg2.ref;
+    return ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Void Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+              ffi.Pointer<objc.ObjCObjectImpl> arg1,
+              ffi.Pointer<objc.ObjCBlockImpl> arg2,
+            )
+          >
+        >()
+        .asFunction<
+          void Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<objc.ObjCObjectImpl>,
+            ffi.Pointer<objc.ObjCBlockImpl>,
           )
-        >
-      >()
-      .asFunction<
-        void Function(
-          ffi.Pointer<objc.ObjCBlockImpl>,
-          ffi.Pointer<ffi.Void>,
-          ffi.Pointer<objc.ObjCObjectImpl>,
-          ffi.Pointer<objc.ObjCBlockImpl>,
-        )
-      >()(ref.pointer, arg0, arg1.ref.pointer, arg2.ref.pointer);
+        >()(ref.pointer, arg0, _$$ref.pointer, _$$ref$1.pointer);
+  }
 }
 
 /// TestAsyncProtocol
@@ -1087,11 +1092,14 @@ extension TestAsyncProtocol$Methods on TestAsyncProtocol {
     objc.NSString param, {
     required objc.ObjCBlock<ffi.Void Function(objc.NSString)> completionHandler,
   }) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = param.ref;
+    final _$$ref$2 = completionHandler.ref;
     _objc_msgSend_o762yo(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_fetchDataWithParam_completionHandler_,
-      param.ref.pointer,
-      completionHandler.ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 }
@@ -1346,12 +1354,15 @@ extension type TestSwiftInvoker._(objc.ObjCObject object$)
     required objc.NSString param,
     required objc.ObjCBlock<ffi.Void Function(objc.NSString)> completionHandler,
   }) {
+    final _$$ref = protocolInstance.ref;
+    final _$$ref$1 = param.ref;
+    final _$$ref$2 = completionHandler.ref;
     _objc_msgSend_18qun1e(
       _class_TestSwiftInvoker,
       _sel_invokeAsyncMethodOnBackgroundThreadWithProtocolInstance_param_completionHandler_,
-      protocolInstance.ref.pointer,
-      param.ref.pointer,
-      completionHandler.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -1361,12 +1372,15 @@ extension type TestSwiftInvoker._(objc.ObjCObject object$)
     required objc.NSString param,
     required objc.ObjCBlock<ffi.Void Function(objc.NSString)> completionHandler,
   }) {
+    final _$$ref = protocolInstance.ref;
+    final _$$ref$1 = param.ref;
+    final _$$ref$2 = completionHandler.ref;
     _objc_msgSend_18qun1e(
       _class_TestSwiftInvoker,
       _sel_invokeAsyncMethodWithProtocolInstance_param_completionHandler_,
-      protocolInstance.ref.pointer,
-      param.ref.pointer,
-      completionHandler.ref.pointer,
+      _$$ref.pointer,
+      _$$ref$1.pointer,
+      _$$ref$2.pointer,
     );
   }
 
@@ -1383,13 +1397,14 @@ extension type TestSwiftInvoker._(objc.ObjCObject object$)
 extension TestSwiftInvoker$Methods on TestSwiftInvoker {
   /// init
   TestSwiftInvoker init() {
+    final _$$ref = object$.ref;
     objc.checkOsVersionInternal(
       'TestSwiftInvoker.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref.retainAndReturnPointer(),
       _sel_init,
     );
     return TestSwiftInvoker.fromPointer($ret, retain: false, release: true);
@@ -1440,10 +1455,11 @@ extension type TestWeatherService._(objc.ObjCObject object$)
 
   /// fetchWeatherWithDelegate:
   static void fetchWeatherWithDelegate(TestWeatherServiceDelegate delegate) {
+    final _$$ref = delegate.ref;
     _objc_msgSend_xtuoz7(
       _class_TestWeatherService,
       _sel_fetchWeatherWithDelegate_,
-      delegate.ref.pointer,
+      _$$ref.pointer,
     );
   }
 
@@ -1460,13 +1476,14 @@ extension type TestWeatherService._(objc.ObjCObject object$)
 extension TestWeatherService$Methods on TestWeatherService {
   /// init
   TestWeatherService init() {
+    final _$$ref$1 = object$.ref;
     objc.checkOsVersionInternal(
       'TestWeatherService.init',
       iOS: (false, (2, 0, 0)),
       macOS: (false, (10, 0, 0)),
     );
     final $ret = _objc_msgSend_151sglz(
-      object$.ref.retainAndReturnPointer(),
+      _$$ref$1.retainAndReturnPointer(),
       _sel_init,
     );
     return TestWeatherService.fromPointer($ret, retain: false, release: true);
@@ -1499,10 +1516,12 @@ extension type TestWeatherServiceDelegate._(objc.ObjCProtocol object$)
 extension TestWeatherServiceDelegate$Methods on TestWeatherServiceDelegate {
   /// didUpdateWeather:
   void didUpdateWeather(objc.NSString weather) {
+    final _$$ref = object$.ref;
+    final _$$ref$1 = weather.ref;
     _objc_msgSend_xtuoz7(
-      object$.ref.pointer,
+      _$$ref.pointer,
       _sel_didUpdateWeather_,
-      weather.ref.pointer,
+      _$$ref$1.pointer,
     );
   }
 }


### PR DESCRIPTION
Store `foo.ref` in a local variable. The main thing that makes this non-trivial is that the `.ref` happens in `Type.convertDartTypeToFfiDartType`, which just returns a string, and is often used inline inside other expressions. So we can't just declare new local variables inside that returned string. Instead we need new `LocalVariables` class to allow the converter to declare local variables, then anyone invoking `convertDartTypeToFfiDartType` needs to also insert the string returned by `LocalVariables.generateDeclarations()` before the conversion.

Fixes https://github.com/dart-lang/native/issues/3342