### PR TITLE
[hooks_runner] Fix record_use file name changing caching

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1-wip
+
+- Fix record_use path changing caching issue.
+
 ## 1.5.0
 
 - Add `GOPATH`, and prefix `CONAN_` to the environment variables allowlist.

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -361,7 +361,7 @@ class NativeAssetsBuildRunner {
               output as LinkOutput,
             ),
         ],
-        targetRecordingsFile,
+        resourcesFile?.uri,
         buildDirUri,
         outDirUri,
         extensions: extensions,

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.5.0
+version: 1.5.1-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/test/build_runner/resources_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/resources_test.dart
@@ -143,7 +143,7 @@ void main() async {
       )).success;
 
       final logMessages = <String>[];
-      Future<void> runLink() async {
+      Future<void> runLink(Uri file) async {
         logMessages.clear();
         await link(
           packageUri,
@@ -151,7 +151,7 @@ void main() async {
           dartExecutable,
           buildResult: buildResult,
           recordUse: RecordUseConfig(
-            file: resourcesUri,
+            file: file,
             entryPoints: [Uri.file('bin/pirate_adventure.dart')],
             compiler: 'dart_aot_compiler_v1',
           ),
@@ -161,21 +161,34 @@ void main() async {
       }
 
       // Initial run: should run hooks.
-      await runLink();
+      await runLink(resourcesUri);
       expect(
         logMessages.join('\n'),
         stringContainsInOrder(['pirate_speak', 'hook.dill']),
       );
 
       // Second run: should be cached.
-      await runLink();
+      await runLink(resourcesUri);
       expect(
         logMessages.join('\n'),
         contains('Skipping link for pirate_speak'),
       );
 
-      // Change resources: should re-run hooks.
-      final newRecordings = Recordings(
+      // Change file path but keep contents: should be cached.
+      final resourcesUriDifferentPath = tempUri.resolve(
+        'treeshaking_info_different_path.json',
+      );
+      await File.fromUri(resourcesUriDifferentPath).writeAsString(
+        jsonEncode(_pirateAdventureRecordings.toJson()),
+      );
+      await runLink(resourcesUriDifferentPath);
+      expect(
+        logMessages.join('\n'),
+        contains('Skipping link for pirate_speak'),
+      );
+
+      // Change irrelevant recorded uses (unrelated package): should be cached.
+      final irrelevantRecordings = Recordings(
         calls: {
           ..._pirateAdventureRecordings.calls,
           const Method(
@@ -191,18 +204,44 @@ void main() async {
         },
         instances: {},
       );
+      await File.fromUri(resourcesUri).writeAsString(
+        jsonEncode(irrelevantRecordings.toJson()),
+      );
+      await runLink(resourcesUri);
+      expect(
+        logMessages.join('\n'),
+        contains('Skipping link for pirate_speak'),
+      );
+
+      // Change relevant recorded uses (this package): should re-run hooks.
+      final newRecordings = Recordings(
+        calls: {
+          ..._pirateAdventureRecordings.calls,
+          const Method(
+            'dummy',
+            Library('package:pirate_speak/src/definitions.dart'),
+          ): [
+            const CallWithArguments(
+              loadingUnit: loadingUnitRoot,
+              positionalArguments: [],
+              namedArguments: {},
+            ),
+          ],
+        },
+        instances: {},
+      );
       await File.fromUri(
         resourcesUri,
       ).writeAsString(jsonEncode(newRecordings.toJson()));
 
-      await runLink();
+      await runLink(resourcesUri);
       expect(
         logMessages.join('\n'),
         stringContainsInOrder(['pirate_speak', 'hook.dill']),
       );
 
       // Run again: should be cached again.
-      await runLink();
+      await runLink(resourcesUri);
       expect(
         logMessages.join('\n'),
         contains('Skipping link for pirate_speak'),


### PR DESCRIPTION
Addresses caching issue when the record-use file path is changing but the contents don't.

The [caching tests started failing](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8678291907058904705/+/u/test_results/new_test_failures__logs_) after trying to give record-use a file name that's changing.