### PR TITLE
Revert "[jni] Migrate to built-in Kotlin (#3477)"

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Revert an unnecessary (and breaking) KGP migration.
+
 ## 1.0.1
 
 - Improve error message when JNI is used before Flutter plugin initialization.

--- a/pkgs/jni/android/build.gradle
+++ b/pkgs/jni/android/build.gradle
@@ -19,11 +19,6 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
-    apply plugin: 'kotlin-android'
-}
-
 android {
     // Keeping the classes from being removed by proguard.
     defaultConfig {
@@ -80,10 +75,3 @@ android {
         minSdk 21
     }
 }
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
-

--- a/pkgs/jni/example/android/gradle.properties
+++ b/pkgs/jni/example/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 android.useAndroidX=true
 android.enableJetifier=true
 # This builtInKotlin flag was added automatically by Flutter migrator

--- a/pkgs/jni/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pkgs/jni/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/pkgs/jni/example/android/settings.gradle
+++ b/pkgs/jni/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni
 description: A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen.
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajni
 

--- a/pkgs/jni_flutter/CHANGELOG.md
+++ b/pkgs/jni_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Use JNIgen 0.17.0.
+
 ## 1.0.1
 
 - Add an example app.

--- a/pkgs/jni_flutter/android/build.gradle
+++ b/pkgs/jni_flutter/android/build.gradle
@@ -19,11 +19,6 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
-    apply plugin: 'kotlin-android'
-}
-
 android {
     if (project.android.hasProperty("namespace")) {
         namespace 'com.github.dart_lang.jni_flutter'
@@ -47,10 +42,3 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 }
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
-

--- a/pkgs/jni_flutter/pubspec.yaml
+++ b/pkgs/jni_flutter/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni_flutter
 description: A library to access Flutter Android specific APIs from Dart.
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni_flutter
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajni_flutter
 

--- a/pkgs/jnigen/android_test_runner/android/gradle.properties
+++ b/pkgs/jnigen/android_test_runner/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 android.useAndroidX=true
 android.enableJetifier=true

--- a/pkgs/jnigen/android_test_runner/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pkgs/jnigen/android_test_runner/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/pkgs/jnigen/android_test_runner/android/settings.gradle
+++ b/pkgs/jnigen/android_test_runner/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/pkgs/jnigen/example/in_app_java/android/gradle.properties
+++ b/pkgs/jnigen/example/in_app_java/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 android.useAndroidX=true
 android.enableJetifier=true
 # This builtInKotlin flag was added automatically by Flutter migrator

--- a/pkgs/jnigen/example/in_app_java/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pkgs/jnigen/example/in_app_java/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/pkgs/jnigen/example/in_app_java/android/settings.gradle
+++ b/pkgs/jnigen/example/in_app_java/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/pkgs/jnigen/example/kotlin_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pkgs/jnigen/example/kotlin_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/pkgs/jnigen/example/kotlin_plugin/example/android/settings.gradle
+++ b/pkgs/jnigen/example/kotlin_plugin/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/pkgs/jnigen/example/maven_libs/android/build.gradle.kts
+++ b/pkgs/jnigen/example/maven_libs/android/build.gradle.kts
@@ -2,7 +2,7 @@ group = "com.example.maven_libs"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    val kotlinVersion = "2.2.20"
+    val kotlinVersion = "2.4.0"
     repositories {
         google()
         mavenCentral()

--- a/pkgs/jnigen/example/maven_libs/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pkgs/jnigen/example/maven_libs/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/pkgs/jnigen/example/maven_libs/example/android/settings.gradle
+++ b/pkgs/jnigen/example/maven_libs/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/pkgs/jnigen/example/maven_libs/example/android/settings.gradle.kts
+++ b/pkgs/jnigen/example/maven_libs/example/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("com.android.application") version "9.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
 include(":app")

--- a/pkgs/jnigen/example/maven_libs_groovy/android/build.gradle
+++ b/pkgs/jnigen/example/maven_libs_groovy/android/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0"
+        classpath 'com.android.tools.build:gradle:9.1.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0"
     }
 }
 

--- a/pkgs/jnigen/example/maven_libs_groovy/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pkgs/jnigen/example/maven_libs_groovy/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/pkgs/jnigen/example/maven_libs_groovy/example/android/settings.gradle
+++ b/pkgs/jnigen/example/maven_libs_groovy/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/pkgs/jnigen/example/notification_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pkgs/jnigen/example/notification_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/pkgs/jnigen/example/notification_plugin/example/android/settings.gradle
+++ b/pkgs/jnigen/example/notification_plugin/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/pkgs/jnigen/example/pdfbox_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pkgs/jnigen/example/pdfbox_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/pkgs/jnigen/example/pdfbox_plugin/example/android/settings.gradle
+++ b/pkgs/jnigen/example/pdfbox_plugin/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
+    id "com.android.application" version "9.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/pkgs/jnigen/java/build.gradle.kts
+++ b/pkgs/jnigen/java/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.17.0")
     implementation("commons-cli:commons-cli:1.5.0")
     implementation("org.ow2.asm:asm-tree:9.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-metadata-jvm:2.2.0")
+    implementation("org.jetbrains.kotlin:kotlin-metadata-jvm:2.4.0")
     implementation(kotlin("stdlib-jdk8"))
     testImplementation("junit:junit:4.13.2")
 }

--- a/pkgs/jnigen/test/kotlin_test/kotlin/pom.xml
+++ b/pkgs/jnigen/test/kotlin_test/kotlin/pom.xml
@@ -15,7 +15,7 @@
         <kotlin.code.style>official</kotlin.code.style>
         <main.class>com.github.dart_lang.jnigen.SuspendFun</main.class>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-        <kotlin.version>2.2.20</kotlin.version>
+        <kotlin.version>2.4.0</kotlin.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This reverts https://github.com/dart-lang/native/pull/3477

Also, prepare to immediately publish jni and jni_flutter.

Fixes https://github.com/flutter/flutter/issues/190084
Fixes https://github.com/dart-lang/native/issues/3499

cc https://github.com/dart-lang/native/issues/3415