### PR TITLE
[native_toolchain_c] Link frameworks for C and C++

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.19.4-wip
+
+- Link frameworks for C and C++ sources targeting macOS or iOS.
+  ([#3162](https://github.com/dart-lang/native/issues/3162))
+
 ## 0.19.3
 
 - Fixed building with MSVC on Windows when a source, include, or output path

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
@@ -66,7 +66,7 @@ abstract class CTool {
 
   /// Frameworks to link.
   ///
-  /// Only effective if [language] is [Language.objectiveC].
+  /// Only effective when targeting macOS or iOS.
   ///
   /// Defaults to `['Foundation']`.
   ///

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -372,7 +372,7 @@ class RunCBuilder {
           )
         else
           ...sourceFiles,
-        if (language == .objectiveC) ...[
+        if (codeConfig.targetOS case .iOS || .macOS) ...[
           for (final framework in frameworks) ...['-framework', framework],
         ],
         if (executable != null) ...[

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.19.3
+version: 0.19.4-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -191,6 +191,54 @@ void main() async {
     );
   }
 
+  test('CBuilder links macOS frameworks for C sources', () async {
+    const name = 'core_foundation';
+    final tempUri = await tempDirForTest();
+    final outputUri = await tempDirForTest();
+    final sourceUri = packageUri.resolve(
+      'test/cbuilder/testfiles/core_foundation/src/core_foundation.c',
+    );
+
+    final buildInputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: name,
+        packageRoot: tempUri,
+        outputFile: tempUri.resolve('output.json'),
+        outputDirectoryShared: outputUri,
+      )
+      ..config.setupBuild(linkingEnabled: false)
+      ..addExtension(
+        CodeAssetExtension(
+          targetOS: .macOS,
+          targetArchitecture: Architecture.current,
+          linkModePreference: .dynamic,
+          macOS: MacOSCodeConfig(targetVersion: defaultMacOSVersion),
+          cCompiler: cCompiler,
+        ),
+      );
+    final buildInput = buildInputBuilder.build();
+    final buildOutput = BuildOutputBuilder();
+
+    final cbuilder = CBuilder.library(
+      name: name,
+      assetName: name,
+      sources: [sourceUri.toFilePath()],
+      language: .c,
+      frameworks: const ['CoreFoundation'],
+      buildMode: .release,
+    );
+    await cbuilder.run(
+      input: buildInput,
+      output: buildOutput,
+      logger: logger,
+    );
+
+    final libraryUri = buildInput.outputDirectory.resolve(
+      OS.macOS.libraryFileName(name, DynamicLoadingBundled()),
+    );
+    expect(await File.fromUri(libraryUri).exists(), isTrue);
+  });
+
   for (final macosVersion in [
     MacOSVersion.flutterLowestBestEffort,
     MacOSVersion.flutterLowestSupported,

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/core_foundation/src/core_foundation.c
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/core_foundation/src/core_foundation.c
@@ -1,0 +1,9 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include <CoreFoundation/CoreFoundation.h>
+
+double current_absolute_time(void) {
+  return CFAbsoluteTimeGetCurrent();
+}


### PR DESCRIPTION
## Description

`CBuilder` only passed `frameworks` to Clang when the source language was
Objective-C. As a result, C and C++ builds targeting Apple platforms silently
dropped explicitly requested frameworks and failed at link time with undefined
symbols.

This change passes framework flags based on the target OS instead of the source
language. Frameworks are now linked for C, C++, and Objective-C builds targeting
macOS or iOS, while non-Apple targets remain unchanged.

The regression test builds a C dynamic library that calls
`CFAbsoluteTimeGetCurrent` and explicitly links CoreFoundation. Without the fix,
the test fails with an undefined symbol because `-framework CoreFoundation` is
missing.

## Related Issues

Fixes #3162.

## PR Checklist

- [x] I’ve reviewed the contributor guide and applied the relevant portions.
- [x] I've run `dart tool/ci.dart --all` locally with Dart
      `3.14.0-52.0.dev`.
- [x] All existing and new tests are passing.
- [x] The PR solves the linked issue and includes a regression test.
- [x] I have updated `CHANGELOG.md`.
- [x] I have updated the package version.
