### PR TITLE
[infra] Support latest `package_config`

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Bump `package:meta` dependency to `^1.19.0` and stop generating
   `experimental_member_use` lint ignore in generated bindings when
   `@RecordUse()` is used.
+- Support versions 3.x of `package:package_config`.
 
 ## 21.0.0
 

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   logging: ^1.0.0
   meta: ^1.11.0
   native_toolchain_c: ^0.19.0
-  package_config: ^2.1.0
+  package_config: '>=2.1.0 <4.0.0'
   path: ^1.8.0
   pub_semver: ^2.1.4
   quiver: ^3.0.0

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.1-wip
+## 1.6.1
 
 - Support versions 3.x of `package:package_config`.
 

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1-wip
+
+- Support versions 3.x of `package:package_config`.
+
 ## 1.6.0
 
 - Fix record_use path changing caching issue.

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.6.1-wip
+version: 1.6.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.6.0
+version: 1.6.1-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 
@@ -20,7 +20,7 @@ dependencies:
   hooks: ^2.0.0
   logging: ^1.3.0
   meta: ^1.19.0
-  package_config: ^2.1.0
+  package_config: '>=2.1.0 <4.0.0'
   pub_semver: ^2.2.0
   record_use: ^1.0.0
   yaml: ^3.1.3

--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Improve no such method error handling.
 - Fix memory leaks and deadlocks that can happen in callbacks, if the target
   isolate is shut down.
+- Support versions 3.x of `package:package_config`.
 
 ## 1.0.0
 

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   ffi: ^2.1.3
   jni_util: ^0.1.0
   meta: ^1.15.0
-  package_config: ^2.1.0
+  package_config: '>=2.1.0 <4.0.0'
   path: ^1.9.0
   plugin_platform_interface: ^2.1.8
 

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -17,6 +17,7 @@
   elements.dart is no longer exported from the library, as these classes were
   always intended to be private. `Config.importedClasses` and
   `Config.importClasses()` have also been made private.
+- Support versions 3.x of `package:package_config`.
 
 ## 0.16.0
 

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   json_annotation: ^4.9.0
   logging: ^1.2.0
   meta: ^1.15.0
-  package_config: ^2.1.0
+  package_config: '>=2.1.0 <4.0.0'
   path: ^1.9.0
   pub_semver: ^2.1.4
   yaml: ^3.1.2

--- a/pkgs/swiftgen/CHANGELOG.md
+++ b/pkgs/swiftgen/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Bump ffigen, objective_c, and swift2objc versions.
 - Fix omitted delegation of `target` property from `SwiftGenerator` to `Swift2ObjCGenerator`.
+- Support versions 3.x of `package:package_config`.
 
 ## 0.1.2
 

--- a/pkgs/swiftgen/pubspec.yaml
+++ b/pkgs/swiftgen/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   ffigen: ^21.0.0
   logging: ^1.3.0
   objective_c: ^9.4.1
-  package_config: ^2.2.0
+  package_config: '>=2.2.0 <4.0.0'
   path: ^1.9.1
   swift2objc: ^0.2.0
 


### PR DESCRIPTION
## Description

This declares support for the latest version of the `package_config` package. No package in this repository is affected by breaking changes, so no code changes are necessary.

Upgrading removes support for `.packages` files, but I can't imagine that to be relevant anymore.

## Related Issues

None (I can create one if needed though).

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [ ] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. Actually there are existing formatting differences, probably because I use a wrong SDK version.
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [ ] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [x] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
