### PR TITLE
[ffigen] Support C++ class pointer parameters and returns

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/cpp_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/cpp_class.dart
@@ -205,15 +205,13 @@ class $name implements $ffiPrefix.Finalizable {
       final localVars = LocalVariables(ctor.localScope);
       final callArgs = ctor.parameters
           .map(
-            (p) => p.type.sameDartAndFfiDartType
-                ? p.name
-                : p.type.convertDartTypeToFfiDartType(
-                    ctx,
-                    p.name,
-                    objCRetain: false,
-                    objCAutorelease: false,
-                    localVariables: localVars,
-                  ),
+            (p) => p.type.convertDartTypeToFfiDartType(
+              ctx,
+              p.name,
+              objCRetain: false,
+              objCAutorelease: false,
+              localVariables: localVars,
+            ),
           )
           .join(', ');
 
@@ -234,52 +232,38 @@ class $name implements $ffiPrefix.Finalizable {
       final callArgs = [
         if (!method.isStatic) '_ptr',
         ...method.parameters.map(
-          (p) => p.type.sameDartAndFfiDartType
-              ? p.name
-              : p.type.convertDartTypeToFfiDartType(
-                  ctx,
-                  p.name,
-                  objCRetain: false,
-                  objCAutorelease: false,
-                  localVariables: localVars,
-                ),
+          (p) => p.type.convertDartTypeToFfiDartType(
+            ctx,
+            p.name,
+            objCRetain: false,
+            objCAutorelease: false,
+            localVariables: localVars,
+          ),
         ),
       ].join(', ');
       final decls = localVars.generateDeclarations();
-      final declsCode = decls.isNotEmpty ? '$decls\n    ' : '';
 
-      final String returnExpr;
-      if (!method.returnType.sameDartAndFfiDartType) {
-        returnExpr = method.returnType.convertFfiDartTypeToDartType(
-          ctx,
-          '$glue($callArgs)',
-          objCRetain: false,
-        );
-      } else {
-        returnExpr = '$glue($callArgs)';
-      }
+      final returnExpr = method.returnType.convertFfiDartTypeToDartType(
+        ctx,
+        '$glue($callArgs)',
+        objCRetain: false,
+      );
 
       if (method.isStatic) {
-        if (decls.isNotEmpty) {
-          s.write('''
+        s.write('''\
   static $dartReturn ${method.originalName}($dartParams) {
     $decls
     return $returnExpr;
   }
 ''');
-        } else {
-          s.write(
-            '  static $dartReturn ${method.originalName}($dartParams) '
-            '=> $returnExpr;\n',
-          );
-        }
       } else {
-        s.write('''
+        s.write('''\
   $dartReturn ${method.originalName}($dartParams) {
     if (_ptr == $ffiPrefix.nullptr) {
       throw StateError('This object has already been disposed.');
     }
-    ${declsCode}return $returnExpr;
+    $decls
+    return $returnExpr;
   }
 ''');
       }

--- a/pkgs/ffigen/lib/src/code_generator/cpp_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/cpp_class.dart
@@ -131,7 +131,7 @@ class $name implements $ffiPrefix.Finalizable {
     $ffiPrefix.NativeFunction<$ffiPrefix.Void Function($ptrVoid)>
   >? _activeFinalizerFn;
 
-  $name.fromPointer(this._ptr, {bool takeOwnership = true}) {
+  $name.fromPointer(this._ptr, {bool takeOwnership = false}) {
     if (takeOwnership) {
       _defaultFinalizer.attach(this, _ptr.cast(), detach: this);
       _activeFinalizer = _defaultFinalizer;
@@ -220,7 +220,7 @@ class $name implements $ffiPrefix.Finalizable {
       s.write('''
   factory $name($dartParams) {
     ${localVars.generateDeclarations()}
-    return $name.fromPointer($privateName($callArgs));
+    return $name.fromPointer($privateName($callArgs), takeOwnership: true);
   }
 ''');
     }
@@ -230,23 +230,56 @@ class $name implements $ffiPrefix.Finalizable {
       final dartReturn = method.returnType.getDartType(ctx);
       final dartParams = dartParamList(method.parameters);
 
+      final localVars = LocalVariables(method.localScope);
       final callArgs = [
         if (!method.isStatic) '_ptr',
-        ...method.parameters.map((p) => p.name),
+        ...method.parameters.map(
+          (p) => p.type.sameDartAndFfiDartType
+              ? p.name
+              : p.type.convertDartTypeToFfiDartType(
+                  ctx,
+                  p.name,
+                  objCRetain: false,
+                  objCAutorelease: false,
+                  localVariables: localVars,
+                ),
+        ),
       ].join(', ');
+      final decls = localVars.generateDeclarations();
+      final declsCode = decls.isNotEmpty ? '$decls\n    ' : '';
+
+      final String returnExpr;
+      if (!method.returnType.sameDartAndFfiDartType) {
+        returnExpr = method.returnType.convertFfiDartTypeToDartType(
+          ctx,
+          '$glue($callArgs)',
+          objCRetain: false,
+        );
+      } else {
+        returnExpr = '$glue($callArgs)';
+      }
 
       if (method.isStatic) {
-        s.write(
-          '  static $dartReturn ${method.originalName}($dartParams) '
-          '=> $glue($callArgs);\n',
-        );
+        if (decls.isNotEmpty) {
+          s.write('''
+  static $dartReturn ${method.originalName}($dartParams) {
+    $decls
+    return $returnExpr;
+  }
+''');
+        } else {
+          s.write(
+            '  static $dartReturn ${method.originalName}($dartParams) '
+            '=> $returnExpr;\n',
+          );
+        }
       } else {
         s.write('''
   $dartReturn ${method.originalName}($dartParams) {
     if (_ptr == $ffiPrefix.nullptr) {
       throw StateError('This object has already been disposed.');
     }
-    return $glue($callArgs);
+    ${declsCode}return $returnExpr;
   }
 ''');
       }
@@ -255,6 +288,10 @@ class $name implements $ffiPrefix.Finalizable {
   void dispose() {
     if (_ptr == $ffiPrefix.nullptr) {
       throw StateError('This object has already been disposed.');
+    }
+    if (_activeFinalizer == null) {
+      throw StateError('Cannot dispose a non-owning wrapper. '
+          'Call retainOwnership() first to take ownership.');
     }
     _activeFinalizer!.detach(this);
     _activeFinalizer = null;

--- a/pkgs/ffigen/lib/src/code_generator/pointer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/pointer.dart
@@ -18,6 +18,8 @@ class PointerType extends Type {
       return ObjCObjectPointer();
     } else if (child == objCBlockType) {
       return ObjCBlockPointer();
+    } else if (child is CppClass) {
+      return CppClassPointerType(child);
     }
     return PointerType._(child);
   }
@@ -249,5 +251,66 @@ class ObjCObjectPointerWithProtocols extends ObjCObjectPointer {
   void visitChildren(Visitor visitor) {
     super.visitChildren(visitor);
     visitor.visitAll(protocols);
+  }
+}
+
+/// A pointer to a C++ class wrapper object.
+/// Returned pointers are always unowned by default. The developer must call
+/// `retainOwnership()` explicitly if ownership has been transferred.
+class CppClassPointerType extends PointerType {
+  final CppClass cppClass;
+
+  CppClassPointerType(this.cppClass) : super._(cppClass);
+
+  @override
+  String getDartType(Context context) => cppClass.name;
+
+  @override
+  String getCType(Context context) {
+    final ffi = context.libs.prefix(ffiImport);
+    return '$ffi.Pointer<$ffi.Void>';
+  }
+
+  @override
+  String getFfiDartType(Context context) => getCType(context);
+
+  @override
+  String getNativeType(Context context, {String varName = ''}) =>
+      '${cppClass.originalName}* $varName';
+
+  @override
+  bool get sameDartAndCType => false;
+
+  @override
+  bool get sameDartAndFfiDartType => false;
+
+  @override
+  String convertDartTypeToFfiDartType(
+    Context context,
+    String value, {
+    required bool objCRetain,
+    required bool objCAutorelease,
+    required LocalVariables localVariables,
+  }) => '$value._ptr';
+
+  @override
+  String convertFfiDartTypeToDartType(
+    Context context,
+    String value, {
+    required bool objCRetain,
+    String? objCEnclosingClass,
+  }) => '${cppClass.name}.fromPointer($value)';
+
+  @override
+  String toString() => '${cppClass.name}*';
+
+  @override
+  String cacheKey() => '${cppClass.cacheKey()}*';
+
+  @override
+  void visitChildren(Visitor visitor) {
+    super.visitChildren(visitor);
+    visitor.visit(cppClass);
+    visitor.visit(ffiImport);
   }
 }

--- a/pkgs/ffigen/lib/src/header_parser/type_extractor/extractor.dart
+++ b/pkgs/ffigen/lib/src/header_parser/type_extractor/extractor.dart
@@ -9,6 +9,7 @@ import '../../code_generator.dart';
 import '../../context.dart';
 import '../../strings.dart' as strings;
 import '../clang_bindings/clang_bindings.dart' as clang_types;
+import '../sub_parsers/classdecl_parser.dart';
 import '../sub_parsers/compounddecl_parser.dart';
 import '../sub_parsers/enumdecl_parser.dart';
 import '../sub_parsers/function_type_param_parser.dart';
@@ -250,6 +251,21 @@ Type? _extractfromRecord(
 
   final declSpelling = cursor.spelling();
   final cursorKind = clang.clang_getCursorKind(cursor);
+
+  if (config.cpp?.classes != null) {
+    final seenCppClass = context.bindingsIndex.getSeenCppClass(cursor.usr());
+    if (seenCppClass != null) {
+      return seenCppClass;
+    }
+    if (cursorKind == clang_types.CXCursorKind.CXCursor_ClassDecl ||
+        cursorKind == clang_types.CXCursorKind.CXCursor_StructDecl) {
+      final cppClass = parseClassDeclaration(context, cursor);
+      if (cppClass != null) {
+        return cppClass;
+      }
+    }
+  }
+
   if (cursorKind == clang_types.CXCursorKind.CXCursor_StructDecl) {
     if (config.structTypeMappings.containsKey(declSpelling)) {
       logger.fine('  Type Mapped from type-map');

--- a/pkgs/ffigen/test/native_cpp_test/cpp_class_test_bindings.dart
+++ b/pkgs/ffigen/test/native_cpp_test/cpp_class_test_bindings.dart
@@ -96,6 +96,7 @@ class Animal implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _Animal_speak(_ptr);
   }
 
@@ -103,16 +104,27 @@ class Animal implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _Animal_getAge(_ptr);
   }
 
-  static int getCount() => _Animal_getCount();
-  static void Animal_new() => _Animal_Animal_new();
-  static void Animal_delete() => _Animal_Animal_delete();
+  static int getCount() {
+    return _Animal_getCount();
+  }
+
+  static void Animal_new() {
+    return _Animal_Animal_new();
+  }
+
+  static void Animal_delete() {
+    return _Animal_Animal_delete();
+  }
+
   bool isMammalClass() {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _Animal_isMammalClass(_ptr);
   }
 
@@ -120,6 +132,7 @@ class Animal implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _Animal_getWeight(_ptr, multiplier);
   }
 
@@ -127,10 +140,14 @@ class Animal implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _Animal_addAges(_ptr, otherAge, scale);
   }
 
-  static int sum(int a, int b) => _Animal_sum(a, b);
+  static int sum(int a, int b) {
+    return _Animal_sum(a, b);
+  }
+
   void dispose() {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');

--- a/pkgs/ffigen/test/native_cpp_test/cpp_class_test_bindings.dart
+++ b/pkgs/ffigen/test/native_cpp_test/cpp_class_test_bindings.dart
@@ -24,7 +24,7 @@ class Animal implements ffi.Finalizable {
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>?
   _activeFinalizerFn;
 
-  Animal.fromPointer(this._ptr, {bool takeOwnership = true}) {
+  Animal.fromPointer(this._ptr, {bool takeOwnership = false}) {
     if (takeOwnership) {
       _defaultFinalizer.attach(this, _ptr.cast(), detach: this);
       _activeFinalizer = _defaultFinalizer;
@@ -90,7 +90,7 @@ class Animal implements ffi.Finalizable {
   }
 
   factory Animal(int age) {
-    return Animal.fromPointer(_Animal_new(age));
+    return Animal.fromPointer(_Animal_new(age), takeOwnership: true);
   }
   void speak() {
     if (_ptr == ffi.nullptr) {
@@ -134,6 +134,12 @@ class Animal implements ffi.Finalizable {
   void dispose() {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
+    }
+    if (_activeFinalizer == null) {
+      throw StateError(
+        'Cannot dispose a non-owning wrapper. '
+        'Call retainOwnership() first to take ownership.',
+      );
     }
     _activeFinalizer!.detach(this);
     _activeFinalizer = null;
@@ -208,7 +214,7 @@ class FinalizerTestSubject implements ffi.Finalizable {
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>?
   _activeFinalizerFn;
 
-  FinalizerTestSubject.fromPointer(this._ptr, {bool takeOwnership = true}) {
+  FinalizerTestSubject.fromPointer(this._ptr, {bool takeOwnership = false}) {
     if (takeOwnership) {
       _defaultFinalizer.attach(this, _ptr.cast(), detach: this);
       _activeFinalizer = _defaultFinalizer;
@@ -274,11 +280,20 @@ class FinalizerTestSubject implements ffi.Finalizable {
   }
 
   factory FinalizerTestSubject(ffi.Pointer<ffi.Int> counter) {
-    return FinalizerTestSubject.fromPointer(_FinalizerTestSubject_new(counter));
+    return FinalizerTestSubject.fromPointer(
+      _FinalizerTestSubject_new(counter),
+      takeOwnership: true,
+    );
   }
   void dispose() {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
+    }
+    if (_activeFinalizer == null) {
+      throw StateError(
+        'Cannot dispose a non-owning wrapper. '
+        'Call retainOwnership() first to take ownership.',
+      );
     }
     _activeFinalizer!.detach(this);
     _activeFinalizer = null;

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.cpp
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.cpp
@@ -25,9 +25,6 @@ Node* NodeManager::getNode() {
     return new Node(100, nullptr);
 }
 
-Node* NodeManager::releaseNode() {
-    return new Node(200, nullptr);
-}
 
 Node* NodeManager::newNode(int value, int* destructorCounter) {
     return new Node(value, destructorCounter);

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.cpp
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.cpp
@@ -14,3 +14,40 @@ Node::~Node() {
 }
 
 int Node::getValue() const { return value_; }
+
+NodeManager::NodeManager() {}
+
+int NodeManager::foo(Node* node) {
+    return node->getValue();
+}
+
+Node* NodeManager::getNode() {
+    return new Node(100, nullptr);
+}
+
+Node* NodeManager::releaseNode() {
+    return new Node(200, nullptr);
+}
+
+Node* NodeManager::newNode(int value, int* destructorCounter) {
+    return new Node(value, destructorCounter);
+}
+
+static Node* gSingletonNode = nullptr;
+
+Node* NodeManager::getSingletonNode(int value, int* destructorCounter) {
+    if (gSingletonNode == nullptr) {
+        gSingletonNode = new Node(value, destructorCounter);
+    }
+    return gSingletonNode;
+}
+
+int NodeManager::getValue(Node* node) {
+    return node->getValue();
+}
+
+int NodeManager::takeNode(Node* node) {
+    int val = node->getValue();
+    delete node;
+    return val;
+}

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.cpp
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.cpp
@@ -21,8 +21,8 @@ int NodeManager::foo(Node* node) {
     return node->getValue();
 }
 
-Node* NodeManager::getNode() {
-    return new Node(100, nullptr);
+Node* NodeManager::getNode(int value, int* destructorCounter) {
+    return new Node(value, destructorCounter);
 }
 
 

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.h
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.h
@@ -19,7 +19,6 @@ public:
     NodeManager();
     int foo(Node* node);
     Node* getNode();
-    Node* releaseNode();
     Node* newNode(int value, int* destructorCounter);
     Node* getSingletonNode(int value, int* destructorCounter);
     int getValue(Node* node);

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.h
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.h
@@ -13,3 +13,16 @@ private:
     int value_;
     int* destructorCounter_;
 };
+
+class NodeManager {
+public:
+    NodeManager();
+    int foo(Node* node);
+    Node* getNode();
+    Node* releaseNode();
+    Node* newNode(int value, int* destructorCounter);
+    Node* getSingletonNode(int value, int* destructorCounter);
+    int getValue(Node* node);
+    int takeNode(Node* node);
+};
+

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.h
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases.h
@@ -18,7 +18,7 @@ class NodeManager {
 public:
     NodeManager();
     int foo(Node* node);
-    Node* getNode();
+    Node* getNode(int value, int* destructorCounter);
     Node* newNode(int value, int* destructorCounter);
     Node* getSingletonNode(int value, int* destructorCounter);
     int getValue(Node* node);

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart
@@ -99,6 +99,7 @@ class Node implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _Node_getValue(_ptr);
   }
 
@@ -225,6 +226,7 @@ class NodeManager implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _NodeManager_foo(_ptr, node._ptr);
   }
 
@@ -232,20 +234,15 @@ class NodeManager implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
-    return Node.fromPointer(_NodeManager_getNode(_ptr));
-  }
 
-  Node releaseNode() {
-    if (_ptr == ffi.nullptr) {
-      throw StateError('This object has already been disposed.');
-    }
-    return Node.fromPointer(_NodeManager_releaseNode(_ptr));
+    return Node.fromPointer(_NodeManager_getNode(_ptr));
   }
 
   Node newNode(int value, ffi.Pointer<ffi.Int> destructorCounter) {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return Node.fromPointer(
       _NodeManager_newNode(_ptr, value, destructorCounter),
     );
@@ -255,6 +252,7 @@ class NodeManager implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return Node.fromPointer(
       _NodeManager_getSingletonNode(_ptr, value, destructorCounter),
     );
@@ -264,6 +262,7 @@ class NodeManager implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _NodeManager_getValue(_ptr, node._ptr);
   }
 
@@ -271,6 +270,7 @@ class NodeManager implements ffi.Finalizable {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
+
     return _NodeManager_takeNode(_ptr, node._ptr);
   }
 
@@ -309,13 +309,6 @@ external int _NodeManager_foo(
   symbol: 'NodeManager_getNode',
 )
 external ffi.Pointer<ffi.Void> _NodeManager_getNode(ffi.Pointer<ffi.Void> self);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>(
-  symbol: 'NodeManager_releaseNode',
-)
-external ffi.Pointer<ffi.Void> _NodeManager_releaseNode(
-  ffi.Pointer<ffi.Void> self,
-);
 
 @ffi.Native<
   ffi.Pointer<ffi.Void> Function(

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart
@@ -24,7 +24,7 @@ class Node implements ffi.Finalizable {
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>?
   _activeFinalizerFn;
 
-  Node.fromPointer(this._ptr, {bool takeOwnership = true}) {
+  Node.fromPointer(this._ptr, {bool takeOwnership = false}) {
     if (takeOwnership) {
       _defaultFinalizer.attach(this, _ptr.cast(), detach: this);
       _activeFinalizer = _defaultFinalizer;
@@ -90,7 +90,10 @@ class Node implements ffi.Finalizable {
   }
 
   factory Node(int value, ffi.Pointer<ffi.Int> destructorCounter) {
-    return Node.fromPointer(_Node_new(value, destructorCounter));
+    return Node.fromPointer(
+      _Node_new(value, destructorCounter),
+      takeOwnership: true,
+    );
   }
   int getValue() {
     if (_ptr == ffi.nullptr) {
@@ -102,6 +105,12 @@ class Node implements ffi.Finalizable {
   void dispose() {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
+    }
+    if (_activeFinalizer == null) {
+      throw StateError(
+        'Cannot dispose a non-owning wrapper. '
+        'Call retainOwnership() first to take ownership.',
+      );
     }
     _activeFinalizer!.detach(this);
     _activeFinalizer = null;
@@ -126,3 +135,231 @@ external int _Node_getValue(ffi.Pointer<ffi.Void> self);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(symbol: 'Node_delete')
 external void _Node_delete(ffi.Pointer<ffi.Void> self);
+
+class NodeManager implements ffi.Finalizable {
+  ffi.Pointer<ffi.Void> _ptr;
+  static final _defaultFinalizer = ffi.NativeFinalizer(
+    ffi.Native.addressOf<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>
+    >(_NodeManager_delete),
+  );
+
+  /// The finalizer currently attached for this instance, or [null] if this
+  /// object does not own its pointer.
+  ffi.NativeFinalizer? _activeFinalizer;
+
+  /// The native function pointer used by [_activeFinalizer], stored so that
+  /// [dispose] can call the correct destructor directly.
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>?
+  _activeFinalizerFn;
+
+  NodeManager.fromPointer(this._ptr, {bool takeOwnership = false}) {
+    if (takeOwnership) {
+      _defaultFinalizer.attach(this, _ptr.cast(), detach: this);
+      _activeFinalizer = _defaultFinalizer;
+      _activeFinalizerFn =
+          ffi.Native.addressOf<
+            ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>
+          >(_NodeManager_delete);
+    }
+  }
+
+  /// Attaches a finalizer so this object takes ownership of the underlying
+  /// C++ pointer. If [customFinalizer] is provided it is used instead of the
+  /// default `delete` finalizer, which is useful when the object was not
+  /// allocated with `new` (e.g. `malloc` or a custom allocator).
+  ///
+  /// Both [customFinalizer] and [customFinalizerFn] must be provided together.
+  ///
+  /// Throws a [StateError] if the object has already been disposed, or if
+  /// this object already owns the pointer.
+  void retainOwnership([
+    ffi.NativeFinalizer? customFinalizer,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>?
+    customFinalizerFn,
+  ]) {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    if (_activeFinalizer != null) {
+      throw StateError('This object already owns its pointer.');
+    }
+    if ((customFinalizer == null) != (customFinalizerFn == null)) {
+      throw ArgumentError(
+        'Both customFinalizer and customFinalizerFn must be provided together.',
+      );
+    }
+    final fin = customFinalizer ?? _defaultFinalizer;
+    final fnPtr =
+        customFinalizerFn ??
+        ffi.Native.addressOf<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>
+        >(_NodeManager_delete);
+    fin.attach(this, _ptr.cast(), detach: this);
+    _activeFinalizer = fin;
+    _activeFinalizerFn = fnPtr;
+  }
+
+  /// Detaches the finalizer so this object releases ownership of the
+  /// underlying C++ pointer. The caller becomes responsible for freeing
+  /// the memory.
+  ///
+  /// Throws a [StateError] if the object has already been disposed, or if
+  /// this object does not own the pointer.
+  void releaseOwnership() {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    if (_activeFinalizer == null) {
+      throw StateError('This object does not own its pointer.');
+    }
+    _activeFinalizer!.detach(this);
+    _activeFinalizer = null;
+    _activeFinalizerFn = null;
+  }
+
+  factory NodeManager() {
+    return NodeManager.fromPointer(_NodeManager_new(), takeOwnership: true);
+  }
+  int foo(Node node) {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    return _NodeManager_foo(_ptr, node._ptr);
+  }
+
+  Node getNode() {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    return Node.fromPointer(_NodeManager_getNode(_ptr));
+  }
+
+  Node releaseNode() {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    return Node.fromPointer(_NodeManager_releaseNode(_ptr));
+  }
+
+  Node newNode(int value, ffi.Pointer<ffi.Int> destructorCounter) {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    return Node.fromPointer(
+      _NodeManager_newNode(_ptr, value, destructorCounter),
+    );
+  }
+
+  Node getSingletonNode(int value, ffi.Pointer<ffi.Int> destructorCounter) {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    return Node.fromPointer(
+      _NodeManager_getSingletonNode(_ptr, value, destructorCounter),
+    );
+  }
+
+  int getValue(Node node) {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    return _NodeManager_getValue(_ptr, node._ptr);
+  }
+
+  int takeNode(Node node) {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    return _NodeManager_takeNode(_ptr, node._ptr);
+  }
+
+  void dispose() {
+    if (_ptr == ffi.nullptr) {
+      throw StateError('This object has already been disposed.');
+    }
+    if (_activeFinalizer == null) {
+      throw StateError(
+        'Cannot dispose a non-owning wrapper. '
+        'Call retainOwnership() first to take ownership.',
+      );
+    }
+    _activeFinalizer!.detach(this);
+    _activeFinalizer = null;
+    _activeFinalizerFn?.asFunction<void Function(ffi.Pointer<ffi.Void>)>()(
+      _ptr,
+    );
+    _activeFinalizerFn = null;
+    _ptr = ffi.nullptr;
+  }
+}
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function()>(symbol: 'NodeManager_new')
+external ffi.Pointer<ffi.Void> _NodeManager_new();
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>(
+  symbol: 'NodeManager_foo',
+)
+external int _NodeManager_foo(
+  ffi.Pointer<ffi.Void> self,
+  ffi.Pointer<ffi.Void> node,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>(
+  symbol: 'NodeManager_getNode',
+)
+external ffi.Pointer<ffi.Void> _NodeManager_getNode(ffi.Pointer<ffi.Void> self);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>(
+  symbol: 'NodeManager_releaseNode',
+)
+external ffi.Pointer<ffi.Void> _NodeManager_releaseNode(
+  ffi.Pointer<ffi.Void> self,
+);
+
+@ffi.Native<
+  ffi.Pointer<ffi.Void> Function(
+    ffi.Pointer<ffi.Void>,
+    ffi.Int,
+    ffi.Pointer<ffi.Int>,
+  )
+>(symbol: 'NodeManager_newNode')
+external ffi.Pointer<ffi.Void> _NodeManager_newNode(
+  ffi.Pointer<ffi.Void> self,
+  int value,
+  ffi.Pointer<ffi.Int> destructorCounter,
+);
+
+@ffi.Native<
+  ffi.Pointer<ffi.Void> Function(
+    ffi.Pointer<ffi.Void>,
+    ffi.Int,
+    ffi.Pointer<ffi.Int>,
+  )
+>(symbol: 'NodeManager_getSingletonNode')
+external ffi.Pointer<ffi.Void> _NodeManager_getSingletonNode(
+  ffi.Pointer<ffi.Void> self,
+  int value,
+  ffi.Pointer<ffi.Int> destructorCounter,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>(
+  symbol: 'NodeManager_getValue',
+)
+external int _NodeManager_getValue(
+  ffi.Pointer<ffi.Void> self,
+  ffi.Pointer<ffi.Void> node,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>(
+  symbol: 'NodeManager_takeNode',
+)
+external int _NodeManager_takeNode(
+  ffi.Pointer<ffi.Void> self,
+  ffi.Pointer<ffi.Void> node,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(
+  symbol: 'NodeManager_delete',
+)
+external void _NodeManager_delete(ffi.Pointer<ffi.Void> self);

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart
@@ -230,12 +230,14 @@ class NodeManager implements ffi.Finalizable {
     return _NodeManager_foo(_ptr, node._ptr);
   }
 
-  Node getNode() {
+  Node getNode(int value, ffi.Pointer<ffi.Int> destructorCounter) {
     if (_ptr == ffi.nullptr) {
       throw StateError('This object has already been disposed.');
     }
 
-    return Node.fromPointer(_NodeManager_getNode(_ptr));
+    return Node.fromPointer(
+      _NodeManager_getNode(_ptr, value, destructorCounter),
+    );
   }
 
   Node newNode(int value, ffi.Pointer<ffi.Int> destructorCounter) {
@@ -305,10 +307,18 @@ external int _NodeManager_foo(
   ffi.Pointer<ffi.Void> node,
 );
 
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>(
-  symbol: 'NodeManager_getNode',
-)
-external ffi.Pointer<ffi.Void> _NodeManager_getNode(ffi.Pointer<ffi.Void> self);
+@ffi.Native<
+  ffi.Pointer<ffi.Void> Function(
+    ffi.Pointer<ffi.Void>,
+    ffi.Int,
+    ffi.Pointer<ffi.Int>,
+  )
+>(symbol: 'NodeManager_getNode')
+external ffi.Pointer<ffi.Void> _NodeManager_getNode(
+  ffi.Pointer<ffi.Void> self,
+  int value,
+  ffi.Pointer<ffi.Int> destructorCounter,
+);
 
 @ffi.Native<
   ffi.Pointer<ffi.Void> Function(

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart.cpp
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart.cpp
@@ -20,4 +20,40 @@ FFIGEN_EXPORT void Node_delete(Node* self) {
   delete self;
 }
 
+FFIGEN_EXPORT NodeManager* NodeManager_new() {
+  return new NodeManager();
+}
+
+FFIGEN_EXPORT int NodeManager_foo(NodeManager* self, Node* node) {
+  return self->foo(node);
+}
+
+FFIGEN_EXPORT Node* NodeManager_getNode(NodeManager* self) {
+  return self->getNode();
+}
+
+FFIGEN_EXPORT Node* NodeManager_releaseNode(NodeManager* self) {
+  return self->releaseNode();
+}
+
+FFIGEN_EXPORT Node* NodeManager_newNode(NodeManager* self, int value, int * destructorCounter) {
+  return self->newNode(value, destructorCounter);
+}
+
+FFIGEN_EXPORT Node* NodeManager_getSingletonNode(NodeManager* self, int value, int * destructorCounter) {
+  return self->getSingletonNode(value, destructorCounter);
+}
+
+FFIGEN_EXPORT int NodeManager_getValue(NodeManager* self, Node* node) {
+  return self->getValue(node);
+}
+
+FFIGEN_EXPORT int NodeManager_takeNode(NodeManager* self, Node* node) {
+  return self->takeNode(node);
+}
+
+FFIGEN_EXPORT void NodeManager_delete(NodeManager* self) {
+  delete self;
+}
+
 }

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart.cpp
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart.cpp
@@ -32,10 +32,6 @@ FFIGEN_EXPORT Node* NodeManager_getNode(NodeManager* self) {
   return self->getNode();
 }
 
-FFIGEN_EXPORT Node* NodeManager_releaseNode(NodeManager* self) {
-  return self->releaseNode();
-}
-
 FFIGEN_EXPORT Node* NodeManager_newNode(NodeManager* self, int value, int * destructorCounter) {
   return self->newNode(value, destructorCounter);
 }

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart.cpp
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_bindings.dart.cpp
@@ -28,8 +28,8 @@ FFIGEN_EXPORT int NodeManager_foo(NodeManager* self, Node* node) {
   return self->foo(node);
 }
 
-FFIGEN_EXPORT Node* NodeManager_getNode(NodeManager* self) {
-  return self->getNode();
+FFIGEN_EXPORT Node* NodeManager_getNode(NodeManager* self, int value, int * destructorCounter) {
+  return self->getNode(value, destructorCounter);
 }
 
 FFIGEN_EXPORT Node* NodeManager_newNode(NodeManager* self, int value, int * destructorCounter) {

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_test.dart
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_test.dart
@@ -76,6 +76,13 @@ void main() {
       expect(node.releaseOwnership, throwsStateError);
     });
 
+    test('getNode() can take ownership via retainOwnership()', () {
+      final manager = NodeManager();
+      final node = manager.getNode()..retainOwnership();
+      expect(node.getValue(), 100);
+      node.dispose();
+    });
+
     test('newNode() returns unowned by default, counter stays 0', () {
       final counter = calloc<Int32>()..value = 0;
       final manager = NodeManager();
@@ -128,11 +135,10 @@ void main() {
       final counter = calloc<Int32>()..value = 0;
       final rawPtr = _rawNodeNew(400, counter.cast());
       final node = Node.fromPointer(rawPtr, takeOwnership: true);
-
-      // Detach Dart finalizer before transferring ownership to C++.
-      node.releaseOwnership();
       final manager = NodeManager();
-      expect(manager.takeNode(node), 400);
+
+      // Detach Dart finalizer and transfer ownership to C++.
+      expect(manager.takeNode(node..releaseOwnership()), 400);
 
       // C++ takeNode deleted the node.
       expect(counter.value, 1);

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_test.dart
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_test.dart
@@ -69,7 +69,7 @@ void main() {
 
     test('getNode() returns unowned pointer by default', () {
       final manager = NodeManager();
-      final node = manager.getNode();
+      final node = manager.getNode(100, nullptr);
       expect(node.getValue(), 100);
 
       // Wrapper is unowned by default, releaseOwnership throws StateError.
@@ -77,10 +77,15 @@ void main() {
     });
 
     test('getNode() can take ownership via retainOwnership()', () {
+      final counter = calloc<Int32>()..value = 0;
       final manager = NodeManager();
-      final node = manager.getNode()..retainOwnership();
+      final node = manager.getNode(100, counter.cast())..retainOwnership();
       expect(node.getValue(), 100);
+      expect(counter.value, 0);
+
       node.dispose();
+      expect(counter.value, 1);
+      calloc.free(counter);
     });
 
     test('newNode() returns unowned by default, counter stays 0', () {

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_test.dart
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_test.dart
@@ -23,7 +23,7 @@ external Pointer<Void> _rawNodeNew(int value, Pointer<Int> counter);
 external void _rawNodeDelete(Pointer<Void> self);
 
 void main() {
-  group('takeOwnership: false', () {
+  group('NodeManager memory management', () {
     // Test A - GC does not delete a non-owning wrapper.
     @pragma('vm:never-inline')
     void gcNonOwningInner(Pointer<Void> rawPtr, Pointer<Int32> counter) {
@@ -64,6 +64,96 @@ void main() {
       final node = Node.fromPointer(rawPtr, takeOwnership: false);
       expect(node.releaseOwnership, throwsStateError);
       _rawNodeDelete(rawPtr);
+      calloc.free(counter);
+    });
+
+    test('getNode() returns unowned pointer by default', () {
+      final manager = NodeManager();
+      final node = manager.getNode();
+      expect(node.getValue(), 100);
+
+      // Wrapper is unowned by default, releaseOwnership throws StateError.
+      expect(node.releaseOwnership, throwsStateError);
+    });
+
+    test(
+      'releaseNode() returns unowned pointer, dev calls retainOwnership()',
+      () {
+        final counter = calloc<Int32>()..value = 0;
+        final manager = NodeManager();
+        // releaseNode() returns unowned by default even though C++ transferred
+        // ownership. Developer must call retainOwnership() explicitly.
+        final node = manager.releaseNode();
+        expect(node.getValue(), 200);
+
+        // Developer explicitly takes ownership after knowing C++ gave it.
+        node.retainOwnership();
+        node.dispose();
+        expect(counter.value, 0); // Node was created without a counter.
+        calloc.free(counter);
+      },
+    );
+
+    test('newNode() returns unowned by default, counter stays 0', () {
+      final counter = calloc<Int32>()..value = 0;
+      final manager = NodeManager();
+      final node = manager.newNode(100, counter.cast());
+      expect(node.getValue(), 100);
+
+      // Wrapper is unowned, Dart will never call Node_delete automatically.
+      // Counter must still be 0 because no finalizer was attached.
+      expect(counter.value, 0);
+      // Transfer ownership so the node can be cleaned up cleanly.
+      node.retainOwnership();
+      node.dispose();
+      expect(counter.value, 1);
+      calloc.free(counter);
+    });
+
+    test('getSingletonNode() returns unowned pointer', () {
+      final counter = calloc<Int32>()..value = 0;
+      final manager = NodeManager();
+      final node = manager.getSingletonNode(200, counter.cast());
+      expect(node.getValue(), 200);
+
+      // Wrapper is unowned, releaseOwnership throws StateError.
+      expect(node.releaseOwnership, throwsStateError);
+      calloc.free(counter);
+    });
+
+    test('foo(node) passes pointer correctly', () {
+      final counter = calloc<Int32>()..value = 0;
+      final rawPtr = _rawNodeNew(42, counter.cast());
+      final node = Node.fromPointer(rawPtr, takeOwnership: false);
+      final manager = NodeManager();
+      expect(manager.foo(node), 42);
+      _rawNodeDelete(rawPtr);
+      calloc.free(counter);
+    });
+
+    test('getValue(node) borrows argument without destroying it', () {
+      final counter = calloc<Int32>()..value = 0;
+      final rawPtr = _rawNodeNew(300, counter.cast());
+      final node = Node.fromPointer(rawPtr, takeOwnership: false);
+      final manager = NodeManager();
+      expect(manager.getValue(node), 300);
+      expect(counter.value, 0); // Still alive!
+      _rawNodeDelete(rawPtr);
+      calloc.free(counter);
+    });
+
+    test('takeNode(node) takes ownership and deletes C++ object', () {
+      final counter = calloc<Int32>()..value = 0;
+      final rawPtr = _rawNodeNew(400, counter.cast());
+      final node = Node.fromPointer(rawPtr, takeOwnership: true);
+
+      // Detach Dart finalizer before transferring ownership to C++.
+      node.releaseOwnership();
+      final manager = NodeManager();
+      expect(manager.takeNode(node), 400);
+
+      // C++ takeNode deleted the node.
+      expect(counter.value, 1);
       calloc.free(counter);
     });
   });

--- a/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_test.dart
+++ b/pkgs/ffigen/test/native_cpp_test/memory_edge_cases_test.dart
@@ -76,24 +76,6 @@ void main() {
       expect(node.releaseOwnership, throwsStateError);
     });
 
-    test(
-      'releaseNode() returns unowned pointer, dev calls retainOwnership()',
-      () {
-        final counter = calloc<Int32>()..value = 0;
-        final manager = NodeManager();
-        // releaseNode() returns unowned by default even though C++ transferred
-        // ownership. Developer must call retainOwnership() explicitly.
-        final node = manager.releaseNode();
-        expect(node.getValue(), 200);
-
-        // Developer explicitly takes ownership after knowing C++ gave it.
-        node.retainOwnership();
-        node.dispose();
-        expect(counter.value, 0); // Node was created without a counter.
-        calloc.free(counter);
-      },
-    );
-
     test('newNode() returns unowned by default, counter stays 0', () {
       final counter = calloc<Int32>()..value = 0;
       final manager = NodeManager();

--- a/pkgs/ffigen/test/native_cpp_test/verify_bindings_test.dart
+++ b/pkgs/ffigen/test/native_cpp_test/verify_bindings_test.dart
@@ -61,7 +61,7 @@ void main() {
           ],
           compilerOptions: ['-x', 'c++'],
         ),
-        cpp: Cpp(classes: CppClasses.includeSet({'Node'})),
+        cpp: Cpp(classes: CppClasses.includeSet({'Node', 'NodeManager'})),
       ),
     };
 


### PR DESCRIPTION
* Support C++ class pointers as method parameters and return values.
* Add ownership-aware wrapper generation with `takeOwnership: false` by default.
* Add tests for borrowed and ownership-transfer scenarios.