### PR TITLE
[native_toolchain_c] Use `-t` instead of `-T` for static libraries in `objdump`

### DIFF
--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -426,11 +426,12 @@ Future<void> expectMachineArchitecture(
       (OS.android, Architecture.riscv64) => 'riscv64-linux-android',
       _ => null,
     };
+    final isStatic = libUri.path.endsWith('.a') || libUri.path.endsWith('.lib');
     final result = await runProcess(
       executable: Uri.file('objdump'),
       arguments: [
         if (triple != null) '--triple=$triple',
-        '-T',
+        isStatic ? '-t' : '-T',
         libUri.path,
       ],
       logger: logger,


### PR DESCRIPTION
Follow up of https://github.com/dart-lang/native/pull/3434, no idea why CI was green on that PR but now red on main.