### PR TITLE
[hooks] Turn `ProtocolExtension` into a base class

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.1.0-wip
 
-- Implemented `outputFiles` protocol extension method to track generated files for cache invalidation, correctly omitting non-local assets like system libraries.
-- Bumped dependency on `package:hooks` to `^2.0.0-wip`.
+- Bumped dependency on `package:hooks` to `^2.0.0-wip` and implemented the new `outputFiles` protocol extension method to track generated files for cache invalidation, correctly omitting non-local assets like system libraries.
 
 ## 1.0.0
 

--- a/pkgs/code_assets/example/mini_audio/lib/src/third_party/miniaudio.g.dart
+++ b/pkgs/code_assets/example/mini_audio/lib/src/third_party/miniaudio.g.dart
@@ -41,7 +41,9 @@ external int _ma_engine_init(
 ma_result ma_engine_init(
   ffi.Pointer<ma_engine_config> pConfig,
   ffi.Pointer<ma_engine> pEngine,
-) => ma_result.fromValue(_ma_engine_init(pConfig, pEngine));
+) {
+  return ma_result.fromValue(_ma_engine_init(pConfig, pEngine));
+}
 
 @meta.RecordUse()
 @ffi.Native<
@@ -61,7 +63,9 @@ ma_result ma_engine_play_sound(
   ffi.Pointer<ma_engine> pEngine,
   ffi.Pointer<ffi.Char> pFilePath,
   ffi.Pointer<ma_sound> pGroup,
-) => ma_result.fromValue(_ma_engine_play_sound(pEngine, pFilePath, pGroup));
+) {
+  return ma_result.fromValue(_ma_engine_play_sound(pEngine, pFilePath, pGroup));
+}
 
 @meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ma_engine>)>()

--- a/pkgs/code_assets/lib/src/code_assets/extension.dart
+++ b/pkgs/code_assets/lib/src/code_assets/extension.dart
@@ -15,7 +15,7 @@ import 'validation.dart';
 
 /// The protocol extension for the `hook/build.dart` and `hook/link.dart`
 /// with [CodeAsset]s and [CodeConfig].
