### PR TITLE
[jni] Handle more kinds of no such method error

### DIFF
--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -311,6 +311,33 @@ jobs:
       #     dart run tool/generate_ffi_bindings.dart
       #     git diff --exit-code -- lib/src/third_party src/third_party
 
+  test_jni_android:
+    needs: [analyze_jni]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./pkgs/jni/example
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        with:
+          channel: 'stable'
+          cache: true
+          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+      - run: flutter pub get
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a
+        with:
+          api-level: 26
+          arch: x86_64
+          script: flutter test --timeout=1200s integration_test/on_device_jni_test.dart
+          working-directory: ./pkgs/jni/example
+
   ## Run tests for package:jni on windows, just to confirm it works.
   ## Do not, for example, collect coverage or check formatting.
   test_jni_windows_minimal:

--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.1-wip
 
 - Improve error message when JNI is used before Flutter plugin initialization.
+- Improve no such method error handling.
 
 ## 1.0.0
 

--- a/pkgs/jni/example/integration_test/on_device_jni_test.dart
+++ b/pkgs/jni/example/integration_test/on_device_jni_test.dart
@@ -15,6 +15,7 @@ import '../../test/jarray_test.dart' as jarray_test;
 import '../../test/boxed_test.dart' as boxed_test;
 import '../../test/load_test.dart' as load_test;
 import '../../test/isolate_test.dart' as isolate_test;
