### PR TITLE
[infra] Fix package_download_asset workflow

### DIFF
--- a/.github/workflows/package_download_asset.yaml
+++ b/.github/workflows/package_download_asset.yaml
@@ -119,6 +119,8 @@ jobs:
         run: ls -R .dart_tool/download_asset/
 
       - name: Release
+        # zizmor: ignore[superfluous-actions]
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         if: startsWith(github.ref, 'refs/tags/download_asset-prebuild-assets')
         with:
           files: 'pkgs/hooks/example/build/download_asset/.dart_tool/download_asset/**'


### PR DESCRIPTION
The correct fix for the redundant `action-gh-release` import was not to delete it, but refactor the job to use the `gh` command line tool. Seems like an excessive change for an `[info]` level warning, so I just added an ignore instead.

Deleting the `uses` makes the workflow invalid, and unrunnable. Not sure why this wasn't an error on the PR's CI. The error only showed up when run on main.