### PR TITLE
[infra] Fix github workflow warnings

### DIFF
--- a/.github/workflows/ffigen.yml
+++ b/.github/workflows/ffigen.yml
@@ -25,6 +25,8 @@ jobs:
   # Check code formatting and static analysis on a single OS (macos).
   analyze:
     runs-on: macos-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
@@ -32,6 +34,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -47,11 +51,15 @@ jobs:
   test-linux:
     needs: analyze
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -69,11 +77,15 @@ jobs:
   test-mac:
     needs: analyze
     runs-on: 'macos-latest'
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -109,11 +121,15 @@ jobs:
   test-mac-latest:
     needs: analyze
     runs-on: 'macos-latest'
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -129,11 +145,15 @@ jobs:
   test-mac-flutter:
     needs: analyze
     runs-on: 'macos-latest'
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -145,11 +165,15 @@ jobs:
   test-mac-aot:
     needs: analyze
     runs-on: 'macos-latest'
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -169,11 +193,15 @@ jobs:
   test-windows:
     needs: analyze
     runs-on: windows-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -198,11 +226,15 @@ jobs:
   test-windows-flutter:
     needs: analyze
     runs-on: windows-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable

--- a/.github/workflows/ffigen_weekly.yml
+++ b/.github/workflows/ffigen_weekly.yml
@@ -23,11 +23,15 @@ jobs:
   # Keep in sync with ffigen.yaml:test-mac
   test-mac-x64:
     runs-on: 'macos-14-large' # x64
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/ffigen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -8,7 +8,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@edfdb3b4063b9034b708144633a700204f865f43
     with:
       coverage_web: false
       # TODO(https://github.com/dart-lang/native/issues/1242): Add coverage back.

--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -36,11 +36,15 @@ env:
 jobs:
   analyze_jni_util:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni_util
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -55,11 +59,15 @@ jobs:
   test_jni_util:
     needs: [analyze_jni_util]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni_util
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -71,6 +79,8 @@ jobs:
 
   analyze_jnigen:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jnigen
@@ -80,6 +90,8 @@ jobs:
         sdk: [stable]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: ${{ matrix.sdk }}
@@ -105,6 +117,8 @@ jobs:
   test_jnigen:
     needs: [analyze_jnigen]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jnigen
@@ -118,6 +132,8 @@ jobs:
             java-version: 'none'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: ${{ matrix.sdk }}
@@ -172,11 +188,15 @@ jobs:
   test_jnigen_android:
     needs: [analyze_jnigen]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jnigen/android_test_runner
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -198,11 +218,15 @@ jobs:
 
   analyze_jni_flutter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni_flutter
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -223,11 +247,15 @@ jobs:
   test_jni_flutter_android:
     needs: [analyze_jni_flutter]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni_flutter/android_test_runner
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -254,11 +282,15 @@ jobs:
 
   analyze_jni:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -289,6 +321,8 @@ jobs:
 
   test_jni:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [analyze_jni]
     defaults:
       run:
@@ -299,6 +333,8 @@ jobs:
         java-version: ['17', '21', 'none']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -358,11 +394,15 @@ jobs:
   test_jni_android:
     needs: [analyze_jni]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni/example
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -387,11 +427,15 @@ jobs:
   test_jni_windows_minimal:
     needs: [analyze_jni]
     runs-on: windows-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -409,6 +453,8 @@ jobs:
   # Not having Java installed on a Desktop will not fail Flutter build.
   test_no_jdk_fallback:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni
@@ -424,6 +470,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -476,11 +524,15 @@ jobs:
   test_jnigen_windows_minimal:
     needs: [analyze_jnigen]
     runs-on: windows-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jnigen
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Setup clang
         uses: egor-tensin/setup-clang@23bc15cd4207e45f1566447deb48f4ff3ef932cb
         with:
@@ -507,11 +559,15 @@ jobs:
   test_jni_macos_minimal:
     needs: [analyze_jni]
     runs-on: macos-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -524,11 +580,15 @@ jobs:
   test_jnigen_macos_minimal:
     needs: [analyze_jnigen]
     runs-on: macos-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jnigen
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Setup clang format
         uses: ConorMacBride/install-package@3e7ad059e07782ee54fa35f827df52aae0626f30
         with:
@@ -547,11 +607,15 @@ jobs:
 
   build_jni_example_linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni/example
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -567,11 +631,15 @@ jobs:
 
   build_jni_example_windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni/example
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -583,11 +651,15 @@ jobs:
 
   build_jni_example_android:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jni/example
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -598,11 +670,15 @@ jobs:
 
   run_pdfbox_example_linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./pkgs/jnigen/example/pdfbox_plugin
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -635,6 +711,8 @@ jobs:
   coveralls_finish:
     needs: [test_jnigen, test_jni]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Coveralls finished
         uses: coverallsapp/github-action@0a51d2e0b5417d06e4ecceb534aec87defc53926

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -4,7 +4,7 @@
 
 name: native
 permissions:
-      contents: read
+  contents: read
 
 on:
   pull_request:
@@ -49,7 +49,6 @@ jobs:
         sdk: [dev, stable]
 
     runs-on: ${{ matrix.os }}-latest
-
 
     defaults:
       run:
@@ -118,8 +117,6 @@ jobs:
   coverage-finished:
     needs: [build]
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Upload coverage
         uses: coverallsapp/github-action@0a51d2e0b5417d06e4ecceb534aec87defc53926

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -3,7 +3,8 @@
 # Combined into a single workflow so that deps are configured and installed once.
 
 name: native
-permissions: read-all
+permissions:
+      contents: read
 
 on:
   pull_request:
