### PR TITLE
[jnigen] Generate Dart @Deprecated annotations

### DIFF
--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.g.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.g.dart
@@ -1961,6 +1961,7 @@ extension EmojiCompat$$Methods on EmojiCompat {
               jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
 
   /// from: `public boolean hasEmojiGlyph(java.lang.CharSequence charSequence)`
+  @core$_.Deprecated('This Java method is deprecated.')
   core$_.bool hasEmojiGlyph(
     CharSequence charSequence,
   ) {
@@ -1989,6 +1990,7 @@ extension EmojiCompat$$Methods on EmojiCompat {
               jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>, core$_.int)>();
 
   /// from: `public boolean hasEmojiGlyph(java.lang.CharSequence charSequence, int i)`
+  @core$_.Deprecated('This Java method is deprecated.')
   core$_.bool hasEmojiGlyph$1(
     CharSequence charSequence,
     core$_.int i,

--- a/pkgs/jnigen/example/maven_libs/lib/maven_libs_bindings.dart
+++ b/pkgs/jnigen/example/maven_libs/lib/maven_libs_bindings.dart
@@ -113,6 +113,7 @@ extension Gson$$Methods on Gson {
 
   /// from: `public com.google.gson.internal.Excluder excluder()`
   /// The returned object must be released after use, by calling the [release] method.
+  @core$_.Deprecated('This Java method is deprecated.')
   Excluder? excluder() {
     final _$$selfRef = reference;
     return _excluder(_$$selfRef.pointer, _id_excluder.pointer)

--- a/pkgs/jnigen/example/maven_libs_groovy/lib/maven_libs_bindings.dart
+++ b/pkgs/jnigen/example/maven_libs_groovy/lib/maven_libs_bindings.dart
@@ -113,6 +113,7 @@ extension Gson$$Methods on Gson {
 
   /// from: `public com.google.gson.internal.Excluder excluder()`
   /// The returned object must be released after use, by calling the [release] method.
+  @core$_.Deprecated('This Java method is deprecated.')
   Excluder? excluder() {
     final _$$selfRef = reference;
     return _excluder(_$$selfRef.pointer, _id_excluder.pointer)

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -1309,6 +1309,7 @@ extension PDDocument$$Methods on PDDocument {
   ///@throws IOException if there is an error creating required fields
   ///@deprecated The method is misleading, because only one signature may be
   /// added in a document. The method will be removed in the future.
+  @core$_.Deprecated('This Java method is deprecated.')
   void addSignatureField(
     jni$_.JList<pdsignaturefield$_.PDSignatureField?>? sigFields,
     signatureinterface$_.SignatureInterface? signatureInterface,

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -1309,6 +1309,9 @@ ${modifier}final _$idName = $_protectedExtension
       defArgs.removeLast();
     }
     final params = defArgs.delimited(', ');
+    if (node.isDeprecated) {
+      s.writeln("  @core\$_.Deprecated('This Java method is deprecated.')");
+    }
     if (node.methodKind == MethodKind.getter) {
       s.write('  $ifStatic$returnType get $name ');
     } else if (node.methodKind == MethodKind.setter) {

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -756,6 +756,9 @@ class Method with ClassMember, Annotated implements Element<Method> {
 
   bool get isConstructor => name == '<init>';
 
+  bool get isDeprecated =>
+      annotations?.any((a) => a.binaryName == 'java.lang.Deprecated') ?? false;
+
   factory Method.fromJson(Map<String, dynamic> json) => _$MethodFromJson(json);
 
   Method clone({GenerationStage until = GenerationStage.userVisitors}) {

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -1016,6 +1016,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@param state Whether to enable or disable the feature
   ///@return This factory instance (to allow call chaining)
   ///@deprecated since 2.10 use JsonFactoryBuilder\#configure(JsonFactory.Feature, boolean) instead
+  @core$_.Deprecated('This Java method is deprecated.')
   JsonFactory? configure(
     JsonFactory$Feature? f,
     core$_.bool state,
@@ -1051,6 +1052,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@param f Feature to enable
   ///@return This factory instance (to allow call chaining)
   ///@deprecated since 2.10 use JsonFactoryBuilder\#configure(JsonFactory.Feature, boolean) instead
+  @core$_.Deprecated('This Java method is deprecated.')
   JsonFactory? enable(
     JsonFactory$Feature? f,
   ) {
@@ -1084,6 +1086,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@param f Feature to disable
   ///@return This factory instance (to allow call chaining)
   ///@deprecated since 2.10 use JsonFactoryBuilder\#configure(JsonFactory.Feature, boolean) instead
+  @core$_.Deprecated('This Java method is deprecated.')
   JsonFactory? disable(
     JsonFactory$Feature? f,
   ) {
@@ -1442,6 +1445,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@param d Decorator to configure for this factory, if any ({@code null} if none)
   ///@return This factory instance (to allow call chaining)
   ///@deprecated Since 2.10 use JsonFactoryBuilder\#inputDecorator(InputDecorator) instead
+  @core$_.Deprecated('This Java method is deprecated.')
   JsonFactory? setInputDecorator(
     inputdecorator$_.InputDecorator? d,
   ) {
@@ -1732,6 +1736,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@return This factory instance (to allow call chaining)
   ///@param d Output decorator to use, if any
   ///@deprecated Since 2.10 use JsonFactoryBuilder\#outputDecorator(OutputDecorator) instead
+  @core$_.Deprecated('This Java method is deprecated.')
   JsonFactory? setOutputDecorator(
     outputdecorator$_.OutputDecorator? d,
   ) {
@@ -2585,6 +2590,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(File) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsonparser$_.JsonParser? createJsonParser(
     file$_.File? f,
   ) {
@@ -2631,6 +2637,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(URL) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsonparser$_.JsonParser? createJsonParser$1(
     url$_.URL? url,
   ) {
@@ -2680,6 +2687,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(InputStream) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsonparser$_.JsonParser? createJsonParser$2(
     inputstream$_.InputStream? in$,
   ) {
@@ -2722,6 +2730,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(Reader) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsonparser$_.JsonParser? createJsonParser$3(
     reader$_.Reader? r,
   ) {
@@ -2757,6 +2766,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(byte[]) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsonparser$_.JsonParser? createJsonParser$4(
     jni$_.JByteArray? data,
   ) {
@@ -2803,6 +2813,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(byte[],int,int) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsonparser$_.JsonParser? createJsonParser$5(
     jni$_.JByteArray? data,
     core$_.int offset,
@@ -2841,6 +2852,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(String) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsonparser$_.JsonParser? createJsonParser$6(
     jni$_.JString? content,
   ) {
@@ -2896,6 +2908,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@return Generator constructed
   ///@throws IOException if parser initialization fails due to I/O (write) problem
   ///@deprecated Since 2.2, use \#createGenerator(OutputStream, JsonEncoding) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsongenerator$_.JsonGenerator? createJsonGenerator(
     outputstream$_.OutputStream? out,
     jsonencoding$_.JsonEncoding? enc,
@@ -2940,6 +2953,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@return Generator constructed
   ///@throws IOException if parser initialization fails due to I/O (write) problem
   ///@deprecated Since 2.2, use \#createGenerator(Writer) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsongenerator$_.JsonGenerator? createJsonGenerator$1(
     writer$_.Writer? out,
   ) {
@@ -2977,6 +2991,7 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@return Generator constructed
   ///@throws IOException if parser initialization fails due to I/O (write) problem
   ///@deprecated Since 2.2, use \#createGenerator(OutputStream) instead.
+  @core$_.Deprecated('This Java method is deprecated.')
   jsongenerator$_.JsonGenerator? createJsonGenerator$2(
     outputstream$_.OutputStream? out,
   ) {

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -1919,6 +1919,7 @@ extension JsonParser$$Methods on JsonParser {
   ///@return This parser, to allow call chaining
   ///@since 2.3
   ///@deprecated Since 2.7, use \#overrideStdFeatures(int, int) instead
+  @core$_.Deprecated('This Java method is deprecated.')
   JsonParser? setFeatureMask(
     core$_.int mask,
   ) {
@@ -2557,6 +2558,7 @@ extension JsonParser$$Methods on JsonParser {
   /// Deprecated alias for \#currentTokenId().
   ///@return {@code int} matching one of constants from JsonTokenId.
   ///@deprecated Since 2.12 use \#currentTokenId instead
+  @core$_.Deprecated('This Java method is deprecated.')
   core$_.int get currentTokenId$1 {
     final _$$selfRef = reference;
     return _get$currentTokenId$1(

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -1264,6 +1264,32 @@ extension Example$$Methods on Example {
         .object<jni$_.JString?>();
   }
 
+  static final _id_deprecatedMethod = Example._class.instanceMethodId(
+    r'deprecatedMethod',
+    r'()Ljava/lang/String;',
+  );
+
+  static final _deprecatedMethod = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JniResult Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(
+            jni$_.Pointer<jni$_.Void>,
+            jni$_.JMethodIDPtr,
+          )>();
+
+  /// from: `public java.lang.String deprecatedMethod()`
+  /// The returned object must be released after use, by calling the [release] method.
+  @core$_.Deprecated('This Java method is deprecated.')
+  jni$_.JString? deprecatedMethod() {
+    final _$$selfRef = reference;
+    return _deprecatedMethod(_$$selfRef.pointer, _id_deprecatedMethod.pointer)
+        .object<jni$_.JString?>();
+  }
+
   static final _id_methodWithSeveralParams = Example._class.instanceMethodId(
     r'methodWithSeveralParams',
     r'(CLjava/lang/String;[ILjava/lang/CharSequence;Ljava/util/List;Ljava/util/Map;)V',

--- a/pkgs/jnigen/test/simple_package_test/java/com/github/dart_lang/jnigen/simple_package/Example.java
+++ b/pkgs/jnigen/test/simple_package_test/java/com/github/dart_lang/jnigen/simple_package/Example.java
@@ -147,6 +147,11 @@ public class Example {
     return null;
   }
 
+  @Deprecated
+  public String deprecatedMethod() {
+    return "deprecated";
+  }
+
   public <T extends CharSequence> void methodWithSeveralParams(
       char ch, String s, int[] a, T t, List<T> lt, Map<String, ? extends CharSequence> wm) {}
 


### PR DESCRIPTION
Addresses part of #2796

This PR generates Dart @Deprecated annotations for Java methods annotated with java.lang.Deprecated during jnigen binding generation.

Changes
- Add a Method.isDeprecated helper to detect java.lang.Deprecated annotations.
- Emit Dart @Deprecated('This Java method is deprecated.') for generated bindings of deprecated Java methods.
- Add a deprecated method to the simple package test fixture to validate the generated annotation. 

Note
This PR focuses on generating Dart deprecation annotations. It does not yet propagate Java/Kotlin deprecation messages or replacement suggestions mentioned in #2796.