### PR TITLE
[hooks_runner] Report a format error for non-object hook output JSON

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -4,7 +4,7 @@
   invoked, so they can emit validation diagnostics.
 - Require `dartExecutable` to be an absolute path, and on Windows to include a
   file extension
-- Report a format error instead of throwing a `TypeError` when a hook's
+- Report a format error instead of throwing a `TypeError` when a hook's cached
   `output.json` contains valid JSON that is not an object.
 
 ## 1.6.1

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -4,6 +4,8 @@
   invoked, so they can emit validation diagnostics.
 - Require `dartExecutable` to be an absolute path, and on Windows to include a
   file extension
+- Report a format error instead of throwing a `TypeError` when a hook's
+  `output.json` contains valid JSON that is not an object.
 
 ## 1.6.1
 

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -1078,7 +1078,11 @@ ${e.message}''');
     logger.info('output.json contents:\n$fileContents');
     final Map<String, Object?> hookOutputJson;
     try {
-      hookOutputJson = jsonDecode(fileContents) as Map<String, Object?>;
+      final decoded = jsonDecode(fileContents);
+      if (decoded is! Map<String, Object?>) {
+        throw const FormatException('Expected a JSON object.');
+      }
+      hookOutputJson = decoded;
     } on FormatException catch (e) {
       logger.severe('''
 Building assets for package:$packageName failed.

--- a/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
@@ -399,4 +399,34 @@ void main() async {
       });
     },
   );
+
+  test(
+    'cached output that is not a JSON object fails gracefully',
+    timeout: longTimeout,
+    () async {
+      await inTempDir((tempUri) async {
+        await copyTestProjects(targetUri: tempUri);
+        final packageUri = tempUri.resolve('native_add/');
+        await runPubGet(workingDirectory: packageUri, logger: logger);
+
+        expect((await buildCodeAssets(packageUri)).isSuccess, isTrue);
+        final buildDirectory =
+            (Directory.fromUri(
+                      packageUri.resolve('.dart_tool/hooks_runner/native_add/'),
+                    ).listSync().single
+                    as Directory)
+                .uri;
+        final outputFile = File.fromUri(buildDirectory.resolve('output.json'));
+        await outputFile.writeAsString('[]');
+
+        final logMessages = <String>[];
+        final result = await buildCodeAssets(
+          packageUri,
+          capturedLogs: logMessages,
+        );
+        expect(result.isFailure, isTrue);
+        expect(logMessages.join('\n'), contains('contained a format error'));
+      });
+    },
+  );
 }

--- a/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
@@ -401,7 +401,7 @@ void main() async {
   );
 
   test(
-    'cached output that is not a JSON object fails gracefully',
+    'cached output that is not a JSON object reports a format error',
     timeout: longTimeout,
     () async {
       await inTempDir((tempUri) async {


### PR DESCRIPTION
## Description

Follow-up to #3484: reverting the cache-hit revalidation there restored a latent `CastError` when a hook's `output.json` holds valid JSON that is not an object (`[]`, a string, a number, `null`). The `as Map<String, Object?>` cast in `_readHookOutputFromUri` threw a `TypeError` that escaped the `Result` failure handling entirely:

```
type 'List<dynamic>' is not a subtype of type 'Map<String, Object?>' in type cast
#0  NativeAssetsBuildRunner._readHookOutputFromUri (build_runner.dart:1081)
#1  NativeAssetsBuildRunner._runHookForPackageCached.<fn> (build_runner.dart:540)
```

Non-object output now takes the same path malformed JSON already takes: a severe "contained a format error" log and `Failure(HooksRunnerFailure.hookRun)`. Deliberately no cache invalidation or rerun, matching the existing malformed-JSON behavior; validators keep running only on freshly produced output as settled in https://github.com/dart-lang/native/pull/3484#discussion_r3641388437.

## Related Issues

Closes the loop on https://github.com/dart-lang/native/pull/3484#discussion_r3641388437.

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [x] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace. (Ran with `--no-apitool --no-format` on stable Dart 3.11.0; 1783 tests passed, the single failure is `native_toolchain_c/test/clinker/rust_test.dart` setUpAll because `rustc` is not installed on this machine, unrelated to this change.)
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [x] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
