### PR TITLE
[native_toolchain_c] Release v0.19.0

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.0
+
+- Bumped dependency on `package:code_assets` to `^1.1.0` and `package:hooks` to `^2.0.0`.
+
 ## 0.18.0
 
 - Made `CLinker.run` `Logger` argument optional. It now defaults to a logger

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.18.0
+version: 0.19.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:


### PR DESCRIPTION
We also need a publish for `package:native_toolchain_c` after:

* https://github.com/dart-lang/native/pull/3359