### PR TITLE
[record_use] Prepare to release v1.0.0

### DIFF
--- a/pkgs/code_assets/example/mini_audio/hook/link.dart
+++ b/pkgs/code_assets/example/mini_audio/hook/link.dart
@@ -14,7 +14,6 @@ void main(List<String> arguments) async {
       input: input,
       output: output,
       linkerOptions: LinkerOptions.treeshake(
-        // ignore: experimental_member_use
         symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
           (e) => recordUseMapping[e.name]!,
         ),

--- a/pkgs/code_assets/example/mini_audio/pubspec.yaml
+++ b/pkgs/code_assets/example/mini_audio/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.11.0
   native_toolchain_c: any
-  record_use: ^1.0.0
+  record_use: any
 
 dev_dependencies:
   ffigen:

--- a/pkgs/code_assets/example/mini_audio/pubspec.yaml
+++ b/pkgs/code_assets/example/mini_audio/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.11.0
   native_toolchain_c: any
-  record_use: ^0.6.0
+  record_use: ^1.0.0
 
 dev_dependencies:
   ffigen:

--- a/pkgs/code_assets/example/sqlite/hook/link.dart
+++ b/pkgs/code_assets/example/sqlite/hook/link.dart
@@ -14,7 +14,6 @@ void main(List<String> arguments) async {
       input: input,
       output: output,
       linkerOptions: LinkerOptions.treeshake(
-        // ignore: experimental_member_use
         symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
           (e) => recordUseMapping[e.name]!,
         ),

--- a/pkgs/code_assets/example/sqlite/pubspec.yaml
+++ b/pkgs/code_assets/example/sqlite/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.11.0
   native_toolchain_c: any
-  record_use: ^1.0.0
+  record_use: any
 
 dev_dependencies:
   ffigen:

--- a/pkgs/code_assets/example/sqlite/pubspec.yaml
+++ b/pkgs/code_assets/example/sqlite/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.11.0
   native_toolchain_c: any
-  record_use: ^0.6.0
+  record_use: ^1.0.0
 
 dev_dependencies:
   ffigen:

--- a/pkgs/code_assets/example/stb_image/hook/link.dart
+++ b/pkgs/code_assets/example/stb_image/hook/link.dart
@@ -14,7 +14,6 @@ void main(List<String> arguments) async {
       input: input,
       output: output,
       linkerOptions: LinkerOptions.treeshake(
-        // ignore: experimental_member_use
         symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
           (e) => recordUseMapping[e.name]!,
         ),

--- a/pkgs/code_assets/example/stb_image/pubspec.yaml
+++ b/pkgs/code_assets/example/stb_image/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.11.0
   native_toolchain_c: any
-  record_use: ^0.6.0
+  record_use: ^1.0.0
 
 dev_dependencies:
   ffigen:

--- a/pkgs/code_assets/example/stb_image/pubspec.yaml
+++ b/pkgs/code_assets/example/stb_image/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.11.0
   native_toolchain_c: any
-  record_use: ^1.0.0
+  record_use: any
 
 dev_dependencies:
   ffigen:

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0
+## 2.1.0-wip
 
 - Graduate `LinkInput.recordedUses` out of experimental.
 

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+- Graduate `LinkInput.recordedUses` out of experimental.
+
 ## 2.0.2
 
 - Update documentation for user-defines.

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.3
+## 2.1.0
 
 - Graduate `LinkInput.recordedUses` out of experimental.
 

--- a/pkgs/hooks/example/link/package_with_assets/hook/link.dart
+++ b/pkgs/hooks/example/link/package_with_assets/hook/link.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: experimental_member_use
-
 import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';

--- a/pkgs/hooks/lib/src/config.dart
+++ b/pkgs/hooks/lib/src/config.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart' show sha256;
-import 'package:meta/meta.dart';
 import 'package:record_use/record_use.dart';
 
 import 'api/build_and_link.dart';
@@ -477,22 +476,10 @@ final class LinkInput extends HookInput {
   List<EncodedAsset> get _encodedAssets => assets.encodedAssets;
 
   /// The file containing recorded usages, if any.
-  ///
-  /// Experimental: The record uses feature needs to be enabled as experiment.
-  /// The experiment is only available in the Dart SDK, not in Flutter. We
-  /// reserve the right to break this API at any point without respecting
-  /// semantic versioning of this package.
-  @experimental
   @Deprecated('Use recordedUses instead')
   Uri? get recordedUsagesFile => _syntaxLinkInput.resourceIdentifiers;
 
   /// The recorded usages, if any.
-  ///
-  /// Experimental: The record uses feature needs to be enabled as experiment.
-  /// The experiment is only available in the Dart SDK, not in Flutter. We
-  /// reserve the right to break this API at any point without respecting
-  /// semantic versioning of this package.
-  @experimental
   late final Recordings? recordedUses = () {
     final file = _syntaxLinkInput.resourceIdentifiers;
     if (file == null) return null;

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 2.0.2
+version: 2.0.3
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 
@@ -25,7 +25,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
   pub_semver: ^2.2.0
-  record_use: ^0.6.0
+  record_use: ^1.0.0
   yaml: ^3.1.3 # Used for reading pubspec.yaml to obtain the package name.
 
 dev_dependencies:

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 2.0.3
+version: 2.1.0
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 2.1.0
+version: 2.1.0-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 
@@ -25,7 +25,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
   pub_semver: ^2.2.0
-  record_use: ^1.0.0
+  record_use: ^1.0.0-wip
   yaml: ^3.1.3 # Used for reading pubspec.yaml to obtain the package name.
 
 dev_dependencies:

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.0
+## 1.6.0-wip
 
 - Fix record_use path changing caching issue.
 

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.5.1-wip
+## 1.5.1
 
 - Fix record_use path changing caching issue.
 

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.5.1
+## 1.6.0
 
 - Fix record_use path changing caching issue.
 

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.5.1-wip
+version: 1.5.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.16.0
   package_config: ^2.1.0
   pub_semver: ^2.2.0
-  record_use: ^0.6.0
+  record_use: ^1.0.0
   yaml: ^3.1.3
 
 dev_dependencies:

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.5.1
+version: 1.6.0
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.6.0
+version: 1.6.0-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.16.0
   package_config: ^2.1.0
   pub_semver: ^2.2.0
-  record_use: ^1.0.0
+  record_use: ^1.0.0-wip
   yaml: ^3.1.3
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test/build_runner/pub_workspace_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/pub_workspace_test.dart
@@ -56,6 +56,7 @@ dependency_overrides:
       'data_assets',
       'hooks',
       'native_toolchain_c',
+      'record_use',
     ];
     for (final package in packagesToOverride) {
       workspacePubSpec +=

--- a/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
@@ -15,7 +15,6 @@ void main(List<String> args) async {
 
     if (translationAsset == null) return;
 
-    // ignore: experimental_member_use
     final recordings = input.recordedUses;
     if (recordings == null) {
       output.assets.data.add(translationAsset.asDataAsset);

--- a/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
@@ -17,7 +17,6 @@ void main(List<String> args) async {
       throw StateError('Could not find technologies asset.');
     }
 
-    // ignore: experimental_member_use
     final recordings = input.recordedUses;
 
     if (recordings == null) {

--- a/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/hook/link.dart
@@ -24,7 +24,6 @@ void main(List<String> arguments) async {
       sources: ['src/multiply.c'],
     );
 
-    // ignore: experimental_member_use
     final usages = input.recordedUses;
 
     final addSymbols = usages?.calls.keys

--- a/pkgs/hooks_runner/test_data/use_all_api/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/use_all_api/hook/link.dart
@@ -18,7 +18,6 @@ void main(List<String> args) async {
     // b. hook-specific
     input.assets.code; // link only
     input.assets.data; // link only
-    // ignore: experimental_member_use
     input.recordedUses; // link only
     // c. target config
     // c.2. per asset

--- a/pkgs/record_use/CHANGELOG.md
+++ b/pkgs/record_use/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0
+## 1.0.0-wip
 
 - Stable release.
 

--- a/pkgs/record_use/CHANGELOG.md
+++ b/pkgs/record_use/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.6.1-wip
+## 1.0.0
 
-- Nothing yet.
+- Stable release.
 
 ## 0.6.0
 

--- a/pkgs/record_use/README.md
+++ b/pkgs/record_use/README.md
@@ -1,11 +1,3 @@
-> [!CAUTION]
-> This is an experimental package. Its API and the underlying JSON format
-> **will break** as we are actively iterating. Use at your own discretion.
->
-> We are continuously changing the implementation, so a released version of the
-> package may only work with one or two [dev releases] of the Dart SDK. This
-> version will work with the first dev release _after_ `3.12.0-203.0.dev`.
-
 This package provides the data classes for the usage recording feature in the
 Dart SDK.
 
@@ -92,5 +84,3 @@ void main(List<String> arguments) {
 
 ## Contributing
 Contributions are welcome! Please open an issue or submit a pull request.
-
-[dev releases]: https://dart.dev/get-dart/archive#dev-channel

--- a/pkgs/record_use/example/api/usage_link.dart
+++ b/pkgs/record_use/example/api/usage_link.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: experimental_member_use
 // ignore_for_file: depend_on_referenced_packages
 
 import 'package:hooks/hooks.dart';

--- a/pkgs/record_use/pubspec.yaml
+++ b/pkgs/record_use/pubspec.yaml
@@ -1,7 +1,7 @@
 name: record_use
 description: >
   The serialization logic and API for the usage recording SDK feature.
-version: 1.0.0
+version: 1.0.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/record_use
 
 environment:

--- a/pkgs/record_use/pubspec.yaml
+++ b/pkgs/record_use/pubspec.yaml
@@ -1,7 +1,7 @@
 name: record_use
 description: >
   The serialization logic and API for the usage recording SDK feature.
-version: 0.6.1-wip
+version: 1.0.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/record_use
 
 environment:

--- a/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: experimental_member_use
-
 import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';
@@ -13,8 +11,8 @@ void main(List<String> arguments) async {
     final usages = input.recordedUses;
     if (usages == null) {
       throw ArgumentError(
-        'Enable the --enable-experiment=record-use experiment'
-        ' to use this app.',
+        'Update to Dart 3.13 or run with --enable-experiment=record-use'
+        ' on older Dart versions.',
       );
     }
     final dataAssets = input.assets.data;

--- a/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: experimental_member_use
-
 import 'dart:io';
 
 import 'package:code_assets/code_assets.dart';
@@ -15,8 +13,8 @@ void main(List<String> arguments) async {
     final usages = input.recordedUses;
     if (usages == null) {
       throw ArgumentError(
-        'Enable the --enable-experiment=record-use experiment'
-        ' to use this app.',
+        'Update to Dart 3.13 or run with --enable-experiment=record-use'
+        ' on older Dart versions.',
       );
     }
     final codeAssets = input.assets.code;

--- a/pkgs/record_use/test_data/library_uris/hook/link.dart
+++ b/pkgs/record_use/test_data/library_uris/hook/link.dart
@@ -12,10 +12,12 @@ void main(List<String> arguments) async {
   await link(
     arguments,
     (input, output) async {
-      // ignore: experimental_member_use
       final recordings = input.recordedUses;
       if (recordings == null) {
-        throw UnsupportedError('Run with --enable-experiment=record-use.');
+        throw UnsupportedError(
+          'Update to Dart 3.13 or run with --enable-experiment=record-use'
+          ' on older Dart versions.',
+        );
       }
 
       // This package.


### PR DESCRIPTION
Record use:

* Bump to 1.0
* Removes the experimental notice in the readme

Hooks:

* Mark recordedUses as nonExperimental
* Update error message if recorded uses are missing to mention the minimal dart version
* Minor version bump: dart_apitool treats marking a member as non experimental identical to adding a member. And adding a member should be a minor release.

Hooks Runner:

* Minor version bump: dart_apitool treats bumping a major version of a dependency as a minor version bump, not a patch release.

TODO:

* https://dart-review.googlesource.com/c/sdk/+/522500 Mark `RecordUse` and `mustBeConst` in `package:meta` as non-experimental and release `package:meta`. Then we can remove more lint suppressions in our examples afterwards