### PR TITLE
[native_toolchain_c] Pass `--triple` to `objdump` in cross-compilation tests

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -78,6 +78,10 @@ jobs:
       - name: Run pub get, analysis, formatting, generators, tests, and examples.
         run: dart tool/ci.dart --all --no-apitool ${{ matrix.sdk == 'stable' && '--no-format' || '' }}
 
+      - name: Trust Coveralls tap
+        run: brew trust coverallsapp/coveralls
+        if: ${{ matrix.os == 'macos' }}
+
       - name: Upload coverage
         uses: coverallsapp/github-action@0a51d2e0b5417d06e4ecceb534aec87defc53926
         with:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -200,30 +200,7 @@ void main() async {
         final libUri = buildInput.outputDirectory.resolve(
           os.libraryFileName(name, linkMode),
         );
-        final triple = switch ((os, arch)) {
-          (OS.linux, Architecture.arm) => 'arm-linux-gnueabihf',
-          (OS.linux, Architecture.arm64) => 'aarch64-linux-gnu',
-          (OS.linux, Architecture.ia32) => 'i686-linux-gnu',
-          (OS.linux, Architecture.x64) => 'x86_64-linux-gnu',
-          (OS.linux, Architecture.riscv32) => 'riscv32-linux-gnu',
-          (OS.linux, Architecture.riscv64) => 'riscv64-linux-gnu',
-          _ => null,
-        };
-
-        final result = await runProcess(
-          executable: Uri.file('objdump'),
-          arguments: [
-            if (triple != null) '--triple=$triple',
-            '-t',
-            libUri.path,
-          ],
-          logger: logger,
-        );
-        expect(result.exitCode, 0);
-        final machine = result.stdout
-            .split('\n')
-            .firstWhere((e) => e.contains('file format'));
-        expect(machine, contains(objdumpFileFormat[(os, arch)]));
+        await expectMachineArchitecture(libUri, arch, os);
       },
       skip: os == OS.linux && !lldAvailable ? 'ld.lld not available' : null,
     );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -200,9 +200,23 @@ void main() async {
         final libUri = buildInput.outputDirectory.resolve(
           os.libraryFileName(name, linkMode),
         );
+        final triple = switch ((os, arch)) {
+          (OS.linux, Architecture.arm) => 'arm-linux-gnueabihf',
+          (OS.linux, Architecture.arm64) => 'aarch64-linux-gnu',
+          (OS.linux, Architecture.ia32) => 'i686-linux-gnu',
+          (OS.linux, Architecture.x64) => 'x86_64-linux-gnu',
+          (OS.linux, Architecture.riscv32) => 'riscv32-linux-gnu',
+          (OS.linux, Architecture.riscv64) => 'riscv64-linux-gnu',
+          _ => null,
+        };
+
         final result = await runProcess(
           executable: Uri.file('objdump'),
-          arguments: ['-t', libUri.path],
+          arguments: [
+            if (triple != null) '--triple=$triple',
+            '-t',
+            libUri.path,
+          ],
           logger: logger,
         );
         expect(result.exitCode, 0);

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -402,9 +402,27 @@ Future<void> expectMachineArchitecture(
     final machine = await readelfMachine(libUri.path);
     expect(machine, contains(readElfMachine[targetArch]));
   } else if (Platform.isMacOS) {
+    final triple = switch ((targetOS, targetArch)) {
+      (OS.linux, Architecture.arm) => 'arm-linux-gnueabihf',
+      (OS.linux, Architecture.arm64) => 'aarch64-linux-gnu',
+      (OS.linux, Architecture.ia32) => 'i686-linux-gnu',
+      (OS.linux, Architecture.x64) => 'x86_64-linux-gnu',
+      (OS.linux, Architecture.riscv32) => 'riscv32-linux-gnu',
+      (OS.linux, Architecture.riscv64) => 'riscv64-linux-gnu',
+      (OS.android, Architecture.arm) => 'arm-linux-androideabi',
+      (OS.android, Architecture.arm64) => 'aarch64-linux-android',
+      (OS.android, Architecture.ia32) => 'i686-linux-android',
+      (OS.android, Architecture.x64) => 'x86_64-linux-android',
+      (OS.android, Architecture.riscv64) => 'riscv64-linux-android',
+      _ => null,
+    };
     final result = await runProcess(
       executable: Uri.file('objdump'),
-      arguments: ['-T', libUri.path],
+      arguments: [
+        if (triple != null) '--triple=$triple',
+        '-T',
+        libUri.path,
+      ],
       logger: logger,
     );
     expect(result.exitCode, 0);

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -376,10 +376,20 @@ const objdumpFileFormatIOS = {
   Architecture.x64: '64-bit x86-64',
 };
 
+const objdumpFileFormatLinux = {
+  Architecture.arm: 'elf32-littlearm',
+  Architecture.arm64: 'elf64-littleaarch64',
+  Architecture.ia32: 'elf32-i386',
+  Architecture.x64: 'elf64-x86-64',
+  Architecture.riscv32: 'elf32-riscv32',
+  Architecture.riscv64: 'elf64-riscv64',
+};
+
 const targetOSToObjdumpFileFormat = {
   OS.android: objdumpFileFormatAndroid,
   OS.macOS: objdumpFileFormatMacOS,
   OS.iOS: objdumpFileFormatMacOS,
+  OS.linux: objdumpFileFormatLinux,
 };
 
 const dumpbinFileFormat = {


### PR DESCRIPTION
```
  INFO: 2026-06-23 08:26:54.090624: Running `objdump -t /private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/8H5Vcn/cae0822077/libadd.a`.
  Bad state: No element
  dart:collection                                                                   ListBase.firstWhere
  pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart 211:14  main.<fn>
```

https://github.com/dart-lang/native/actions/runs/28012425103/job/82908553071

Apparently newer apple `objdump` implementations (since `clang` `21.0.0`) don't inspect the magic bytes and try to read elf files as macho files if you don't pass in the target tripple.

```
Error: Refusing to load formula coverallsapp/coveralls/coveralls from untrusted tap coverallsapp/coveralls.
```

https://github.com/dart-lang/native/actions/runs/28193880144/job/83515324202

And Brew also became more strict.