### PR TITLE
[jni] Migrate to built-in Kotlin

### DIFF
--- a/pkgs/jni/android/build.gradle
+++ b/pkgs/jni/android/build.gradle
@@ -19,6 +19,11 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 android {
     // Keeping the classes from being removed by proguard.
     defaultConfig {
@@ -75,3 +80,10 @@ android {
         minSdk 21
     }
 }
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+

--- a/pkgs/jni_flutter/android/build.gradle
+++ b/pkgs/jni_flutter/android/build.gradle
@@ -19,6 +19,11 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 android {
     if (project.android.hasProperty("namespace")) {
         namespace 'com.github.dart_lang.jni_flutter'
@@ -42,3 +47,10 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 }
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+


### PR DESCRIPTION
Applying the migration listed here: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors#support-flutter-versions-earlier-than-3-44

Fixes https://github.com/dart-lang/native/issues/3415