### PR TITLE
[hooks_runner] Skip dynamic lookup on Linux/Android

### DIFF
--- a/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/test/add_test.dart
+++ b/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/test/add_test.dart
@@ -6,19 +6,31 @@
 library;
 
 import 'dart:ffi';
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:treeshaking_dylib_record_use/treeshaking_dylib_record_use.dart';
 
 void main() {
   test('add works, but subtract and multiply are tree-shaken', () {
+    // Dynamic lookup via Process only works on platforms where the dynamic
+    // linker searches RTLD_LOCAL loaded libraries (like macOS and Windows).
+    // TODO(https://github.com/dart-lang/sdk/issues/63295): Use
+    // DynamicLibrary.openAsset when available.
+    final skipDynamicLookup = (Platform.isLinux || Platform.isAndroid)
+        ? 'DynamicLibrary.process() does not search RTLD_LOCAL libraries on Linux/Android'
+        : null;
+
     // 1. Statically call `add`, which records it as used and keeps it.
     expect(add(10, 5), equals(15));
 
     // 2. Look up 'add' dynamically; it should succeed.
     final process = DynamicLibrary.process();
     expect(
-      process.lookup<NativeFunction<Int32 Function(Int32, Int32)>>('add'),
-      isNotNull,
+      () => process.lookup<NativeFunction<Int32 Function(Int32, Int32)>>(
+        'add',
+      ),
+      returnsNormally,
+      skip: skipDynamicLookup,
     );
 
     // 3. 'subtract' is not statically called, so it should be tree-shaken
@@ -28,6 +40,7 @@ void main() {
         'subtract',
       ),
       throwsArgumentError,
+      skip: skipDynamicLookup,
     );
 
     // 4. 'multiply' is completely unused, so the entire multiply library

--- a/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/test/multiply_test.dart
+++ b/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/test/multiply_test.dart
@@ -6,19 +6,31 @@
 library;
 
 import 'dart:ffi';
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:treeshaking_dylib_record_use/treeshaking_dylib_record_use.dart';
 
 void main() {
   test('multiply works, but divide is tree-shaken', () {
+    // Dynamic lookup via Process only works on platforms where the dynamic
+    // linker searches RTLD_LOCAL loaded libraries (like macOS and Windows).
+    // TODO(https://github.com/dart-lang/sdk/issues/63295): Use
+    // DynamicLibrary.openAsset when available.
+    final skipDynamicLookup = (Platform.isLinux || Platform.isAndroid)
+        ? 'DynamicLibrary.process() does not search RTLD_LOCAL libraries on Linux/Android'
+        : null;
+
     // 1. Statically call `multiply`, which records it as used and keeps it.
     expect(multiply(14, 3), equals(42));
 
     // 2. Look up 'multiply' dynamically; it should succeed.
     final process = DynamicLibrary.process();
     expect(
-      process.lookup<NativeFunction<Int32 Function(Int32, Int32)>>('multiply'),
-      isNotNull,
+      () => process.lookup<NativeFunction<Int32 Function(Int32, Int32)>>(
+        'multiply',
+      ),
+      returnsNormally,
+      skip: skipDynamicLookup,
     );
 
     // 3. 'divide' is not statically called, so it should be tree-shaken
@@ -28,6 +40,7 @@ void main() {
         'divide',
       ),
       throwsArgumentError,
+      skip: skipDynamicLookup,
     );
   });
 }

--- a/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/test/subtract_test.dart
+++ b/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/test/subtract_test.dart
@@ -6,19 +6,31 @@
 library;
 
 import 'dart:ffi';
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:treeshaking_dylib_record_use/treeshaking_dylib_record_use.dart';
 
 void main() {
   test('subtract works, but add and multiply are tree-shaken', () {
+    // Dynamic lookup via Process only works on platforms where the dynamic
+    // linker searches RTLD_LOCAL loaded libraries (like macOS and Windows).
+    // TODO(https://github.com/dart-lang/sdk/issues/63295): Use
+    // DynamicLibrary.openAsset when available.
+    final skipDynamicLookup = (Platform.isLinux || Platform.isAndroid)
+        ? 'DynamicLibrary.process() does not search RTLD_LOCAL libraries on Linux/Android'
+        : null;
+
     // 1. Statically call `subtract`, which records it as used and keeps it.
     expect(subtract(10, 5), equals(5));
 
     // 2. Look up 'subtract' dynamically; it should succeed.
     final process = DynamicLibrary.process();
     expect(
-      process.lookup<NativeFunction<Int32 Function(Int32, Int32)>>('subtract'),
-      isNotNull,
+      () => process.lookup<NativeFunction<Int32 Function(Int32, Int32)>>(
+        'subtract',
+      ),
+      returnsNormally,
+      skip: skipDynamicLookup,
     );
 
     // 3. 'add' is not statically called, so it should be tree-shaken
@@ -26,6 +38,7 @@ void main() {
     expect(
       () => process.lookup<NativeFunction<Int32 Function(Int32, Int32)>>('add'),
       throwsArgumentError,
+      skip: skipDynamicLookup,
     );
 
     // 4. 'multiply' is completely unused, so the entire multiply library


### PR DESCRIPTION
My test writing was _too_ clever. `DynamicLibrary.process()` doesn't find the symbols on Linux and Android because the dynamic libraries are not opened with `RLTD_GLOBAL` on those OSes. The dylib loading defaults are different than MacOS/Windows.

We can properly test once we have `DynamicLibrary.openAsset(assetId)`. For now skip the test expectations on Linux.

Tested via https://dart-review.googlesource.com/c/sdk/+/518780. [failure logs](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8677566494195999777/+/u/test_results/new_test_failures__logs_)

Tested locally on Linux machine.