+import '../../test/no_such_method_test.dart' as no_such_method_test;
 
 void integrationTestRunner(String description, void Function() testCallback,
     {Object? skip}) {
@@ -35,6 +36,7 @@ void main() {
     boxed_test.run,
     load_test.run,
     isolate_test.run,
+    no_such_method_test.run,
   ];
   for (var testSuite in testSuites) {
     testSuite(testRunner: integrationTestRunner);

--- a/pkgs/jni/lib/src/errors.dart
+++ b/pkgs/jni/lib/src/errors.dart
@@ -41,6 +41,12 @@ final class JNullError extends StateError {
   JNullError() : super('The reference was null');
 }
 
+final class NoSuchMethodError extends StateError {
+  final String name;
+
+  NoSuchMethodError(this.name) : super('No such method: $name');
+}
+
 final class DoubleReleaseError extends StateError with _ExplainsRelease {
   @override
   final String? releaseStackTrace;

--- a/pkgs/jni/lib/src/errors.dart
+++ b/pkgs/jni/lib/src/errors.dart
@@ -44,7 +44,7 @@ final class JNullError extends StateError {
 final class NoSuchMethodError extends StateError {
   final String name;
 
-  NoSuchMethodError(this.name) : super('No such method: $name');
+  NoSuchMethodError(this.name) : super('No such method or field: $name');
 }
 
 final class DoubleReleaseError extends StateError with _ExplainsRelease {

--- a/pkgs/jni/lib/src/jclass.dart
+++ b/pkgs/jni/lib/src/jclass.dart
@@ -42,11 +42,15 @@ extension type JInstanceFieldId._fromPointer(JFieldIDPtr pointer) {
   JInstanceFieldId._(JClass jClass, String name, String signature)
       : pointer = using((arena) {
           final jClassRef = jClass.reference;
-          return Jni.env.GetFieldID(
+          final ptr = Jni.env.GetFieldID(
             jClassRef.pointer,
             name.toNativeChars(arena),
             signature.toNativeChars(arena),
           );
+          if (ptr == nullptr) {
+            throw NoSuchMethodError(name);
+          }
+          return ptr;
         });
 
   DartT get<JavaT, DartT>(JObject object, JAccessible<JavaT, DartT> type) {
@@ -72,11 +76,15 @@ extension type JStaticFieldId._fromPointer(JFieldIDPtr pointer) {
   JStaticFieldId._(JClass jClass, String name, String signature)
       : pointer = using((arena) {
           final jClassRef = jClass.reference;
-          return Jni.env.GetStaticFieldID(
+          final ptr = Jni.env.GetStaticFieldID(
             jClassRef.pointer,
             name.toNativeChars(arena),
             signature.toNativeChars(arena),
           );
+          if (ptr == nullptr) {
+            throw NoSuchMethodError(name);
+          }
+          return ptr;
         });
 
   DartT get<JavaT, DartT>(JClass jClass, JAccessible<JavaT, DartT> type) {
@@ -107,11 +115,15 @@ class JInstanceMethodId {
     String signature,
   ) : pointer = using((arena) {
           final jClassRef = jClass.reference;
-          return Jni.env.GetMethodID(
+          final ptr = Jni.env.GetMethodID(
             jClassRef.pointer,
             name.toNativeChars(arena),
             signature.toNativeChars(arena),
           );
+          if (ptr == nullptr) {
+            throw NoSuchMethodError(name);
+          }
+          return ptr;
         });
 
   /// Calls the instance method on [object] with the given arguments.
@@ -149,11 +161,15 @@ extension type JStaticMethodId._fromPointer(JMethodIDPtr pointer) {
     String signature,
   ) : pointer = using((arena) {
           final jClassRef = jClass.reference;
-          return Jni.env.GetStaticMethodID(
+          final ptr = Jni.env.GetStaticMethodID(
             jClassRef.pointer,
             name.toNativeChars(arena),
             signature.toNativeChars(arena),
           );
+          if (ptr == nullptr) {
+            throw NoSuchMethodError(name);
+          }
+          return ptr;
         });
 
   /// Calls the static method on [jClass] with the given arguments.
@@ -186,11 +202,15 @@ extension type JConstructorId._fromPointer(JMethodIDPtr pointer) {
     String signature,
   ) : pointer = using((arena) {
           final jClassRef = jClass.reference;
-          return Jni.env.GetMethodID(
+          final ptr = Jni.env.GetMethodID(
             jClassRef.pointer,
             '<init>'.toNativeChars(arena),
             signature.toNativeChars(arena),
           );
+          if (ptr == nullptr) {
+            throw NoSuchMethodError('<init>');
+          }
+          return ptr;
         });
 
   /// Constructs an instance of [jClass] with the given arguments.

--- a/pkgs/jni/lib/src/types.dart
+++ b/pkgs/jni/lib/src/types.dart
@@ -7,6 +7,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart' show internal;
 
+import 'errors.dart';
 import 'jni.dart';
 import 'jobject.dart';
 import 'jreference.dart';

--- a/pkgs/jni/test/no_such_method_test.dart
+++ b/pkgs/jni/test/no_such_method_test.dart
@@ -19,80 +19,95 @@ void main() {
 
 void run({required TestRunnerCallback testRunner}) {
   group('Method, Field, and Constructor Lookup Failure Tests', () {
-    testRunner('Non-existent constructorId throws java.lang.NoSuchMethodError', () {
-      final stringClass = JClass.forName('java/lang/String');
-      // java.lang.String does not have a (I)V constructor (i.e. new String(int))
-      expect(
-        () => stringClass.constructorId('(I)V'),
-        throwsA(
-          isA<JThrowable>().having(
-            (e) => e.toString(),
-            'toString()',
-            contains('java.lang.NoSuchMethodError'),
+    testRunner(
+      'Non-existent constructorId throws java.lang.NoSuchMethodError',
+      () {
+        final stringClass = JClass.forName('java/lang/String');
+        // java.lang.String does not have a (I)V constructor (new String(int))
+        expect(
+          () => stringClass.constructorId('(I)V'),
+          throwsA(
+            isA<JThrowable>().having(
+              (e) => e.toString(),
+              'toString()',
+              contains('java.lang.NoSuchMethodError'),
+            ),
           ),
-        ),
-      );
-      stringClass.release();
-    });
+        );
+        stringClass.release();
+      },
+    );
 
-    testRunner('Non-existent instanceMethodId throws java.lang.NoSuchMethodError', () {
-      final stringClass = JClass.forName('java/lang/String');
-      expect(
-        () => stringClass.instanceMethodId('nonExistentMethod', '()V'),
-        throwsA(
-          isA<JThrowable>().having(
-            (e) => e.toString(),
-            'toString()',
-            contains('java.lang.NoSuchMethodError'),
+    testRunner(
+      'Non-existent instanceMethodId throws java.lang.NoSuchMethodError',
+      () {
+        final stringClass = JClass.forName('java/lang/String');
+        expect(
+          () => stringClass.instanceMethodId('nonExistentMethod', '()V'),
+          throwsA(
+            isA<JThrowable>().having(
+              (e) => e.toString(),
+              'toString()',
+              contains('java.lang.NoSuchMethodError'),
+            ),
           ),
-        ),
-      );
-      stringClass.release();
-    });
+        );
+        stringClass.release();
+      },
+    );
 
-    testRunner('Non-existent staticMethodId throws java.lang.NoSuchMethodError', () {
-      final stringClass = JClass.forName('java/lang/String');
-      expect(
-        () => stringClass.staticMethodId('nonExistentStaticMethod', '()V'),
-        throwsA(
-          isA<JThrowable>().having(
-            (e) => e.toString(),
-            'toString()',
-            contains('java.lang.NoSuchMethodError'),
+    testRunner(
+      'Non-existent staticMethodId throws java.lang.NoSuchMethodError',
+      () {
+        final stringClass = JClass.forName('java/lang/String');
+        expect(
+          () => stringClass.staticMethodId('nonExistentStaticMethod', '()V'),
+          throwsA(
+            isA<JThrowable>().having(
+              (e) => e.toString(),
+              'toString()',
+              contains('java.lang.NoSuchMethodError'),
+            ),
           ),
-        ),
-      );
-      stringClass.release();
-    });
+        );
+        stringClass.release();
+      },
+    );
 
-    testRunner('Non-existent instanceFieldId throws java.lang.NoSuchFieldError', () {
-      final stringClass = JClass.forName('java/lang/String');
-      expect(
-        () => stringClass.instanceFieldId('nonExistentField', 'I'),
-        throwsA(
-          isA<JThrowable>().having(
-            (e) => e.toString(),
-            'toString()',
-            contains('java.lang.NoSuchFieldError'),
+    testRunner(
+      'Non-existent instanceFieldId throws java.lang.NoSuchFieldError',
+      () {
+        final stringClass = JClass.forName('java/lang/String');
+        expect(
+          () => stringClass.instanceFieldId('nonExistentField', 'I'),
+          throwsA(
+            isA<JThrowable>().having(
+              (e) => e.toString(),
+              'toString()',
+              contains('java.lang.NoSuchFieldError'),
+            ),
           ),
-        ),
-      );
-      stringClass.release();
-    });
+        );
+        stringClass.release();
+      },
+    );
 
-    testRunner('Non-existent staticFieldId throws java.lang.NoSuchFieldError', () {
-      final stringClass = JClass.forName('java/lang/String');
-      expect(
-        () => stringClass.staticFieldId('nonExistentStaticField', 'I'),
-        throwsA(
-          isA<JThrowable>().having(
-            (e) => e.toString(),
-            'toString()',
-            contains('java.lang.NoSuchFieldError'),
+    testRunner(
+      'Non-existent staticFieldId throws java.lang.NoSuchFieldError',
+      () {
+        final stringClass = JClass.forName('java/lang/String');
+        expect(
+          () => stringClass.staticFieldId('nonExistentStaticField', 'I'),
+          throwsA(
+            isA<JThrowable>().having(
+              (e) => e.toString(),
+              'toString()',
+              contains('java.lang.NoSuchFieldError'),
+            ),
           ),
-        ),
-      );
-      stringClass.release();
-    });
+        );
+        stringClass.release();
+      },
+    );
   });
 }

--- a/pkgs/jni/test/no_such_method_test.dart
+++ b/pkgs/jni/test/no_such_method_test.dart
@@ -20,17 +20,19 @@ void main() {
 void run({required TestRunnerCallback testRunner}) {
   group('Method, Field, and Constructor Lookup Failure Tests', () {
     testRunner(
-      'Non-existent constructorId throws java.lang.NoSuchMethodError',
+      'Non-existent constructorId throws NoSuchMethodError or JThrowable',
       () {
         final stringClass = JClass.forName('java/lang/String');
-        // java.lang.String does not have a (I)V constructor (new String(int))
         expect(
           () => stringClass.constructorId('(I)V'),
           throwsA(
-            isA<JThrowable>().having(
-              (e) => e.toString(),
-              'toString()',
-              contains('java.lang.NoSuchMethodError'),
+            anyOf(
+              isA<NoSuchMethodError>().having(
+                (e) => e.name,
+                'name',
+                '<init>',
+              ),
+              isA<JThrowable>(),
             ),
           ),
         );
@@ -39,16 +41,19 @@ void run({required TestRunnerCallback testRunner}) {
     );
 
     testRunner(
-      'Non-existent instanceMethodId throws java.lang.NoSuchMethodError',
+      'Non-existent instanceMethodId throws NoSuchMethodError or JThrowable',
       () {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.instanceMethodId('nonExistentMethod', '()V'),
           throwsA(
-            isA<JThrowable>().having(
-              (e) => e.toString(),
-              'toString()',
-              contains('java.lang.NoSuchMethodError'),
+            anyOf(
+              isA<NoSuchMethodError>().having(
+                (e) => e.name,
+                'name',
+                'nonExistentMethod',
+              ),
+              isA<JThrowable>(),
             ),
           ),
         );
@@ -57,16 +62,19 @@ void run({required TestRunnerCallback testRunner}) {
     );
 
     testRunner(
-      'Non-existent staticMethodId throws java.lang.NoSuchMethodError',
+      'Non-existent staticMethodId throws NoSuchMethodError or JThrowable',
       () {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.staticMethodId('nonExistentStaticMethod', '()V'),
           throwsA(
-            isA<JThrowable>().having(
-              (e) => e.toString(),
-              'toString()',
-              contains('java.lang.NoSuchMethodError'),
+            anyOf(
+              isA<NoSuchMethodError>().having(
+                (e) => e.name,
+                'name',
+                'nonExistentStaticMethod',
+              ),
+              isA<JThrowable>(),
             ),
           ),
         );
@@ -75,16 +83,19 @@ void run({required TestRunnerCallback testRunner}) {
     );
 
     testRunner(
-      'Non-existent instanceFieldId throws java.lang.NoSuchFieldError',
+      'Non-existent instanceFieldId throws NoSuchMethodError or JThrowable',
       () {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.instanceFieldId('nonExistentField', 'I'),
           throwsA(
-            isA<JThrowable>().having(
-              (e) => e.toString(),
-              'toString()',
-              contains('java.lang.NoSuchFieldError'),
+            anyOf(
+              isA<NoSuchMethodError>().having(
+                (e) => e.name,
+                'name',
+                'nonExistentField',
+              ),
+              isA<JThrowable>(),
             ),
           ),
         );
@@ -93,16 +104,19 @@ void run({required TestRunnerCallback testRunner}) {
     );
 
     testRunner(
-      'Non-existent staticFieldId throws java.lang.NoSuchFieldError',
+      'Non-existent staticFieldId throws NoSuchMethodError or JThrowable',
       () {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.staticFieldId('nonExistentStaticField', 'I'),
           throwsA(
-            isA<JThrowable>().having(
-              (e) => e.toString(),
-              'toString()',
-              contains('java.lang.NoSuchFieldError'),
+            anyOf(
+              isA<NoSuchMethodError>().having(
+                (e) => e.name,
+                'name',
+                'nonExistentStaticField',
+              ),
+              isA<JThrowable>(),
             ),
           ),
         );

--- a/pkgs/jni/test/no_such_method_test.dart
+++ b/pkgs/jni/test/no_such_method_test.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:jni/jni.dart';
+import 'package:test/test.dart';
+
+import 'test_util/test_util.dart';
+
+void main() {
+  if (!Platform.isAndroid) {
+    checkDylibIsUpToDate();
+    spawnJvm();
+  }
+  run(testRunner: test);
+}
+
+void run({required TestRunnerCallback testRunner}) {
+  group('Method, Field, and Constructor Lookup Failure Tests', () {
+    testRunner('Non-existent constructorId throws java.lang.NoSuchMethodError', () {
+      final stringClass = JClass.forName('java/lang/String');
+      // java.lang.String does not have a (I)V constructor (i.e. new String(int))
+      expect(
+        () => stringClass.constructorId('(I)V'),
+        throwsA(
+          isA<JThrowable>().having(
+            (e) => e.toString(),
+            'toString()',
+            contains('java.lang.NoSuchMethodError'),
+          ),
+        ),
+      );
+      stringClass.release();
+    });
+
+    testRunner('Non-existent instanceMethodId throws java.lang.NoSuchMethodError', () {
+      final stringClass = JClass.forName('java/lang/String');
+      expect(
+        () => stringClass.instanceMethodId('nonExistentMethod', '()V'),
+        throwsA(
+          isA<JThrowable>().having(
+            (e) => e.toString(),
+            'toString()',
+            contains('java.lang.NoSuchMethodError'),
+          ),
+        ),
+      );
+      stringClass.release();
+    });
+
+    testRunner('Non-existent staticMethodId throws java.lang.NoSuchMethodError', () {
+      final stringClass = JClass.forName('java/lang/String');
+      expect(
+        () => stringClass.staticMethodId('nonExistentStaticMethod', '()V'),
+        throwsA(
+          isA<JThrowable>().having(
+            (e) => e.toString(),
+            'toString()',
+            contains('java.lang.NoSuchMethodError'),
+          ),
+        ),
+      );
+      stringClass.release();
+    });
+
+    testRunner('Non-existent instanceFieldId throws java.lang.NoSuchFieldError', () {
+      final stringClass = JClass.forName('java/lang/String');
+      expect(
+        () => stringClass.instanceFieldId('nonExistentField', 'I'),
+        throwsA(
+          isA<JThrowable>().having(
+            (e) => e.toString(),
+            'toString()',
+            contains('java.lang.NoSuchFieldError'),
+          ),
+        ),
+      );
+      stringClass.release();
+    });
+
+    testRunner('Non-existent staticFieldId throws java.lang.NoSuchFieldError', () {
+      final stringClass = JClass.forName('java/lang/String');
+      expect(
+        () => stringClass.staticFieldId('nonExistentStaticField', 'I'),
+        throwsA(
+          isA<JThrowable>().having(
+            (e) => e.toString(),
+            'toString()',
+            contains('java.lang.NoSuchFieldError'),
+          ),
+        ),
+      );
+      stringClass.release();
+    });
+  });
+}

--- a/pkgs/jni/test/no_such_method_test.dart
+++ b/pkgs/jni/test/no_such_method_test.dart
@@ -25,16 +25,7 @@ void run({required TestRunnerCallback testRunner}) {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.constructorId('(I)V'),
-          throwsA(
-            anyOf(
-              isA<NoSuchMethodError>().having(
-                (e) => e.name,
-                'name',
-                '<init>',
-              ),
-              isA<JThrowable>(),
-            ),
-          ),
+          throwsA(anyOf(isA<NoSuchMethodError>(), isA<JThrowable>())),
         );
         stringClass.release();
       },
@@ -46,16 +37,7 @@ void run({required TestRunnerCallback testRunner}) {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.instanceMethodId('nonExistentMethod', '()V'),
-          throwsA(
-            anyOf(
-              isA<NoSuchMethodError>().having(
-                (e) => e.name,
-                'name',
-                'nonExistentMethod',
-              ),
-              isA<JThrowable>(),
-            ),
-          ),
+          throwsA(anyOf(isA<NoSuchMethodError>(), isA<JThrowable>())),
         );
         stringClass.release();
       },
@@ -67,16 +49,7 @@ void run({required TestRunnerCallback testRunner}) {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.staticMethodId('nonExistentStaticMethod', '()V'),
-          throwsA(
-            anyOf(
-              isA<NoSuchMethodError>().having(
-                (e) => e.name,
-                'name',
-                'nonExistentStaticMethod',
-              ),
-              isA<JThrowable>(),
-            ),
-          ),
+          throwsA(anyOf(isA<NoSuchMethodError>(), isA<JThrowable>())),
         );
         stringClass.release();
       },
@@ -88,16 +61,7 @@ void run({required TestRunnerCallback testRunner}) {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.instanceFieldId('nonExistentField', 'I'),
-          throwsA(
-            anyOf(
-              isA<NoSuchMethodError>().having(
-                (e) => e.name,
-                'name',
-                'nonExistentField',
-              ),
-              isA<JThrowable>(),
-            ),
-          ),
+          throwsA(anyOf(isA<NoSuchMethodError>(), isA<JThrowable>())),
         );
         stringClass.release();
       },
@@ -109,16 +73,7 @@ void run({required TestRunnerCallback testRunner}) {
         final stringClass = JClass.forName('java/lang/String');
         expect(
           () => stringClass.staticFieldId('nonExistentStaticField', 'I'),
-          throwsA(
-            anyOf(
-              isA<NoSuchMethodError>().having(
-                (e) => e.name,
-                'name',
-                'nonExistentStaticField',
-              ),
-              isA<JThrowable>(),
-            ),
-          ),
+          throwsA(anyOf(isA<NoSuchMethodError>(), isA<JThrowable>())),
         );
         stringClass.release();
       },


### PR DESCRIPTION
Our method loading code looks like this:

```C++
JniPointerResult globalEnv_GetMethodID(jclass clazz, char* name, char* sig) {
  attach_thread();
  jmethodID _result = (*jniEnv)->GetMethodID(jniEnv, clazz, name, sig);
  jthrowable _exception = check_exception();
  if (_exception != NULL) {
    return (JniPointerResult){.value = NULL, .exception = _exception};
  }
  return (JniPointerResult){.value = _result, .exception = NULL};
}
```

Essentially, it assumes that if the method doesn't exist, the JVM will set an exception. When I look up a nonexistent method on my Linux machine I get a `NoSuchMethod` exception. But it seems that some Android JVMs can return a null method without setting an exception, in which case we hold on to the null method ID until we invoke the method and get a seg fault.

The fix is just to wrap this getter (and all the other field/ctor getters) in a null check.

Fixes https://github.com/dart-lang/native/issues/2943