### PR TITLE
[code_assets] Support custom target `OS` and `Architecture`

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -7,7 +7,7 @@
   recognize, or a recognized library built for an architecture they do not
   know, warns on the supplied logger instead of failing.
 - Bump the dependency on `package:hooks` to `^2.2.0-wip`.
-- **Breaking change**: Overrode `==` and `hashCode` in `OS`, `Architecture`, `Sanitizer`, and `LinkModePreference` to support custom targets. These objects can no longer be used as keys of `const` maps and sets.
+- **Breaking change**: Overrode `==` and `hashCode` in `OS`, `Architecture`, and `Sanitizer` to support custom targets. These objects can no longer be used as keys of `const` maps and sets.
   - *Migration*: Use `final` (runtime) maps and sets instead of `const`, or use the string representations (e.g., `OS.name`, `Architecture.name`) as keys if `const` is required.
 - Support custom target OS, architecture, and santizer in protocol extension.
 ## 1.2.1

--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.0-wip
+## 2.0.0-wip
 
 - Validate bundled dynamic libraries by reading their header: when the file is
   a recognized ELF, Mach-O, or PE binary, check that it was built for the
@@ -7,7 +7,9 @@
   recognize, or a recognized library built for an architecture they do not
   know, warns on the supplied logger instead of failing.
 - Bump the dependency on `package:hooks` to `^2.2.0-wip`.
-
+- **Breaking change**: Overrode `==` and `hashCode` in `OS`, `Architecture`, `Sanitizer`, and `LinkModePreference` to support custom targets. These objects can no longer be used as keys of `const` maps and sets.
+  - *Migration*: Use `final` (runtime) maps and sets instead of `const`, or use the string representations (e.g., `OS.name`, `Architecture.name`) as keys if `const` is required.
+- Support custom target OS, architecture, and santizer in protocol extension.
 ## 1.2.1
 
 - Avoid throwing a null-assertion error/exception when `input.config.code` is

--- a/pkgs/code_assets/README.md
+++ b/pkgs/code_assets/README.md
@@ -113,5 +113,22 @@ void main(List<String> args) async {
 
 See the full example in [example/host_name/](example/host_name/).
 
+### Custom Operating Systems and Architectures
+
+SDK authors can define custom OSes and Architectures that they support in a helper package like:
+
+<!-- file://./../hooks_runner/test/build_runner/custom_os_arch_test.dart -->
+```dart
+extension CustomOS on OS {
+  static final ohos = OS.fromString('ohos');
+}
+
+extension CustomArchitecture on Architecture {
+  static final mips = Architecture.fromString('mips');
+}
+```
+
+The users of those SDKs can import this helper package to use the custom OSes and Architectures in their build hooks.
+
 For more information see [dart.dev/tools/hooks](https://dart.dev/tools/hooks).
 

--- a/pkgs/code_assets/example/sqlite_prebuilt/hook/build.dart
+++ b/pkgs/code_assets/example/sqlite_prebuilt/hook/build.dart
@@ -39,7 +39,7 @@ void main(List<String> args) async {
   });
 }
 
