### PR TITLE
[swift2objc] Fix nested extension target qualification

### DIFF
--- a/pkgs/swift2objc/CHANGELOG.md
+++ b/pkgs/swift2objc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0-wip
+
+- Fix extensions of nested types to use fully qualified generated wrapper names.
+
 ## 0.2.0
 
 - Fix [a bug](https://github.com/dart-lang/native/issues/2666) where generated

--- a/pkgs/swift2objc/lib/src/generator/generators/extension_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/extension_generator.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../ast/_core/interfaces/declaration.dart';
 import '../../ast/declarations/compounds/extension_declaration.dart';
 import '../_core/utils.dart';
 import 'class_generator.dart';
@@ -9,7 +10,7 @@ import 'class_generator.dart';
 List<String> generateExtension(ExtensionDeclaration declaration) {
   return [
     ...generateAvailability(declaration),
-    '@objc extension ${declaration.extendedType.declaration.name} {',
+    '@objc extension ${declaration.extendedType.declaration.fullName} {',
     ...[
       for (final method in declaration.methods) ...generateClassMethod(method),
       for (final property in declaration.properties)

--- a/pkgs/swift2objc/pubspec.yaml
+++ b/pkgs/swift2objc/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: swift2objc
 description: 'A tool for generating bindings that allow interop between Dart and Swift code.'
-version: 0.2.0
+version: 0.3.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/swift2objc
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aswift2objc
 

--- a/pkgs/swift2objc/test/integration/extensions_input.swift
+++ b/pkgs/swift2objc/test/integration/extensions_input.swift
@@ -58,3 +58,18 @@ public extension MyEnum {
         return 0
     }
 }
+
+// Extension on a nested class
+public class OuterClass {
+    public class InnerClass {
+        public func originalNestedFunc() -> Int {
+            return 0
+        }
+    }
+}
+
+public extension OuterClass.InnerClass {
+    func nestedExtensionFunc() -> Int {
+        return 0
+    }
+}

--- a/pkgs/swift2objc/test/integration/extensions_output.swift
+++ b/pkgs/swift2objc/test/integration/extensions_output.swift
@@ -2,6 +2,28 @@
 
 import Foundation
 
+@objc public class OuterClassWrapper: NSObject {
+  var wrappedInstance: OuterClass
+
+  init(_ wrappedInstance: OuterClass) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @objc public class InnerClassWrapper: NSObject {
+    var wrappedInstance: OuterClass.InnerClass
+
+    init(_ wrappedInstance: OuterClass.InnerClass) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+    @objc public func originalNestedFunc() -> Int {
+      return wrappedInstance.originalNestedFunc()
+    }
+
+  }
+
+}
+
 @objc public class MyEnumWrapper: NSObject {
   var wrappedInstance: MyEnum
 
@@ -48,6 +70,13 @@ import Foundation
 
   init(_ wrappedInstance: BareClass) {
     self.wrappedInstance = wrappedInstance
+  }
+
+}
+
+@objc extension OuterClassWrapper.InnerClassWrapper {
+  @objc public func nestedExtensionFunc() -> Int {
+    return wrappedInstance.nestedExtensionFunc()
   }
 
 }


### PR DESCRIPTION
## Description

This PR fixes code generation for extensions of nested Swift types by using the fully qualified declaration name (`fullName`) when generating extension targets.

It also adds a regression test covering extensions on nested types.

## Related Issues

Fixes #3258

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [ ] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
  - I was able to run `dart analyze`, but I couldn't run the full integration pipeline because it requires macOS SymbolGraph tooling (`xcrun`/Apple SDKs), which isn't available in my Linux environment.
- [ ] All existing and new tests are passing. I added a new integration test input, but I couldn't regenerate the expected integration output locally for the reason above.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [x] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.