### PR TITLE
[native_toolchain_c] Fix CI try 3

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.2
+
+- Fixed compatibility with newer Xcode versions when cross-compiling static libraries on macOS hosts targeting Android and Linux.
+
 ## 0.19.1
 
 - Added support for passing sanitizer flags (`-fsanitize=address`, `-fsanitize=memory`, `-fsanitize=thread`) to C compilers and linkers.

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:math';
 
 import 'package:code_assets/code_assets.dart';
@@ -200,10 +201,14 @@ class RunCBuilder {
         );
         objectFiles.add(objectFile);
       }
+      final isMacToElfCross =
+          Platform.isMacOS &&
+          (codeConfig.targetOS == OS.linux ||
+              codeConfig.targetOS == OS.android);
       await runProcess(
         executable: archiver_!,
         arguments: [
-          'rc',
+          isMacToElfCross ? 'rcS' : 'rc',
           outDir.resolveUri(staticLibrary!).toFilePath(),
           ...objectFiles.map((objectFile) => objectFile.toFilePath()),
         ],

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.19.1
+version: 0.19.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:


### PR DESCRIPTION
I've now installed xcode 26.5 with clang 21.0.0 locally.

I don't know why the bot on the PR passes but then fails when merged into main. Gemini suspects GitHub provisions different machine types for `macos-latest`. (Edit: apparently we were skipping https://github.com/dart-lang/native/pull/3438. But that doesn't explain why we would skip on the PR and not on the main branch...)

Adding `S` should prevent Apple's `ranlib` trying to add a Mach-O symbol table to the ELF file. 