### PR TITLE
feat(code_assets): add ohos OS support for OpenHarmony/HarmonyOS NEXT

### DIFF
--- a/pkgs/code_assets/lib/src/code_assets/os.dart
+++ b/pkgs/code_assets/lib/src/code_assets/os.dart
@@ -36,8 +36,12 @@ final class OS {
   /// operating system.
   static const OS windows = OS._('windows');
 
+  /// The
+  /// [OpenHarmony / HarmonyOS NEXT](https://harmonyos.com) operating system.
+  static const OS ohos = OS._('ohos');
+
   /// Known values for [OS].
-  static const List<OS> values = [android, fuchsia, iOS, linux, macOS, windows];
+  static const List<OS> values = [android, fuchsia, iOS, linux, macOS, windows, ohos];
 
   /// Typical cross compilation between OSes.
   static const osCrossCompilationDefault = {

--- a/pkgs/code_assets/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/code_assets/lib/src/code_assets/syntax.g.dart
@@ -908,7 +908,9 @@ class OSSyntax {
 
   static const windows = OSSyntax._('windows');
 
-  static const List<OSSyntax> values = [android, iOS, linux, macOS, windows];
+  static const ohos = OSSyntax._('ohos');
+
+  static const List<OSSyntax> values = [android, iOS, linux, macOS, windows, ohos];
 
   static final Map<String, OSSyntax> _byName = {
     for (final value in values) value.name: value,


### PR DESCRIPTION
                                                                                                                                                                                                                   
    ## Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                      
    Add `ohos` as a recognized operating system in the `OS` and `OSSyntax` enums                                                                                                                                      
    within the `code_assets` package, enabling native assets hooks to work on the                                                                                                                                     
    OpenHarmony / HarmonyOS NEXT platform.                                                                                                                                                                            
                                                                                                                                                                                                                      
    ## Background                                                                                                                                                                                                     
                                                                                                                                                                                                                      
    The `code_assets` package currently only recognizes six OS types: `android`,                                                                                                                                      
    `fuchsia`, `ios`, `linux`, `macos`, and `windows`. When the Flutter OHOS                                                                                                                                          
    toolchain (e.g. `flutter build hap` / `flutter run`) invokes native assets                                                                                                                                        
    hooks with `target_os: "ohos"`, it crashes with:                                                                                                                                                                  
                                                                                                                                                                                                                      
  FormatException: The OS "ohos" is not known                                                                                                                                                                         
                                                                                                                                                                                                                      
    This blocks any Flutter project targeting HarmonyOS NEXT from using packages                                                                                                                                      
    that depend on native assets (e.g. `objective_c`).                                                                                                                                                                
                                                                                                                                                                                                                      
    ## Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                      
    ### `lib/src/code_assets/os.dart`                                                                                                                                                                                 
    - Add `static const OS ohos = OS._('ohos')`                                                                                                                                                                       
    - Add `ohos` to the `OS.values` list                                                                                                                                                                              
                                                                                                                                                                                                                      
    ### `lib/src/code_assets/syntax.g.dart`                                                                                                                                                                           
    - Add `static const ohos = OSSyntax._('ohos')`                                                                                                                                                                    
    - Add `ohos` to the `OSSyntax.values` list                                                                                                                                                                        
                                                                                                                                                                                                                      
    ## Testing                                                                                                                                                                                                        
                                                                                                                                                                                                                      
    After applying the change, `flutter run` on a HarmonyOS NEXT device                                                                                                                                               
    (OpenHarmony 6.1.0.115, API 23) completed successfully:                                                                                                                                                           
    - Native assets hooks no longer throw OS format errors                                                                                                                                                            
    - `flutter build hap` succeeds in building the `.hap` artifact                                                                                                                                                    
                                                                                                                                                                                                                      
    ## Notes                                                                                                                                                                                                          
                                                                                                                                                                                                                      
    `syntax.g.dart` is a generated file. The permanent fix should be to update                                                                                                                                        
    the code generation tool (`pkgs/hooks/tool/generate_syntax.dart`) to include                                                                                                                                      
    `ohos` in the schema, then re-run generation. This patch applies the change                                                                                                                                       
    directly to the generated file as a temporary measure.                        