-const _windowsDownloadInfo = {
+final _windowsDownloadInfo = {
   Architecture.arm64: (
     url: 'https://sqlite.org/2025/sqlite-dll-win-arm64-3500400.zip',
     sha256: 'c4f3d245377f4ee2da5c08e882ecaff376b35a609198dc399dd8cec0add1ea43',
@@ -50,7 +50,7 @@ const _windowsDownloadInfo = {
   ),
 };
 
-const _linuxPaths = {
+final _linuxPaths = {
   Architecture.arm64: <String>[],
   Architecture.x64: ['/usr/lib/x86_64-linux-gnu/libsqlite3.so'],
 };

--- a/pkgs/code_assets/lib/src/code_assets/architecture.dart
+++ b/pkgs/code_assets/lib/src/code_assets/architecture.dart
@@ -81,33 +81,27 @@ final class Architecture {
   ///
   /// The name can be obtained from [Architecture.name] or
   /// [Architecture.toString].
-  factory Architecture.fromString(String name) =>
-      ArchitectureSyntaxExtension.fromSyntax(ArchitectureSyntax.fromJson(name));
+  factory Architecture.fromString(String name) => values.firstWhere(
+    (e) => e.name == name,
+    orElse: () => Architecture._(name),
+  );
 
   /// The current [Architecture].
   static final Architecture current = _abiToArch[Abi.current()]!;
+
+  @override
+  bool operator ==(Object other) => other is Architecture && other.name == name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 /// Extension methods for [Architecture] to convert to and from the syntax.
 extension ArchitectureSyntaxExtension on Architecture {
-  static final _toSyntax = {
-    for (final item in Architecture.values)
-      item: ArchitectureSyntax.fromJson(item.name),
-  };
-
-  static final _fromSyntax = {
-    for (var entry in _toSyntax.entries) entry.value: entry.key,
-  };
-
   /// Converts this [Architecture] to its corresponding [ArchitectureSyntax].
-  ArchitectureSyntax toSyntax() => _toSyntax[this]!;
+  ArchitectureSyntax toSyntax() => ArchitectureSyntax.fromJson(name);
 
   /// Converts an [ArchitectureSyntax] to its corresponding [Architecture].
   static Architecture fromSyntax(ArchitectureSyntax syntax) =>
-      switch (_fromSyntax[syntax]) {
-        null => throw FormatException(
-          'The architecture "${syntax.name}" is not known',
-        ),
-        final arch => arch,
-      };
+      Architecture.fromString(syntax.name);
 }

--- a/pkgs/code_assets/lib/src/code_assets/code_asset.dart
+++ b/pkgs/code_assets/lib/src/code_assets/code_asset.dart
@@ -189,7 +189,7 @@ extension OSLibraryNaming on OS {
 }
 
 /// The default name prefix for dynamic libraries per [OS].
-const _dylibPrefix = {
+final _dylibPrefix = {
   OS.android: 'lib',
   OS.fuchsia: 'lib',
   OS.iOS: 'lib',
@@ -199,7 +199,7 @@ const _dylibPrefix = {
 };
 
 /// The default extension for dynamic libraries per [OS].
-const _dylibExtension = {
+final _dylibExtension = {
   OS.android: 'so',
   OS.fuchsia: 'so',
   OS.iOS: 'dylib',
@@ -209,10 +209,10 @@ const _dylibExtension = {
 };
 
 /// The default name prefix for static libraries per [OS].
-const _staticlibPrefix = _dylibPrefix;
+final _staticlibPrefix = _dylibPrefix;
 
 /// The default extension for static libraries per [OS].
-const _staticlibExtension = {
+final _staticlibExtension = {
   OS.android: 'a',
   OS.fuchsia: 'a',
   OS.iOS: 'a',
@@ -222,7 +222,7 @@ const _staticlibExtension = {
 };
 
 /// The default extension for executables per [OS].
-const _executableExtension = {
+final _executableExtension = {
   OS.android: '',
   OS.fuchsia: '',
   OS.iOS: '',

--- a/pkgs/code_assets/lib/src/code_assets/link_mode_preference.dart
+++ b/pkgs/code_assets/lib/src/code_assets/link_mode_preference.dart
@@ -51,27 +51,20 @@ final class LinkModePreference {
   static const values = [dynamic, static, preferDynamic, preferStatic];
 
   @override
-  bool operator ==(Object other) =>
-      other is LinkModePreference && other.name == name;
-
-  @override
-  int get hashCode => name.hashCode;
-
-  @override
   String toString() => name;
 }
 
 /// Extension methods for [LinkModePreference] to convert to and from the
 /// syntax model.
 extension LinkModePreferenceSyntaxExtension on LinkModePreference {
-  static final _toSyntax = {
+  static const _toSyntax = {
     LinkModePreference.dynamic: LinkModePreferenceSyntax.dynamic,
     LinkModePreference.preferDynamic: LinkModePreferenceSyntax.preferDynamic,
     LinkModePreference.preferStatic: LinkModePreferenceSyntax.preferStatic,
     LinkModePreference.static: LinkModePreferenceSyntax.static,
   };
 
-  static final _fromSyntax = {
+  static const _fromSyntax = {
     LinkModePreferenceSyntax.dynamic: LinkModePreference.dynamic,
     LinkModePreferenceSyntax.preferDynamic: LinkModePreference.preferDynamic,
     LinkModePreferenceSyntax.preferStatic: LinkModePreference.preferStatic,

--- a/pkgs/code_assets/lib/src/code_assets/os.dart
+++ b/pkgs/code_assets/lib/src/code_assets/os.dart
@@ -40,7 +40,7 @@ final class OS {
   static const List<OS> values = [android, fuchsia, iOS, linux, macOS, windows];
 
   /// Typical cross compilation between OSes.
-  static const osCrossCompilationDefault = {
+  static final osCrossCompilationDefault = {
     OS.macOS: [OS.macOS, OS.iOS, OS.android],
     OS.linux: [OS.linux, OS.android],
     OS.windows: [OS.windows, OS.android],
@@ -57,30 +57,25 @@ final class OS {
   ///
   /// The name can be obtained from [OS.name] or [OS.toString].
   factory OS.fromString(String name) =>
-      OSSyntaxExtension.fromSyntax(OSSyntax.fromJson(name));
+      values.firstWhere((e) => e.name == name, orElse: () => OS._(name));
 
   /// The current [OS].
   ///
   /// Consistent with the [Platform.version] string.
   static final OS current = OS.fromString(Platform.operatingSystem);
+
+  @override
+  bool operator ==(Object other) => other is OS && other.name == name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 /// Extension methods for [OS] to convert to and from the syntax model.
 extension OSSyntaxExtension on OS {
-  static final _toSyntax = {
-    for (final item in OS.values) item: OSSyntax.fromJson(item.name),
-  };
-
-  static final _fromSyntax = {
-    for (var entry in _toSyntax.entries) entry.value: entry.key,
-  };
-
   /// Converts this [OS] to its corresponding [OSSyntax].
-  OSSyntax toSyntax() => _toSyntax[this]!;
+  OSSyntax toSyntax() => OSSyntax.fromJson(name);
 
   /// Converts an [OSSyntax] to its corresponding [OS].
-  static OS fromSyntax(OSSyntax syntax) => switch (_fromSyntax[syntax]) {
-    null => throw FormatException('The OS "${syntax.name}" is not known'),
-    final e => e,
-  };
+  static OS fromSyntax(OSSyntax syntax) => OS.fromString(syntax.name);
 }

--- a/pkgs/code_assets/lib/src/code_assets/sanitizer.dart
+++ b/pkgs/code_assets/lib/src/code_assets/sanitizer.dart
@@ -60,28 +60,21 @@ final class Sanitizer {
   ///
   /// The name can be obtained from [Sanitizer.name] or [Sanitizer.toString].
   factory Sanitizer.fromString(String name) =>
-      SanitizerSyntaxExtension.fromSyntax(SanitizerSyntax.fromJson(name));
+      values.firstWhere((e) => e.name == name, orElse: () => Sanitizer._(name));
+
+  @override
+  bool operator ==(Object other) => other is Sanitizer && other.name == name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 /// Extension methods for [Sanitizer] to convert to and from the syntax model.
 extension SanitizerSyntaxExtension on Sanitizer {
-  static final _toSyntax = {
-    for (final item in Sanitizer.values)
-      item: SanitizerSyntax.fromJson(item.name),
-  };
-
-  static final _fromSyntax = {
-    for (var entry in _toSyntax.entries) entry.value: entry.key,
-  };
-
   /// Converts this [Sanitizer] to its corresponding [SanitizerSyntax].
-  SanitizerSyntax toSyntax() =>
-      _toSyntax[this] ?? SanitizerSyntax.fromJson(name);
+  SanitizerSyntax toSyntax() => SanitizerSyntax.fromJson(name);
 
   /// Converts an [SanitizerSyntax] to its corresponding [Sanitizer].
   static Sanitizer fromSyntax(SanitizerSyntax syntax) =>
-      switch (_fromSyntax[syntax]) {
-        null => Sanitizer._(syntax.name),
-        final e => e,
-      };
+      Sanitizer.fromString(syntax.name);
 }

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling native code
   with Dart packages.
 
-version: 1.3.0-wip
+version: 2.0.0-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 

--- a/pkgs/code_assets/test/code_assets/config_test.dart
+++ b/pkgs/code_assets/test/code_assets/config_test.dart
@@ -325,27 +325,24 @@ void main() async {
     }
   });
 
-  test('BuildInput.config.code: invalid architecture', () {
+  test('BuildInput.config.code: custom architecture', () {
     final input = inputJson();
     traverseJson<Map<String, Object?>>(input, [
       'config',
       'extensions',
       'code_assets',
-    ])['target_architecture'] = 'invalid_architecture';
-    expect(
-      () => BuildInput(input).config.code.targetArchitecture,
-      throwsFormatException,
-    );
+    ])['target_architecture'] = 'mips';
+    expect(BuildInput(input).config.code.targetArchitecture.name, 'mips');
   });
 
-  test('LinkInput.config.code: invalid os', () {
+  test('LinkInput.config.code: custom os', () {
     final input = inputJson(hookType: 'link');
     traverseJson<Map<String, Object?>>(input, [
       'config',
       'extensions',
       'code_assets',
-    ])['target_os'] = 'invalid_os';
-    expect(() => LinkInput(input).config.code.targetOS, throwsFormatException);
+    ])['target_os'] = 'ohos';
+    expect(LinkInput(input).config.code.targetOS.name, 'ohos');
   });
 
   test('LinkInput.config.code.target_os invalid type', () {

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Remove `libraryImports`, which was dead code
   - Remove `useSupportedTypedefs`, treating it as always true
 - Minor Objective-C code generator and function type signature fixes.
+- Bump `package:code_assets` dependency to `^2.0.0`.
 
 ## 21.0.0
 

--- a/pkgs/ffigen/example/add/pubspec.yaml
+++ b/pkgs/ffigen/example/add/pubspec.yaml
@@ -15,3 +15,13 @@ dev_dependencies:
   ffigen:
     path: '../../'
   test: ^1.25.15
+
+dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  record_use:
+    path: ../../../record_use

--- a/pkgs/ffigen/example/c_json/pubspec.yaml
+++ b/pkgs/ffigen/example/c_json/pubspec.yaml
@@ -15,3 +15,13 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
   ffigen:
     path: '../../'
+
+dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  record_use:
+    path: ../../../record_use

--- a/pkgs/ffigen/example/ffinative/pubspec.yaml
+++ b/pkgs/ffigen/example/ffinative/pubspec.yaml
@@ -14,3 +14,13 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
   ffigen:
     path: '../../'
+
+dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  record_use:
+    path: ../../../record_use

--- a/pkgs/ffigen/example/libclang-example/pubspec.yaml
+++ b/pkgs/ffigen/example/libclang-example/pubspec.yaml
@@ -14,3 +14,13 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
   ffigen:
     path: '../../'
+
+dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  record_use:
+    path: ../../../record_use

--- a/pkgs/ffigen/example/objective_c/pubspec.yaml
+++ b/pkgs/ffigen/example/objective_c/pubspec.yaml
@@ -19,5 +19,13 @@ dev_dependencies:
     path: ../../
 
 dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
   objective_c:
     path: ../../../objective_c/
+  record_use:
+    path: ../../../record_use

--- a/pkgs/ffigen/example/shared_bindings/pubspec.yaml
+++ b/pkgs/ffigen/example/shared_bindings/pubspec.yaml
@@ -16,3 +16,15 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
   ffigen:
     path: '../../'
+
+dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  objective_c:
+    path: ../../../objective_c
+  record_use:
+    path: ../../../record_use

--- a/pkgs/ffigen/example/simple/pubspec.yaml
+++ b/pkgs/ffigen/example/simple/pubspec.yaml
@@ -14,3 +14,13 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
   ffigen:
     path: '../../'
+
+dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  record_use:
+    path: ../../../record_use

--- a/pkgs/ffigen/example/swift/pubspec.yaml
+++ b/pkgs/ffigen/example/swift/pubspec.yaml
@@ -18,5 +18,13 @@ dev_dependencies:
     path: ../../
 
 dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
   objective_c:
     path: ../../../objective_c/
+  record_use:
+    path: ../../../record_use

--- a/pkgs/ffigen/hook/build.dart
+++ b/pkgs/ffigen/hook/build.dart
@@ -221,12 +221,12 @@ String toTargetTriple(CodeConfig codeConfig) {
   return appleClangMacosTargetFlags[architecture]!;
 }
 
-const appleClangMacosTargetFlags = {
+final appleClangMacosTargetFlags = {
   Architecture.arm64: 'arm64-apple-darwin',
   Architecture.x64: 'x86_64-apple-darwin',
 };
 
-const appleClangIosTargetFlags = {
+final appleClangIosTargetFlags = {
   Architecture.arm64: {
     IOSSdk.iPhoneOS: 'arm64-apple-ios',
     IOSSdk.iPhoneSimulator: 'arm64-apple-ios-simulator',

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -21,7 +21,7 @@ environment:
 dependencies:
   args: ^2.6.0
   cli_util: ^0.4.2
-  code_assets: ^1.1.0
+  code_assets: ^2.0.0-wip
   collection: ^1.18.0
   dart_style: ^3.0.0
   ffi: ^2.0.1

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.6.0
-  code_assets: ^1.0.0 # Used for running tests with real asset types.
+  code_assets: ^2.0.0-wip # Used for running tests with real asset types.
   dart_flutter_team_lints: ^3.5.2
   data_assets: any # Used for running tests with real asset types.
   file_testing: ^3.0.2

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -6,11 +6,10 @@
   file extension
 - Report a format error instead of throwing a `TypeError` when a hook's cached
   `output.json` contains valid JSON that is not an object.
-
+- Bump `package:code_assets` dependency to `^2.0.0`.
 ## 1.6.1
 
 - Support versions 3.x of `package:package_config`.
-
 ## 1.6.0
 
 - Fix record_use path changing caching issue.

--- a/pkgs/hooks_runner/lib/src/model/target.dart
+++ b/pkgs/hooks_runner/lib/src/model/target.dart
@@ -151,16 +151,20 @@ final class Target implements Comparable<Target> {
 
   /// A list of supported target [Target]s from this host [os].
   List<Target> supportedTargetTargets({
-    Map<OS, List<OS>> osCrossCompilation = OS.osCrossCompilationDefault,
-  }) => Target.values
-      .where(
-        (target) =>
-            // Only valid cross compilation.
-            osCrossCompilation[os]!.contains(target.os) &&
-            // And no deprecated architectures.
-            target != Target.iOSArm,
-      )
-      .sorted;
+    Map<OS, List<OS>>? osCrossCompilation,
+  }) {
+    final osCrossCompilation_ =
+        osCrossCompilation ?? OS.osCrossCompilationDefault;
+    return Target.values
+        .where(
+          (target) =>
+              // Only valid cross compilation.
+              osCrossCompilation_[os]!.contains(target.os) &&
+              // And no deprecated architectures.
+              target != Target.iOSArm,
+        )
+        .sorted;
+  }
 }
 
 /// Common methods for manipulating iterables of [Target]s.

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  code_assets: ^1.3.0-wip # Needed for OS for Target for KernelAssets.
+  code_assets: ^2.0.0-wip # Needed for OS for Target for KernelAssets.
   collection: ^1.19.1
   crypto: ^3.0.6
   file: ^7.0.1

--- a/pkgs/hooks_runner/test/build_runner/custom_os_arch_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/custom_os_arch_test.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:file/local.dart' show LocalFileSystem;
+import 'package:hooks_runner/hooks_runner.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'helpers.dart';
+
+const Timeout longTimeout = Timeout(Duration(minutes: 5));
+
+void main() async {
+  test('build custom OS and architecture', timeout: longTimeout, () async {
+    await inTempDir((tempUri) async {
+      await copyTestProjects(targetUri: tempUri);
+      final packageUri = tempUri.resolve('custom_os_arch/');
+
+      // First, run `pub get` to resolve our dependencies.
+      await runPubGet(workingDirectory: packageUri, logger: logger);
+
+      final packageLayout = await PackageLayout.fromWorkingDirectory(
+        const LocalFileSystem(),
+        packageUri,
+        'custom_os_arch',
+        includeDevDependencies: false,
+      );
+
+      final buildRunner = NativeAssetsBuildRunner(
+        logger: logger,
+        dartExecutable: dartExecutable,
+        fileSystem: const LocalFileSystem(),
+        packageLayout: packageLayout,
+      );
+
+      final result = await buildRunner.build(
+        extensions: [
+          CodeAssetExtension(
+            targetOS: CustomOS.ohos,
+            targetArchitecture: CustomArchitecture.mips,
+            linkModePreference: LinkModePreference.dynamic,
+            sanitizer: CustomSanitizer.mySanitizer,
+          ),
+        ],
+        linkingEnabled: false,
+      );
+
+      expect(result.isSuccess, isTrue);
+      final buildResult = result.success;
+
+      expect(buildResult.encodedAssets.length, 1);
+      final codeAsset = buildResult.encodedAssets.first.asCodeAsset;
+      expect(codeAsset.id, 'package:custom_os_arch/my_asset');
+
+      expect(codeAsset.linkMode, isA<DynamicLoadingBundled>());
+
+      final fileContents = await File.fromUri(codeAsset.file!).readAsString();
+      expect(
+        fileContents,
+        'dummy: ohos, mips, my_sanitizer',
+      );
+    });
+  });
+}
+
+// snippet-start
+extension CustomOS on OS {
+  static final ohos = OS.fromString('ohos');
+}
+
+extension CustomArchitecture on Architecture {
+  static final mips = Architecture.fromString('mips');
+}
+
+// snippet-end
+
+extension CustomSanitizer on Sanitizer {
+  static final mySanitizer = Sanitizer.fromString('my_sanitizer');
+}

--- a/pkgs/hooks_runner/test_data/custom_os_arch/hook/build.dart
+++ b/pkgs/hooks_runner/test_data/custom_os_arch/hook/build.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+
+void main(List<String> arguments) async {
+  await build(arguments, (input, output) async {
+    final targetOS = input.config.code.targetOS;
+    final targetArch = input.config.code.targetArchitecture;
+    final sanitizer = input.config.code.sanitizer;
+
+    final file = File.fromUri(input.outputDirectory.resolve('my_asset.so'));
+    await file.writeAsString(
+      'dummy: $targetOS, $targetArch, $sanitizer',
+    );
+
+    output.assets.code.add(
+      CodeAsset(
+        package: 'custom_os_arch',
+        name: 'my_asset',
+        linkMode: DynamicLoadingBundled(),
+        file: file.uri,
+      ),
+    );
+  });
+}

--- a/pkgs/hooks_runner/test_data/custom_os_arch/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/custom_os_arch/pubspec.yaml
@@ -1,0 +1,14 @@
+name: custom_os_arch
+description: A package to test custom OS and architecture settings.
+version: 0.1.0
+
+publish_to: none
+
+resolution: workspace
+
+environment:
+  sdk: '>=3.10.0 <4.0.0'
+
+dependencies:
+  code_assets: any
+  hooks: any

--- a/pkgs/hooks_runner/test_data/manifest.yaml
+++ b/pkgs/hooks_runner/test_data/manifest.yaml
@@ -23,6 +23,8 @@
 - complex_link_helper/hook/build.dart
 - complex_link_helper/lib/complex_link_helper.dart
 - complex_link_helper/pubspec.yaml
+- custom_os_arch/hook/build.dart
+- custom_os_arch/pubspec.yaml
 - cyclic_link_package_1/hook/link.dart
 - cyclic_link_package_1/pubspec.yaml
 - cyclic_link_package_2/hook/link.dart

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Link frameworks for C and C++ sources targeting macOS or iOS.
   ([#3162](https://github.com/dart-lang/native/issues/3162))
-
+- Bump `package:code_assets` dependency to `^2.0.0`.
 ## 0.19.3
 
 - Fixed building with MSVC on Windows when a source, include, or output path
@@ -20,7 +20,8 @@
 
 ## 0.19.2
 
-- Fixed compatibility with newer Xcode versions when cross-compiling static libraries on macOS hosts targeting Android and Linux.
+- Fixed compatibility with newer Xcode versions when cross-compiling static
+  libraries on macOS hosts targeting Android and Linux.
 
 ## 0.19.1
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -499,7 +499,7 @@ class RunCBuilder {
     return '$baseName.obj';
   }
 
-  static const androidNdkClangTargetFlags = {
+  static final androidNdkClangTargetFlags = {
     Architecture.arm: 'armv7a-linux-androideabi',
     Architecture.arm64: 'aarch64-linux-android',
     Architecture.ia32: 'i686-linux-android',
@@ -507,12 +507,12 @@ class RunCBuilder {
     Architecture.riscv64: 'riscv64-linux-android',
   };
 
-  static const appleClangMacosTargetFlags = {
+  static final appleClangMacosTargetFlags = {
     Architecture.arm64: 'arm64-apple-darwin',
     Architecture.x64: 'x86_64-apple-darwin',
   };
 
-  static const appleClangIosTargetFlags = {
+  static final appleClangIosTargetFlags = {
     Architecture.arm64: {
       IOSSdk.iPhoneOS: 'arm64-apple-ios',
       IOSSdk.iPhoneSimulator: 'arm64-apple-ios-simulator',
@@ -520,7 +520,7 @@ class RunCBuilder {
     Architecture.x64: {IOSSdk.iPhoneSimulator: 'x86_64-apple-ios-simulator'},
   };
 
-  static const clangLinuxTargetFlags = {
+  static final clangLinuxTargetFlags = {
     Architecture.arm: 'arm-linux-gnueabihf',
     Architecture.arm64: 'aarch64-linux-gnu',
     Architecture.ia32: 'i686-linux-gnu',
@@ -529,19 +529,19 @@ class RunCBuilder {
     Architecture.riscv64: 'riscv64-linux-gnu',
   };
 
-  static const clangWindowsTargetFlags = {
+  static final clangWindowsTargetFlags = {
     Architecture.arm64: 'arm64-pc-windows-msvc',
     Architecture.ia32: 'i386-pc-windows-msvc',
     Architecture.x64: 'x86_64-pc-windows-msvc',
   };
 
-  static const clTargetFlags = {
+  static final clTargetFlags = {
     Architecture.arm64: 'ARM64',
     Architecture.ia32: 'X86',
     Architecture.x64: 'X64',
   };
 
-  static const defaultCppLinkStdLib = {
+  static final defaultCppLinkStdLib = {
     OS.android: 'c++_shared',
     OS.fuchsia: 'c++',
     OS.iOS: 'c++',
@@ -549,13 +549,13 @@ class RunCBuilder {
     OS.macOS: 'c++',
   };
 
-  static const _clangSanitizers = {
+  static final _clangSanitizers = {
     Sanitizer.asan: '-fsanitize=address',
     Sanitizer.msan: '-fsanitize=memory',
     Sanitizer.tsan: '-fsanitize=thread',
   };
 
-  static const _msvcSanitizers = {
+  static final _msvcSanitizers = {
     Sanitizer.asan: '/fsanitize=address',
   };
 }

--- a/pkgs/native_toolchain_c/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/native_toolchain_c/lib/src/native_toolchain/msvc.dart
@@ -219,7 +219,7 @@ final Tool dumpbin = _msvcTool(
   hostArchitecture: .current,
 );
 
-const _msvcArchNames = {
+final _msvcArchNames = {
   Architecture.ia32: 'x86',
   Architecture.x64: 'x64',
   Architecture.arm64: 'arm64',

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  code_assets: ^1.2.0
+  code_assets: ^2.0.0-wip
   glob: ^2.1.1
   hooks: ^2.0.0
   logging: ^1.3.0

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -25,7 +25,7 @@ import 'package:test_case_selector/test_case_selector.dart';
 import '../helpers.dart';
 
 // Dont include 'mach-o' or 'Mach-O', different spelling is used.
-const objdumpFileFormat = {
+final objdumpFileFormat = {
   (OS.macOS, Architecture.arm64): 'arm64',
   (OS.macOS, Architecture.x64): '64-bit x86-64',
   (OS.linux, Architecture.arm): 'elf32-littlearm',

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -54,7 +54,7 @@ void main() async {
     )).first.uri;
   });
 
-  const dumpbinMachine = {
+  final dumpbinMachine = {
     Architecture.arm64: 'ARM64',
     Architecture.ia32: 'x86',
     Architecture.x64: 'x64',

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -187,7 +187,7 @@ Future<String> readelfMachine(String path) async {
   return result.split('\n').firstWhere((e) => e.contains('Machine:'));
 }
 
-const readElfMachine = {
+final readElfMachine = {
   Architecture.arm: 'ARM',
   Architecture.arm64: 'AArch64',
   Architecture.ia32: 'Intel 80386',
@@ -382,7 +382,7 @@ int defaultMacOSVersion = MacOSVersion.flutterLowestSupported.value;
 
 /// File-format strings used by the `objdump` tool for Android binaries that
 /// run on a given architecture.
-const objdumpFileFormatAndroid = {
+final objdumpFileFormatAndroid = {
   Architecture.arm: 'elf32-littlearm',
   Architecture.arm64: 'elf64-littleaarch64',
   Architecture.ia32: 'elf32-i386',
@@ -390,18 +390,18 @@ const objdumpFileFormatAndroid = {
   Architecture.riscv64: 'elf64-littleriscv',
 };
 
-const objdumpFileFormatMacOS = {
+final objdumpFileFormatMacOS = {
   Architecture.arm64: 'mach-o arm64',
   Architecture.x64: 'mach-o 64-bit x86-64',
 };
 
 // Don't include 'mach-o' or 'Mach-O', different spelling is used.
-const objdumpFileFormatIOS = {
+final objdumpFileFormatIOS = {
   Architecture.arm64: 'arm64',
   Architecture.x64: '64-bit x86-64',
 };
 
-const objdumpFileFormatLinux = {
+final objdumpFileFormatLinux = {
   Architecture.arm: 'elf32-littlearm',
   Architecture.arm64: 'elf64-littleaarch64',
   Architecture.ia32: 'elf32-i386',
@@ -432,14 +432,14 @@ String? targetTriple(OS targetOS, Architecture targetArch) =>
       _ => null,
     };
 
-const targetOSToObjdumpFileFormat = {
+final targetOSToObjdumpFileFormat = {
   OS.android: objdumpFileFormatAndroid,
   OS.macOS: objdumpFileFormatMacOS,
   OS.iOS: objdumpFileFormatMacOS,
   OS.linux: objdumpFileFormatLinux,
 };
 
-const dumpbinFileFormat = {
+final dumpbinFileFormat = {
   Architecture.arm64: 'ARM64',
   Architecture.ia32: 'x86',
   Architecture.x64: 'x64',

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,10 +1,13 @@
+## 9.5.1-wip
+
+- Bump `package:code_assets` dependency to `^2.0.0`.
+
 ## 9.5.0
 
 - Add internal utils required to support FFIgen's new port based blocks.
 - Make an internal-only FFI struct, `DOBJC_Context`, opaque. This is
   technically a breaking change, but it's extremely unlikely that any users are
   using these internal structs (and doing so would be a mistake).
-
 ## 9.4.1
 
 - Fix a [bug](https://github.com/flutter/flutter/issues/186794) related to

--- a/pkgs/objective_c/analysis_options.yaml
+++ b/pkgs/objective_c/analysis_options.yaml
@@ -1,5 +1,13 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-raw-types: true

--- a/pkgs/objective_c/example/command_line/analysis_options.yaml
+++ b/pkgs/objective_c/example/command_line/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:lints/recommended.yaml
+
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/pkgs/objective_c/example/command_line/pubspec.yaml
+++ b/pkgs/objective_c/example/command_line/pubspec.yaml
@@ -13,3 +13,13 @@ dependencies:
 dev_dependencies:
   lints: ^6.0.0
   test: ^1.27.0
+
+dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  record_use:
+    path: ../../../record_use

--- a/pkgs/objective_c/example/flutter_app/analysis_options.yaml
+++ b/pkgs/objective_c/example/flutter_app/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/pkgs/objective_c/example/flutter_app/pubspec.yaml
+++ b/pkgs/objective_c/example/flutter_app/pubspec.yaml
@@ -17,5 +17,17 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
 
+dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  record_use:
+    path: ../../../record_use
+  objective_c:
+    path: ../..
+
 flutter:
   uses-material-design: true

--- a/pkgs/objective_c/example/flutter_app/pubspec.yaml
+++ b/pkgs/objective_c/example/flutter_app/pubspec.yaml
@@ -22,6 +22,7 @@ dependency_overrides:
     path: ../../../code_assets
   hooks:
     path: ../../../hooks
+  meta: ^1.19.0
   native_toolchain_c:
     path: ../../../native_toolchain_c
   record_use:

--- a/pkgs/objective_c/example/path_provider_example/analysis_options.yaml
+++ b/pkgs/objective_c/example/path_provider_example/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/pkgs/objective_c/example/path_provider_example/ios/Flutter/Debug.xcconfig
+++ b/pkgs/objective_c/example/path_provider_example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/pkgs/objective_c/example/path_provider_example/ios/Flutter/Release.xcconfig
+++ b/pkgs/objective_c/example/path_provider_example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/pkgs/objective_c/example/path_provider_example/ios/Podfile
+++ b/pkgs/objective_c/example/path_provider_example/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/pkgs/objective_c/example/path_provider_example/pubspec.yaml
+++ b/pkgs/objective_c/example/path_provider_example/pubspec.yaml
@@ -19,6 +19,14 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 dependency_overrides:
+  code_assets:
+    path: ../../../code_assets
+  hooks:
+    path: ../../../hooks
+  native_toolchain_c:
+    path: ../../../native_toolchain_c
+  record_use:
+    path: ../../../record_use
   objective_c:
     path: ../..
 

--- a/pkgs/objective_c/example/path_provider_example/pubspec.yaml
+++ b/pkgs/objective_c/example/path_provider_example/pubspec.yaml
@@ -23,6 +23,7 @@ dependency_overrides:
     path: ../../../code_assets
   hooks:
     path: ../../../hooks
+  meta: ^1.19.0
   native_toolchain_c:
     path: ../../../native_toolchain_c
   record_use:

--- a/pkgs/objective_c/hook/build.dart
+++ b/pkgs/objective_c/hook/build.dart
@@ -25,7 +25,7 @@ void main(List<String> args) async {
       return;
     }
 
-    const supportedOSs = {OS.iOS, OS.macOS};
+    final supportedOSs = {OS.iOS, OS.macOS};
     final codeConfig = input.config.code;
     final os = codeConfig.targetOS;
     if (!supportedOSs.contains(os)) {
@@ -217,12 +217,12 @@ String toTargetTriple(CodeConfig codeConfig) {
   return appleClangMacosTargetFlags[architecture]!;
 }
 
-const appleClangMacosTargetFlags = {
+final appleClangMacosTargetFlags = {
   Architecture.arm64: 'arm64-apple-darwin',
   Architecture.x64: 'x86_64-apple-darwin',
 };
 
-const appleClangIosTargetFlags = {
+final appleClangIosTargetFlags = {
   Architecture.arm64: {
     IOSSdk.iPhoneOS: 'arm64-apple-ios',
     IOSSdk.iPhoneSimulator: 'arm64-apple-ios-simulator',

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 9.5.0
+version: 9.5.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aobjective_c
 
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  code_assets: ^1.1.0
+  code_assets: ^2.0.0-wip
   collection: ^1.19.1
   ffi: ^2.1.0
   hooks: ^2.0.0
@@ -43,6 +43,8 @@ dependency_overrides:
     path: ../ffigen
   hooks:
     path: ../hooks
+  native_toolchain_c:
+    path: ../native_toolchain_c
   record_use:
     path: ../record_use
 

--- a/pkgs/swiftgen/example/pubspec.yaml
+++ b/pkgs/swiftgen/example/pubspec.yaml
@@ -25,8 +25,14 @@ dev_dependencies:
   test: ^1.21.1
 
 dependency_overrides:
+  code_assets:
+    path: ../../code_assets/
   ffigen:
     path: ../../ffigen/
+  hooks:
+    path: ../../hooks/
+  native_toolchain_c:
+    path: ../../native_toolchain_c/
   objective_c:
     path: ../../objective_c/
   swift2objc:

--- a/pkgs/swiftgen/pubspec.yaml
+++ b/pkgs/swiftgen/pubspec.yaml
@@ -33,8 +33,14 @@ dev_dependencies:
   test: ^1.21.1
 
 dependency_overrides:
+  code_assets:
+    path: ../code_assets/
   ffigen:
     path: ../ffigen/
+  hooks:
+    path: ../hooks/
+  native_toolchain_c:
+    path: ../native_toolchain_c/
   objective_c:
     path: ../objective_c/
   swift2objc:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ workspace:
   - pkgs/hooks_runner/test_data/add_asset_link
   - pkgs/hooks_runner/test_data/complex_link
   - pkgs/hooks_runner/test_data/complex_link_helper
+  - pkgs/hooks_runner/test_data/custom_os_arch
   - pkgs/hooks_runner/test_data/cyclic_link_package_1
   - pkgs/hooks_runner/test_data/cyclic_link_package_2
   - pkgs/hooks_runner/test_data/cyclic_package_1

--- a/tool/ci.dart
+++ b/tool/ci.dart
@@ -190,7 +190,10 @@ class WorkspaceTask extends Task {
     final rootDir = Directory.fromUri(repositoryRoot.resolve('pkgs'));
     for (final entity in rootDir.listSync(recursive: true)) {
       if (entity is File && entity.path.endsWith('pubspec.yaml')) {
-        if (entity.path.split(Platform.pathSeparator).contains('.dart_tool')) {
+        final pathSegments = entity.path.split(Platform.pathSeparator);
+        if (pathSegments.contains('.dart_tool') ||
+            pathSegments.contains('ephemeral')) {
+          // Can contain generated or symlinked pubspecs.
           continue;
         }
         packages.add(


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/3411

Closes: https://github.com/dart-lang/native/issues/1258

Enables

```dart
extension OhosOS on OS {
  static final ohos = OS.fromString('ohos');
}
```

to work properly.

The other open enums in the JSON schema that were not open in the Dart API:

* architecture
* sanitizer

Link mode and link mode preference should be closed:

* https://github.com/dart-lang/native/pull/3462

If we were to add code assets already presigned and prepackaged in xcodeframeworks for example, it would be a new asset type, rather than new option for the existing asset type.

Because we don't have a pub workspace for FFIgen and JNIgen with the other packages, we now need many more pubspec overrides. Basically before it was kinda working without a complete set of overrides because the inconsistent set of deps (half from the repo, half from pub) managed to resolve. This is no longer true with pushing `code_assets` to `v2.0.0`.
