### PR TITLE
[native_toolchain_c] Fix MSVC builds when paths contain spaces

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.19.3
+## 0.19.3-wip
 
 - Fixed building with MSVC on Windows when a source, include, or output path
   contains a space (e.g. a user name with a space in the default pub cache

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.19.3
+
+- Fixed building with MSVC on Windows when a source, include, or output path
+  contains a space (e.g. a user name with a space in the default pub cache
+  location). The compiler and archiver are now invoked directly instead of
+  through `cmd.exe`, whose quote handling mangled such command lines. As a
+  consequence, `cmd.exe` environment variable expansion (`%VAR%`) no longer
+  applies to compiler flags and defines; they are passed to the tools
+  verbatim.
+- The MSVC archiver is now passed the object file names derived from the
+  sources instead of `*.obj`, so object files left in the output directory by
+  other builds are no longer swept into the archive, and archive member names
+  no longer embed the local build directory path.
+
 ## 0.19.2
 
 - Fixed compatibility with newer Xcode versions when cross-compiling static libraries on macOS hosts targeting Android and Linux.

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -445,9 +445,18 @@ class RunCBuilder {
     );
 
     if (staticLibrary != null) {
+      // `cl.exe /c` writes one object file per source into the working
+      // directory ([outDir]), named after the source file with its extension
+      // replaced by `.obj`. Pass exactly those file names to the archiver
+      // instead of `*.obj`, so that object files left in [outDir] by other
+      // builds are not swept into this archive, and so that the archive
+      // member names stay independent of the build directory location.
+      final objectFiles = {
+        for (final source in sources) _objectFileName(source),
+      }.toList();
       await runProcess(
         executable: archiver_!,
-        arguments: ['/out:${staticLibrary!.toFilePath()}', '*.obj'],
+        arguments: ['/out:${staticLibrary!.toFilePath()}', ...objectFiles],
         workingDirectory: outDir,
         environment: environment,
         logger: logger,
@@ -458,6 +467,17 @@ class RunCBuilder {
     }
 
     assert(result.exitCode == 0);
+  }
+
+  /// The name of the object file `cl.exe /c` produces for [source]: the
+  /// source file name with its extension replaced by `.obj`.
+  static String _objectFileName(Uri source) {
+    final fileName = source.pathSegments.last;
+    final extensionIndex = fileName.lastIndexOf('.');
+    final baseName = extensionIndex > 0
+        ? fileName.substring(0, extensionIndex)
+        : fileName;
+    return '$baseName.obj';
   }
 
   static const androidNdkClangTargetFlags = {

--- a/pkgs/native_toolchain_c/lib/src/utils/run_process.dart
+++ b/pkgs/native_toolchain_c/lib/src/utils/run_process.dart
@@ -25,11 +25,12 @@ Future<RunProcessResult> runProcess({
 }) async {
   final printWorkingDir =
       workingDirectory != null && workingDirectory != Directory.current.uri;
+  String quoteIfSpaced(String s) => s.contains(' ') ? '"$s"' : s;
   final commandString = [
     if (printWorkingDir) '(cd ${workingDirectory.toFilePath()};',
     ...?environment?.entries.map((entry) => '${entry.key}=${entry.value}'),
-    executable.toFilePath(),
-    ...arguments.map((a) => a.contains(' ') ? "'$a'" : a),
+    quoteIfSpaced(executable.toFilePath()),
+    ...arguments.map(quoteIfSpaced),
     if (printWorkingDir) ')',
   ].join(' ');
   logger?.info('Running `$commandString`.');
@@ -41,7 +42,13 @@ Future<RunProcessResult> runProcess({
     arguments,
     workingDirectory: workingDirectory?.toFilePath(),
     environment: environment,
-    runInShell: Platform.isWindows && workingDirectory != null,
+    // Never run through a shell. On Windows, running an executable through
+    // `cmd.exe /c` mangles the command line when more than one argument is
+    // quoted (cmd strips the outer quotes when the line contains more than
+    // two quote characters), which breaks any invocation whose executable and
+    // arguments contain spaces. A shell is also not needed for wildcard
+    // arguments: on Windows, programs expand wildcards themselves; `cmd.exe`
+    // performs no glob expansion.
   );
 
   final stdoutSub = process.stdout.listen((List<int> data) {

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.19.3
+version: 0.19.3-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.19.2
+version: 0.19.3
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_msvc_archiver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_msvc_archiver_test.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Regression test for the MSVC archiver invocation. `RunCBuilder.runCl` must
+// pass the archiver (`lib.exe`) the object file names derived from the sources
+// (e.g. `add.obj`), not `*.obj`.
+//
+// `cl.exe /c` writes one object file per source into the build output
+// directory, and `lib.exe` expands `*.obj` against that directory. So with
+// `*.obj` the archiver sweeps in *any* `.obj` file left in the output
+// directory by another build, corrupting the archive (and failing outright if
+// such a leftover object is not a valid COFF file). Passing the derived names
+// keeps the archive contents independent of unrelated files in the directory.
+//
+// This guards against a well-meaning simplification back to `*.obj`.
+
+@TestOn('windows')
+@OnPlatform({'windows': Timeout.factor(10)})
+library;
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  if (!Platform.isWindows) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
+  test('CBuilder static library ignores stray .obj files in the output '
+      'directory', () async {
+    final tempUri = await tempDirForTest();
+    final tempUri2 = await tempDirForTest();
+    final addCUri = packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+    const name = 'add';
+
+    final buildInputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: name,
+        packageRoot: tempUri,
+        outputFile: tempUri.resolve('output.json'),
+        outputDirectoryShared: tempUri2,
+      )
+      ..config.setupBuild(linkingEnabled: false)
+      ..addExtension(
+        CodeAssetExtension(
+          targetOS: OS.windows,
+          targetArchitecture: Architecture.current,
+          linkModePreference: LinkModePreference.static,
+          cCompiler: cCompiler,
+        ),
+      );
+
+    final buildInput = buildInputBuilder.build();
+    final buildOutput = BuildOutputBuilder();
+
+    // Drop a leftover object file into the build output directory before the
+    // build runs, simulating an object file left behind by an earlier build.
+    // `CBuilder.run` creates this directory with `create(recursive: true)`,
+    // which does not remove existing contents, so the stray file is still
+    // present when the archiver runs. It is deliberately not a valid COFF
+    // file, so `lib.exe` fails on it (`LNK1107`) if it is ever passed `*.obj`.
+    final outputDirectory = buildInput.outputDirectory;
+    await Directory.fromUri(outputDirectory).create(recursive: true);
+    await File.fromUri(
+      outputDirectory.resolve('stray.obj'),
+    ).writeAsString('not a valid object file');
+
+    final cbuilder = CBuilder.library(
+      name: name,
+      assetName: name,
+      sources: [addCUri.toFilePath()],
+      buildMode: .release,
+    );
+    // Throws on the unpatched (`*.obj`) code: `lib.exe` picks up `stray.obj`
+    // and fails with `fatal error LNK1107: invalid or corrupt file`.
+    await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
+
+    final libUri = outputDirectory.resolve(
+      OS.windows.libraryFileName(name, StaticLinking()),
+    );
+    expect(await File.fromUri(libUri).exists(), isTrue);
+  });
+}

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_space_in_path_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_space_in_path_test.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Regression test for building with MSVC when the source, include, and output
+// paths contain a space (e.g. the default pub cache under a Windows user name
+// with a space, `C:\Users\First Last\AppData\Local\Pub\Cache\...`).
+//
+// Previously the MSVC compiler/archiver were invoked through `cmd.exe`, whose
+// `/c` quote-stripping rule mangled the command line as soon as more than one
+// argument (the `cl.exe` path plus a spaced source/include) was quoted, causing
+// `'C:\Program' is not recognized as an internal or external command`.
+
+@TestOn('windows')
+@OnPlatform({'windows': Timeout.factor(10)})
+library;
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  if (!Platform.isWindows) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
+  for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
+    test('CBuilder $linkMode with a space in the source path', () async {
+      // The spaced prefix puts a space in the source/include paths as well
+      // as in the output paths (`/Fe:`, `/out:`), which are derived from
+      // [outputDirectoryShared] below.
+      const spacedPrefix = 'ntc space test ';
+      final spacedRoot = await tempDirForTest(prefix: spacedPrefix);
+      final addCUri = packageUri.resolve(
+        'test/cbuilder/testfiles/add/src/add.c',
+      );
+      final spacedSourceUri = spacedRoot.resolve('add.c');
+      await File.fromUri(addCUri).copy(spacedSourceUri.toFilePath());
+
+      final tempUri = await tempDirForTest(prefix: spacedPrefix);
+      final tempUri2 = await tempDirForTest(prefix: spacedPrefix);
+      const name = 'add';
+
+      final buildInputBuilder = BuildInputBuilder()
+        ..setupShared(
+          packageName: name,
+          packageRoot: tempUri,
+          outputFile: tempUri.resolve('output.json'),
+          outputDirectoryShared: tempUri2,
+        )
+        ..config.setupBuild(linkingEnabled: false)
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: OS.windows,
+            targetArchitecture: Architecture.current,
+            linkModePreference: linkMode == DynamicLoadingBundled()
+                ? LinkModePreference.dynamic
+                : LinkModePreference.static,
+            cCompiler: cCompiler,
+          ),
+        );
+
+      final buildInput = buildInputBuilder.build();
+      final buildOutput = BuildOutputBuilder();
+
+      final cbuilder = CBuilder.library(
+        name: name,
+        assetName: name,
+        sources: [spacedSourceUri.toFilePath()],
+        // Also exercise a `/I` include argument whose path contains a space.
+        includes: [spacedRoot.toFilePath()],
+        buildMode: .release,
+      );
+      // Fails on the unpatched code with a `ProcessException` because the
+      // compiler dies with `'C:\Program' is not recognized ...`.
+      await cbuilder.run(
+        input: buildInput,
+        output: buildOutput,
+        logger: logger,
+      );
+
+      final libUri = buildInput.outputDirectory.resolve(
+        OS.windows.libraryFileName(name, linkMode),
+      );
+      expect(await File.fromUri(libUri).exists(), isTrue);
+
+      if (linkMode == DynamicLoadingBundled()) {
+        final dylib = openDynamicLibraryForTest(libUri.toFilePath());
+        final add = dylib
+            .lookupFunction<
+              Int32 Function(Int32, Int32),
+              int Function(int, int)
+            >('add');
+        expect(add(1, 2), 3);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Description

Building with MSVC failed with `'C:\Program' is not recognized as an internal
or external command` whenever a source or include path contained a space —
e.g. the default pub cache under a Windows user name with a space
(`C:\Users\First Last\AppData\Local\Pub\Cache\...`).

The cause: `runProcess` ran every command through `cmd.exe /c` on Windows
(when a working directory was set), and cmd strips the outer quotes once the
command line contains more than two quote characters — so a quoted `cl.exe`
path plus one quoted argument was enough to mangle the invocation.

Changes:

- `runProcess` no longer runs through a shell; `cl.exe`/`lib.exe` are invoked
  directly. (No caller needs shell features: on Windows programs expand
  wildcards themselves, and the vcvars environment setup uses its own
  `Process.run`.) As a consequence, `cmd.exe` `%VAR%` expansion no longer
  applies to compiler flags/defines — they now reach the tools verbatim.
- The archiver is now passed the object file names derived from `sources`
  (matching `cl.exe /c`'s naming) instead of `*.obj`. This keeps object files
  left in the output directory by other builds out of the archive, and keeps
  archive member names short and machine-independent instead of embedding
  the local build path (verified with `lib.exe /list`).
- The logged command line now quotes the executable and spaced arguments so
  it can be copy-pasted to reproduce an invocation.
- Adds a Windows regression test building a library (dynamic + static) with
  spaces in the source, include, and output paths.
- Bumps to 0.19.3.

## Related Issues

Fixes #3321.
Fixes #2848.

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [x] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [x] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