@@ -49,12 +50,15 @@ jobs:
 
     runs-on: ${{ matrix.os }}-latest
 
+
     defaults:
       run:
         working-directory: .
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
@@ -114,6 +118,8 @@ jobs:
   coverage-finished:
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Upload coverage
         uses: coverallsapp/github-action@0a51d2e0b5417d06e4ecceb534aec87defc53926

--- a/.github/workflows/native_doc_dartifier.yaml
+++ b/.github/workflows/native_doc_dartifier.yaml
@@ -19,6 +19,8 @@ env:
 jobs:
   analyze_and_test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/native_doc_dartifier/
@@ -28,6 +30,8 @@ jobs:
         sdk: [stable]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: ${{ matrix.sdk }}

--- a/.github/workflows/native_toolchain_c.yaml
+++ b/.github/workflows/native_toolchain_c.yaml
@@ -1,7 +1,8 @@
 # Workflow that runs relevant tests with the clang from the Dart SDK.
 
 name: native_toolchain_c
-permissions: read-all
+permissions:
+      contents: read
 
 on:
   pull_request:
@@ -26,6 +27,8 @@ jobs:
         package: [native_toolchain_c]
 
     runs-on: ${{ matrix.os }}-latest
+    permissions:
+      contents: read
 
     defaults:
       run:
@@ -33,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   no-response:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.repository_owner == 'dart-lang' }}
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899

--- a/.github/workflows/objective_c.yaml
+++ b/.github/workflows/objective_c.yaml
@@ -26,6 +26,8 @@ jobs:
   # Check code formatting and static analysis.
   analyze:
     runs-on: macos-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/objective_c/
@@ -33,6 +35,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -49,11 +53,15 @@ jobs:
   test-mac:
     needs: analyze
     runs-on: 'macos-latest'
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/objective_c/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: stable
@@ -86,6 +94,8 @@ jobs:
   build-flutter-example:
     needs: analyze
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/objective_c/example/flutter_app
@@ -101,6 +111,8 @@ jobs:
             xcode_version: "26.3"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
@@ -126,11 +138,15 @@ jobs:
   build-command-line-example:
     needs: analyze
     runs-on: 'macos-latest'
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/objective_c/example/command_line
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: stable

--- a/.github/workflows/package_download_asset.yaml
+++ b/.github/workflows/package_download_asset.yaml
@@ -24,6 +24,8 @@ jobs:
         os: [ubuntu, macos, windows]
 
     runs-on: ${{ matrix.os }}-latest
+    permissions:
+      contents: read
 
     defaults:
       run:
@@ -31,6 +33,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
 
     - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       with:
@@ -92,6 +96,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     defaults:
       run:
@@ -101,6 +107,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Download assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -112,7 +119,6 @@ jobs:
         run: ls -R .dart_tool/download_asset/
 
       - name: Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         if: startsWith(github.ref, 'refs/tags/download_asset-prebuild-assets')
         with:
           files: 'pkgs/hooks/example/build/download_asset/.dart_tool/download_asset/**'

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -8,10 +8,10 @@ on:
       - Health
       - Publish
     types:
-      - completed
+      - completed  # zizmor: ignore[dangerous-triggers]
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@edfdb3b4063b9034b708144633a700204f865f43
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-title-checker.yaml
+++ b/.github/workflows/pr-title-checker.yaml
@@ -6,18 +6,12 @@ on:
       - edited
       - reopened
       - synchronize
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
-      - labeled
-      - unlabeled
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: thehanimo/pr-title-checker@7fbfe05602bdd86f926d3fb3bccb6f3aed43bc70
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@edfdb3b4063b9034b708144633a700204f865f43
     permissions:
       id-token: write # Required for authentication using OIDC
       pull-requests: write # Required for writing the pull request note

--- a/.github/workflows/swift2objc.yaml
+++ b/.github/workflows/swift2objc.yaml
@@ -24,6 +24,8 @@ jobs:
   # Check code formatting and static analysis.
   analyze:
     runs-on: macos-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/swift2objc/
@@ -31,6 +33,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: stable
@@ -47,11 +51,15 @@ jobs:
   test-mac:
     needs: analyze
     runs-on: 'macos-latest'
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/swift2objc/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: stable

--- a/.github/workflows/swiftgen.yaml
+++ b/.github/workflows/swiftgen.yaml
@@ -30,6 +30,8 @@ jobs:
   # Check code formatting and static analysis.
   analyze:
     runs-on: macos-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/swiftgen/
@@ -37,6 +39,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: master
@@ -53,11 +57,15 @@ jobs:
   test-mac:
     needs: analyze
     runs-on: 'macos-latest'
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: pkgs/swiftgen/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: master


### PR DESCRIPTION
Google has enabled [Zizmor](https://docs.zizmor.sh/audits/) for all its open source projects. This is a static analysis tool that looks for security issues in github workflows. I immediately started seeing Zizmor errors on my PRs. So I've gone through and fixed all our workflows.

Fixes:
- Pinned our dart-lang/ecosystem action imports to the latest git hash (we'll need to update this manually if we want to use a newer version in future)
- Zizmor is very unhappy with some of our workflow triggers
  - pr-title-checker has a lot of triggers, and all the pull_request_target triggers are insecure apparently. They seem unnecessary so I just removed them
  - post_summaries.yaml's workflow completed trigger is also insecure according to Zizmor. But it's clearly necessary and I'm not sure how to refactor the workflow to do it differently. So I just added an ignore rule.
- Tightened permissions (most of our workflows just need read access to the repo contents)
- Added `persist-credentials: false` to a bunch of actions invocations
- package_download_asset.yaml's import of softprops is redundant (already transitively imported), so I removed it