-final class CodeAssetExtension implements ProtocolExtension {
+final class CodeAssetExtension extends ProtocolExtension {
   /// The architecture to build for.
   final Architecture targetArchitecture;
 

--- a/pkgs/data_assets/CHANGELOG.md
+++ b/pkgs/data_assets/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.20.0-wip
 
-- Implemented `outputFiles` protocol extension method to track generated data asset files for cache invalidation.
-- Bumped dependency on `package:hooks` to `^2.0.0-wip`.
+- Bumped dependency on `package:hooks` to `^2.0.0-wip` and implemented the new `outputFiles` protocol extension method to track generated data asset files for cache invalidation.
 
 ## 0.19.6
 

--- a/pkgs/data_assets/lib/src/data_assets/extension.dart
+++ b/pkgs/data_assets/lib/src/data_assets/extension.dart
@@ -9,7 +9,7 @@ import 'validation.dart';
 
 /// The protocol extension for the `hook/build.dart` and `hook/link.dart`
 /// with [DataAsset]s.
-final class DataAssetsExtension implements ProtocolExtension {
+final class DataAssetsExtension extends ProtocolExtension {
   DataAssetsExtension();
 
   @override

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0-wip
 
-- **Breaking change**: Added `outputFiles` method to `ProtocolExtension`.
+- **Breaking change**: Turned `ProtocolExtension` into a base class instead of an interface, with default implementations for all methods including the newly added `outputFiles`.
 
 ## 1.0.3
 

--- a/pkgs/hooks/lib/src/extension.dart
+++ b/pkgs/hooks/lib/src/extension.dart
@@ -17,43 +17,56 @@ typedef ValidationErrors = List<String>;
 /// The extension contains callbacks to
 /// 1. setup the input, and
 /// 2. validate syntactic and semantic constraints.
-abstract interface class ProtocolExtension {
+///
+/// This is an `abstract base class` rather than an interface so that adding new
+/// methods is not a breaking change. This avoids major-version conflicts across
+/// the ecosystem: `package:hooks` is a dependency of many packages, whereas
+/// [ProtocolExtension] is only extended by a small number of asset type
+/// definitions.
+///
+/// New methods must be added with default implementations such that not
+/// overriding them is semantically correct. If a new method cannot have a
+/// semantically correct default implementation, downstream maintainers of
+/// protocol extensions must be notified.
+abstract base class ProtocolExtension {
   /// The [HookConfig.buildAssetTypes] this extension adds.
   // List<String> get buildAssetTypes;
 
   /// Setup the [BuildConfig] for this extension.
-  void setupBuildInput(BuildInputBuilder input);
+  void setupBuildInput(BuildInputBuilder input) {}
 
   /// Setup the [HookConfig] for this extension.
-  void setupLinkInput(LinkInputBuilder input);
+  void setupLinkInput(LinkInputBuilder input) {}
 
   /// Reports errors from this extension on the [BuildInput].
-  Future<ValidationErrors> validateBuildInput(BuildInput input);
+  Future<ValidationErrors> validateBuildInput(BuildInput input) async => [];
 
   /// Reports errors from this extension on the [LinkInput].
   Future<ValidationErrors> validateBuildOutput(
     BuildInput input,
     BuildOutput output,
-  );
+  ) async => [];
 
   /// Reports errors from this extension on the [LinkInput].
-  Future<ValidationErrors> validateLinkInput(LinkInput input);
+  Future<ValidationErrors> validateLinkInput(LinkInput input) async => [];
 
   /// Reports errors from this extension on the [LinkOutput].
   Future<ValidationErrors> validateLinkOutput(
     LinkInput input,
     LinkOutput output,
-  );
+  ) async => [];
 
   /// Reports errors on the complete set of assets after all hooks are run.
   ///
   /// Can be used to validate that there are no asset-id or shared library name
   /// collisions.
-  Future<ValidationErrors> validateApplicationAssets(List<EncodedAsset> assets);
+  Future<ValidationErrors> validateApplicationAssets(
+    List<EncodedAsset> assets,
+  ) async => [];
 
   /// Returns any files emitted by the hook output for this extension.
   ///
   /// If any of these output files are modified or deleted, the hook needs to be
   /// rerun.
-  Iterable<Uri> outputFiles(List<EncodedAsset> assets);
+  Iterable<Uri> outputFiles(List<EncodedAsset> assets) => [];
 }

--- a/pkgs/hooks/test/api/protocol_extension_test.dart
+++ b/pkgs/hooks/test/api/protocol_extension_test.dart
@@ -19,7 +19,9 @@ import 'package:test/test.dart';
 /// error, it means an abstract member was added to [ProtocolExtension]. To fix
 /// it, add a default implementation to the member in [ProtocolExtension]
 /// instead of implementing it here.
-final class ConcreteProtocolExtension extends ProtocolExtension {}
+final class ConcreteProtocolExtension extends ProtocolExtension {
+  // Class body must be left empty (see doc comment).
+}
 
 void main() {
   test(

--- a/pkgs/hooks/test/api/protocol_extension_test.dart
+++ b/pkgs/hooks/test/api/protocol_extension_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:hooks/hooks.dart';
+import 'package:test/test.dart';
+
+/// A concrete subclass of [ProtocolExtension] that intentionally implements
+/// nothing.
+///
+/// **CRITICAL**: Do NOT add any method or member implementations/overrides to
+/// this class.
+///
+/// [ProtocolExtension] is an abstract base class (not an interface) to prevent
+/// breaking changes across the ecosystem when new methods are added. All new
+/// methods added to [ProtocolExtension] MUST have a default implementation.
+///
+/// If this class fails to compile with a "missing concrete implementation"
+/// error, it means an abstract member was added to [ProtocolExtension]. To fix
+/// it, add a default implementation to the member in [ProtocolExtension]
+/// instead of implementing it here.
+final class ConcreteProtocolExtension extends ProtocolExtension {}
+
+void main() {
+  test(
+    'ProtocolExtension can be fully subclassed without overriding methods',
+    () {
+      final extension = ConcreteProtocolExtension();
+
+      // Verify default implementations return expected empty collections.
+      expect(extension.validateApplicationAssets([]), completion(isEmpty));
+      expect(extension.outputFiles([]), isEmpty);
+    },
+  );
+}


### PR DESCRIPTION
Addressing:

* https://github.com/dart-lang/native/pull/3359#issuecomment-4446194991

This will prevent future major version churn on `package:hooks` for changes only relevant for SDKs (flutter_tools, dartdev, etc.) for potentially ~1e6 MAU.

This is at the cost of potential semantic errors in ~10 SDKs. So we'll need to be conscious to roll into SDKs proactively and consistently.