### PR TITLE
[record_use] Docs: add examples

### DIFF
--- a/pkgs/record_use/README.md
+++ b/pkgs/record_use/README.md
@@ -1,5 +1,4 @@
-This package provides the data classes for the usage recording feature in the
-Dart SDK.
+Dart API to access `@RecordUse()` recorded usages in link hooks.
 
 During compilation, usages of declarations annotated with `@RecordUse()` in
 reachable code are recorded, and information about these usages is made available
@@ -94,6 +93,8 @@ void main(List<String> arguments) {
   });
 }
 ```
+
+For complete end-to-end examples combining link hooks (`hook/link.dart`) and `package:record_use` to tree-shake native C libraries (`LinkerOptions.treeshake`), see the [examples index](example/README.md).
 
 ## Contributing
 Contributions are welcome! Please open an issue or submit a pull request.

--- a/pkgs/record_use/example/README.md
+++ b/pkgs/record_use/example/README.md
@@ -1,0 +1,11 @@
+# Examples
+
+The following complete examples use link hooks (`hook/link.dart`) and
+`package:record_use` to tree-shake native C libraries
+(`LinkerOptions.treeshake`):
+
+| Example | Description | Used Features |
+| :--- | :--- | :--- |
+| [`mini_audio`](../../code_assets/example/mini_audio) | Play audio. | - Tree-shaking C library built from source with `package:native_toolchain_c` based on recorded Dart calls.<br/>- Link hook (`hook/link.dart`) with `LinkerOptions.treeshake`. |
+| [`sqlite`](../../code_assets/example/sqlite) | Database access. | - Tree-shaking C library built from source with `package:native_toolchain_c` based on recorded Dart calls.<br/>- Link hook (`hook/link.dart`) with `LinkerOptions.treeshake`. |
+| [`stb_image`](../../code_assets/example/stb_image) | Read image metadata. | - Tree-shaking C library built from source with `package:native_toolchain_c` based on recorded Dart calls.<br/>- Link hook (`hook/link.dart`) with `LinkerOptions.treeshake`. |

--- a/pkgs/record_use/lib/record_use.dart
+++ b/pkgs/record_use/lib/record_use.dart
@@ -4,8 +4,7 @@
 
 /// @docImport 'src/recordings.dart';
 
-/// This package provides the data classes for the usage recording feature in
-/// the Dart SDK.
+/// Dart API to access `@RecordUse()` recorded usages in link hooks.
 ///
 /// During compilation, usages of declarations annotated with `@RecordUse()` in
 /// reachable code are recorded, and information about these usages is made


### PR DESCRIPTION
Add the examples from `package:code_assets` in a readme so that they show up on pub for `package:record_use` in the same style as we have `package:code_assets` examples in `package:hooks` https://pub.dev/packages/hooks/example.