### PR TITLE
[ffigen] Config update part 1: trivial stuff

### DIFF
--- a/pkgs/code_assets/example/host_name/tool/ffigen.dart
+++ b/pkgs/code_assets/example/host_name/tool/ffigen.dart
@@ -12,7 +12,7 @@ void main() {
   final FfiGenerator generator;
   if (Platform.isWindows) {
     generator = FfiGenerator(
-      headers: Headers(entryPoints: [packageRoot.resolve('src/windows.h')]),
+      input: Input(entryPoints: [packageRoot.resolve('src/windows.h')]),
       functions: functions,
       output: Output(
         dartFile: packageRoot.resolve('lib/src/third_party/windows.dart'),
@@ -26,7 +26,7 @@ void main() {
     );
   } else {
     generator = FfiGenerator(
-      headers: Headers(entryPoints: [packageRoot.resolve('src/unix.h')]),
+      input: Input(entryPoints: [packageRoot.resolve('src/unix.h')]),
       functions: functions,
       output: Output(
         dartFile: packageRoot.resolve('lib/src/third_party/unix.dart'),

--- a/pkgs/code_assets/example/mini_audio/tool/ffigen.dart
+++ b/pkgs/code_assets/example/mini_audio/tool/ffigen.dart
@@ -9,9 +9,7 @@ import 'package:ffigen/ffigen.dart';
 void main() {
   final packageRoot = Platform.script.resolve('../');
   FfiGenerator(
-    headers: Headers(
-      entryPoints: [packageRoot.resolve('third_party/miniaudio.h')],
-    ),
+    input: Input(entryPoints: [packageRoot.resolve('third_party/miniaudio.h')]),
     functions: Functions(
       include: (decl) => {
         'ma_engine_init',

--- a/pkgs/code_assets/example/sqlite/tool/ffigen.dart
+++ b/pkgs/code_assets/example/sqlite/tool/ffigen.dart
@@ -9,7 +9,7 @@ import 'package:ffigen/ffigen.dart';
 void main() {
   final packageRoot = Platform.script.resolve('../');
   FfiGenerator(
-    headers: Headers(
+    input: Input(
       entryPoints: [packageRoot.resolve('third_party/sqlite/sqlite3.h')],
     ),
     functions: Functions(

--- a/pkgs/code_assets/example/sqlite_no_link/tool/ffigen.dart
+++ b/pkgs/code_assets/example/sqlite_no_link/tool/ffigen.dart
@@ -9,7 +9,7 @@ import 'package:ffigen/ffigen.dart';
 void main() {
   final packageRoot = Platform.script.resolve('../');
   FfiGenerator(
-    headers: Headers(
+    input: Input(
       entryPoints: [packageRoot.resolve('third_party/sqlite/sqlite3.h')],
     ),
     functions: Functions.includeSet({'sqlite3_libversion'}),

--- a/pkgs/code_assets/example/sqlite_prebuilt/tool/ffigen.dart
+++ b/pkgs/code_assets/example/sqlite_prebuilt/tool/ffigen.dart
@@ -9,7 +9,7 @@ import 'package:ffigen/ffigen.dart';
 void main() {
   final packageRoot = Platform.script.resolve('../');
   FfiGenerator(
-    headers: Headers(
+    input: Input(
       entryPoints: [packageRoot.resolve('third_party/sqlite/sqlite3.h')],
     ),
     functions: Functions.includeSet({'sqlite3_libversion'}),

--- a/pkgs/code_assets/example/stb_image/tool/ffigen.dart
+++ b/pkgs/code_assets/example/stb_image/tool/ffigen.dart
@@ -9,9 +9,7 @@ import 'package:ffigen/ffigen.dart';
 void main() {
   final packageRoot = Platform.script.resolve('../');
   FfiGenerator(
-    headers: Headers(
-      entryPoints: [packageRoot.resolve('third_party/stb_image.h')],
-    ),
+    input: Input(entryPoints: [packageRoot.resolve('third_party/stb_image.h')]),
     functions: Functions(
       include: (decl) => {'stbi_info'}.contains(decl.originalName),
       recordUse: (_) => true,

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 22.0.0-wip
 
+- __Breaking change__: Major overhaul of Dart config API:
+  - Rename `Headers` to `Input`
+  - Remove `libraryImports`, which was dead code
+  - Remove `useSupportedTypedefs`, treating it as always true
 - Minor Objective-C code generator and function type signature fixes.
 
 ## 21.0.0

--- a/pkgs/ffigen/README.md
+++ b/pkgs/ffigen/README.md
@@ -64,7 +64,7 @@ app has been created via `dart create ffigen_example`.
        // Required. Output path for the generated bindings.
        output: Output(dartFile: packageRoot.resolve('lib/add.g.dart')),
        // Optional. Where to look for header files.
-       headers: Headers(entryPoints: [packageRoot.resolve('src/add.h')]),
+       input: Input(entryPoints: [packageRoot.resolve('src/add.h')]),
        // Optional. What functions to generate bindings for.
        functions: Functions.includeSet({'add'}),
      ).generate();

--- a/pkgs/ffigen/example/add/tool/ffigen.dart
+++ b/pkgs/ffigen/example/add/tool/ffigen.dart
@@ -8,7 +8,7 @@ import 'package:ffigen/ffigen.dart';
 FfiGenerator getConfig(Uri packageRoot) {
   return FfiGenerator(
     output: Output(dartFile: packageRoot.resolve('lib/add.g.dart')),
-    headers: Headers(entryPoints: [packageRoot.resolve('src/add.h')]),
+    input: Input(entryPoints: [packageRoot.resolve('src/add.h')]),
     functions: Functions.includeSet({'add'}),
   );
 }

--- a/pkgs/ffigen/example/objective_c/generate_code.dart
+++ b/pkgs/ffigen/example/objective_c/generate_code.dart
@@ -8,7 +8,7 @@ import 'package:ffigen/ffigen.dart';
 import 'package:logging/logging.dart';
 
 final config = FfiGenerator(
-  headers: Headers(
+  input: Input(
     // The entryPoints are the files that FFIgen should scan to find the APIs
     // you want to generate bindings for. You can use the macSdkPath or
     // iosSdkPath getters to find the Apple SDKs.

--- a/pkgs/ffigen/lib/ffigen.dart
+++ b/pkgs/ffigen/lib/ffigen.dart
@@ -31,7 +31,7 @@ export 'src/config_provider.dart'
         FfiGenerator,
         Functions,
         Globals,
-        Headers,
+        Input,
         Integers,
         Interfaces,
         Macros,

--- a/pkgs/ffigen/lib/src/code_generator/library.dart
+++ b/pkgs/ffigen/lib/src/code_generator/library.dart
@@ -39,7 +39,7 @@ class Library {
     // ignore: deprecated_member_use_from_same_package
     libraryImports: context.config.libraryImports,
     silenceEnumWarning: context.config.enums.silenceWarning,
-    nativeEntryPoints: context.config.headers.entryPoints
+    nativeEntryPoints: context.config.input.entryPoints
         .map((uri) => uri.toFilePath())
         .toList(),
     context: context,

--- a/pkgs/ffigen/lib/src/code_generator/library.dart
+++ b/pkgs/ffigen/lib/src/code_generator/library.dart
@@ -36,8 +36,6 @@ class Library {
     generateForPackageObjectiveC:
         // ignore: deprecated_member_use_from_same_package
         context.config.objectiveC?.generateForPackageObjectiveC ?? false,
-    // ignore: deprecated_member_use_from_same_package
-    libraryImports: context.config.libraryImports,
     silenceEnumWarning: context.config.enums.silenceWarning,
     nativeEntryPoints: context.config.input.entryPoints
         .map((uri) => uri.toFilePath())
@@ -50,7 +48,6 @@ class Library {
     required List<Binding> bindings,
     String? header,
     bool generateForPackageObjectiveC = false,
-    List<LibraryImport> libraryImports = const <LibraryImport>[],
     bool silenceEnumWarning = false,
     List<String> nativeEntryPoints = const <String>[],
     required Context context,
@@ -88,7 +85,6 @@ class Library {
       noLookUpBindings: noLookUpBindings,
       classDocComment: description,
       header: header,
-      additionalImports: libraryImports.map(context.libs.canonicalize).toList(),
       generateForPackageObjectiveC: generateForPackageObjectiveC,
       silenceEnumWarning: silenceEnumWarning,
       nativeEntryPoints: nativeEntryPoints,

--- a/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
@@ -239,7 +239,7 @@ class ObjCBuiltInFunctions {
   // a hash of parts of the config.
   static String _libraryIdFromConfigHash(Config config) => fnvHash32(
     [
-      ...config.headers.entryPoints,
+      ...config.input.entryPoints,
       config.output.dartFile,
       config.output.objCFile,
     ].map((uri) => path.basename(uri.toFilePath())).join('\n'),

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -48,7 +48,6 @@ class Writer {
     required this.ffiNativeBindings,
     required this.noLookUpBindings,
     required this.nativeAssetId,
-    List<LibraryImport> additionalImports = const <LibraryImport>[],
     this.classDocComment,
     this.header,
     required this.generateForPackageObjectiveC,

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -420,7 +420,7 @@ id objc_retainBlock(id);
     final s = StringBuffer();
     final outDir = p.dirname(outFilename);
     // Emit each entry-point header exactly once.
-    for (final header in context.config.headers.entryPoints) {
+    for (final header in context.config.input.entryPoints) {
       s.write('#include "${p.relative(header.toFilePath(), from: outDir)}"\n');
     }
     s.write(r'''

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -16,7 +16,7 @@ import 'config_types.dart';
 // TODO: Add a code snippet example.
 final class FfiGenerator {
   /// The configuration for header parsing of [FfiGenerator].
-  final Headers headers;
+  final Input input;
 
   /// Configuration for enums.
   final Enums enums;
@@ -88,7 +88,7 @@ final class FfiGenerator {
   final Uri? libclangDylib;
 
   const FfiGenerator({
-    this.headers = const Headers(),
+    this.input = const Input(),
     this.enums = Enums.excludeAll,
     this.functions = Functions.excludeAll,
     this.globals = Globals.excludeAll,
@@ -126,7 +126,7 @@ final class FfiGenerator {
 }
 
 /// The configuration for header parsing of [FfiGenerator].
-final class Headers {
+final class Input {
   /// Path to headers. May not contain globs.
   final List<Uri> entryPoints;
 
@@ -142,7 +142,7 @@ final class Headers {
   /// Where to ignore compiler warnings/errors in source header files.
   final bool ignoreSourceErrors;
 
-  const Headers({
+  const Input({
     this.entryPoints = const [],
     this.include = _includeDefault,
     this.compilerOptions,

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -72,15 +72,6 @@ final class FfiGenerator {
   )
   final Map<String, ImportedType> importedTypesByUsr;
 
-  /// Stores all the library imports specified by user including those for ffi
-  /// and pkg_ffi.
-  // TODO(https://github.com/dart-lang/native/issues/2597): Remove this.
-  @Deprecated(
-    'In the future, this shoud be inferred from ImportedTypes. See '
-    'https://github.com/dart-lang/native/issues/2597.',
-  )
-  final List<LibraryImport> libraryImports;
-
   /// Path to the clang library.
   ///
   /// Only visible for YamlConfig plumbing.
@@ -106,11 +97,6 @@ final class FfiGenerator {
       'https://github.com/dart-lang/native/issues/2596.',
     )
     this.importedTypesByUsr = const <String, ImportedType>{},
-    @Deprecated(
-      'In the future, this shoud be inferred from ImportedTypes. See '
-      'https://github.com/dart-lang/native/issues/2597.',
-    )
-    this.libraryImports = const <LibraryImport>[],
     @Deprecated('Only visible for YamlConfig plumbing.') this.libclangDylib,
   });
 

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -460,9 +460,6 @@ final class Typedefs extends Declarations {
   /// If enabled, unused typedefs will also be generated.
   final bool includeUnused;
 
-  /// If typedef of supported types(int8_t) should be directly used.
-  final bool useSupportedTypedefs;
-
   const Typedefs({
     super.rename,
     super.include,
@@ -472,7 +469,6 @@ final class Typedefs extends Declarations {
     )
     this.imported = const <ImportedType>[],
     this.includeUnused = false,
-    this.useSupportedTypedefs = true,
   });
 
   static const Typedefs excludeAll = Typedefs(include: Declarations.excludeAll);

--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -1227,7 +1227,7 @@ final class YamlConfig {
   }
 
   FfiGenerator configAdapter() => FfiGenerator(
-    headers: Headers(
+    input: Input(
       compilerOptions: compilerOpts,
       entryPoints: entryPoints,
       include: shouldIncludeHeader,

--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -1336,8 +1336,6 @@ final class YamlConfig {
           )
         : null,
     // ignore: deprecated_member_use_from_same_package
-    libraryImports: libraryImports.values.toList(),
-    // ignore: deprecated_member_use_from_same_package
     importedTypesByUsr: usrTypeMappings,
     // ignore: deprecated_member_use_from_same_package
     integers: Integers(imported: nativeTypeMappings.values.toList()),

--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -150,10 +150,6 @@ final class YamlConfig {
   bool get sort => _sort;
   late bool _sort;
 
-  /// If typedef of supported types(int8_t) should be directly used.
-  bool get useSupportedTypedefs => _useSupportedTypedefs;
-  late bool _useSupportedTypedefs;
-
   /// Stores all the library imports specified by user including those for ffi
   /// and pkg_ffi.
   Map<String, LibraryImport> get libraryImports => _libraryImports;
@@ -836,8 +832,6 @@ final class YamlConfig {
         HeterogeneousMapEntry(
           key: strings.useSupportedTypedefs,
           valueConfigSpec: BoolConfigSpec(),
-          defaultValue: (node) => true,
-          resultOrDefault: (node) => _useSupportedTypedefs = node.value as bool,
         ),
         HeterogeneousMapEntry(
           key: strings.comments,
@@ -1300,7 +1294,6 @@ final class YamlConfig {
     typedefs: Typedefs(
       include: typedefs.shouldInclude,
       rename: typedefs.rename,
-      useSupportedTypedefs: useSupportedTypedefs,
       includeUnused: includeUnusedTypedefs,
       // ignore: deprecated_member_use_from_same_package
       imported: typedefTypeMappings.values.toList(),

--- a/pkgs/ffigen/lib/src/context.dart
+++ b/pkgs/ffigen/lib/src/context.dart
@@ -28,7 +28,7 @@ class Context {
   final reportedCommentRanges = <((String, int), (String, int))>{};
   final libs = LibraryImports();
   late final compilerOpts =
-      config.headers.compilerOptions ?? defaultCompilerOpts(logger);
+      config.input.compilerOptions ?? defaultCompilerOpts(logger);
   final Scope rootScope = Scope.createRoot('root');
   final Scope rootObjCScope = Scope.createRoot('objc_root');
   late final ExtraSymbols extraSymbols;

--- a/pkgs/ffigen/lib/src/header_parser/parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/parser.dart
@@ -72,12 +72,12 @@ List<Binding> parseToBindings(Context context) {
   final bindings = <Binding>{};
 
   // Log all headers for user.
-  context.logger.info('Input Headers: ${config.headers.entryPoints}');
+  context.logger.info('Input Headers: ${config.input.entryPoints}');
 
   final tuList = <Pointer<clang_types.CXTranslationUnitImpl>>[];
 
   // Parse all translation units from entry points.
-  for (final headerLocationUri in config.headers.entryPoints) {
+  for (final headerLocationUri in config.input.entryPoints) {
     final headerLocation = headerLocationUri.toFilePath();
     context.logger.fine('Creating TranslationUnit for header: $headerLocation');
 
@@ -114,7 +114,7 @@ List<Binding> parseToBindings(Context context) {
       'The compiler found warnings/errors in source files.',
     );
     context.logger.warning('This will likely generate invalid bindings.');
-    if (config.headers.ignoreSourceErrors) {
+    if (config.input.ignoreSourceErrors) {
       context.logger.warning(
         'Ignored source errors. (User supplied --ignore-source-errors)',
       );

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/macro_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/macro_parser.dart
@@ -196,7 +196,7 @@ File createFileForMacros(Context context) {
 
   // Write file contents.
   final sb = StringBuffer();
-  for (final h in context.config.headers.entryPoints) {
+  for (final h in context.config.input.entryPoints) {
     final fullHeaderPath = File(h.toFilePath()).absolute.path;
     sb.writeln('#include "$fullHeaderPath"');
   }

--- a/pkgs/ffigen/lib/src/header_parser/translation_unit_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/translation_unit_parser.dart
@@ -26,7 +26,7 @@ Set<Binding> parseTranslationUnit(
   translationUnitCursor.visitChildren((cursor) {
     final file = cursor.sourceFileName();
     if (file.isEmpty) return;
-    if (headers[file] ??= context.config.headers.include(Uri.file(file))) {
+    if (headers[file] ??= context.config.input.include(Uri.file(file))) {
       try {
         logger.finest('rootCursorVisitor: ${cursor.completeStringRepr()}');
         switch (clang.clang_getCursorKind(cursor)) {

--- a/pkgs/ffigen/lib/src/header_parser/type_extractor/extractor.dart
+++ b/pkgs/ffigen/lib/src/header_parser/type_extractor/extractor.dart
@@ -189,15 +189,13 @@ Type? _createTypeFromCursor(
         logger.fine('  Type $spelling mapped from type-map');
         return config.typedefTypeMappings[spelling]!;
       }
-      // Get name from supported typedef name if config allows.
-      if (config.typedefs.useSupportedTypedefs) {
-        if (suportedTypedefToSuportedNativeType.containsKey(spelling)) {
-          logger.fine('  Type Mapped from supported typedef');
-          return NativeType(suportedTypedefToSuportedNativeType[spelling]!);
-        } else if (supportedTypedefToImportedType.containsKey(spelling)) {
-          logger.fine('  Type Mapped from supported typedef');
-          return supportedTypedefToImportedType[spelling]!;
-        }
+      // Get name from supported typedef name.
+      if (suportedTypedefToSuportedNativeType.containsKey(spelling)) {
+        logger.fine('  Type Mapped from supported typedef');
+        return NativeType(suportedTypedefToSuportedNativeType[spelling]!);
+      } else if (supportedTypedefToImportedType.containsKey(spelling)) {
+        logger.fine('  Type Mapped from supported typedef');
+        return supportedTypedefToImportedType[spelling]!;
       }
 
       final typealias = parseTypedefDeclaration(context, cursor);

--- a/pkgs/ffigen/test/collision_tests/reserved_keyword_collision_test.dart
+++ b/pkgs/ffigen/test/collision_tests/reserved_keyword_collision_test.dart
@@ -21,7 +21,7 @@ void main() {
               style: const DynamicLibraryBindings(),
             ),
 
-            headers: Headers(
+            input: Input(
               entryPoints: [
                 Uri.file(
                   path.join(

--- a/pkgs/ffigen/test/config_tests/compiler_opts_test.dart
+++ b/pkgs/ffigen/test/config_tests/compiler_opts_test.dart
@@ -37,7 +37,7 @@ ${strings.compilerOptsAuto}:
     ${strings.includeCStdLib}: false
         ''');
       expect(
-        config.headers.compilerOptions,
+        config.input.compilerOptions,
         equals([if (Platform.isMacOS) '-Wno-nullability-completeness']),
       );
     });

--- a/pkgs/ffigen/test/example_tests/libclang_example_test.dart
+++ b/pkgs/ffigen/test/example_tests/libclang_example_test.dart
@@ -28,7 +28,7 @@ void main() {
       // compiler options. It can't use absolute paths because it's checked in
       // yaml code. To support concurrent tests, we can't set Directory.current.
       // As a workaround, add an extra '-I' option that uses the absolute path.
-      generator.headers.compilerOptions!.add(
+      generator.input.compilerOptions!.add(
         '-I${path.join(packagePathForTests, 'third_party/libclang/include')}',
       );
 

--- a/pkgs/ffigen/test/header_parser_tests/record_use_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/record_use_test.dart
@@ -16,7 +16,7 @@ void main() {
         p.join('test', 'header_parser_tests', 'record_use.h'),
       );
       final generator = FfiGenerator(
-        headers: Headers(entryPoints: [Uri.file(headerFile)]),
+        input: Input(entryPoints: [Uri.file(headerFile)]),
         functions: Functions(
           include: (decl) => true,
           recordUse: (decl) => true,

--- a/pkgs/ffigen/test/header_parser_tests/sort_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/sort_test.dart
@@ -19,7 +19,7 @@ void main() {
         testContext(
           FfiGenerator(
             output: Output(dartFile: Uri.file('unused')),
-            headers: Headers(
+            input: Input(
               entryPoints: [
                 Uri.file(
                   path.join(

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -72,7 +72,7 @@ void main() {
     const forceIncludedProtocols = {'NSTextLocation'};
 
     final generator = FfiGenerator(
-      headers: Headers(
+      input: Input(
         entryPoints: [
           Uri.file(
             path.join(

--- a/pkgs/ffigen/test/large_integration_tests/large_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_test.dart
@@ -39,7 +39,7 @@ void main() {
             wrapperDocComment: 'Bindings to LibClang.',
           ),
         ),
-        headers: Headers(
+        input: Input(
           compilerOptions: [...defaultCompilerOpts(logger), '-I$includeDir'],
           entryPoints: [
             Uri.file(
@@ -135,7 +135,7 @@ void main() {
             wrapperDocComment: 'Bindings to Cjson.',
           ),
         ),
-        headers: Headers(
+        input: Input(
           entryPoints: [
             Uri.file(
               path.join(
@@ -176,7 +176,7 @@ void main() {
           ),
           commentType: const CommentType(CommentStyle.any, CommentLength.full),
         ),
-        headers: Headers(
+        input: Input(
           entryPoints: [
             Uri.file(
               path.join(

--- a/pkgs/ffigen/test/native_cpp_test/verify_bindings_test.dart
+++ b/pkgs/ffigen/test/native_cpp_test/verify_bindings_test.dart
@@ -37,7 +37,7 @@ void main() {
             assetId: 'package:ffigen/cpp_test',
           ),
         ),
-        headers: Headers(
+        input: Input(
           entryPoints: [
             Uri.file(path.join(testDir.path, 'cpp_class_test.h')),
             Uri.file(path.join(testDir.path, 'finalizer_test_subject.h')),
@@ -55,7 +55,7 @@ void main() {
             assetId: 'package:ffigen/cpp_test',
           ),
         ),
-        headers: Headers(
+        input: Input(
           entryPoints: [
             Uri.file(path.join(testDir.path, 'memory_edge_cases.h')),
           ],

--- a/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
@@ -32,7 +32,7 @@ String bindingsForVersion({Versions? iosVers, Versions? macosVers}) {
         wrapperDocComment: 'Tests API deprecation',
       ),
     ),
-    headers: Headers(
+    input: Input(
       entryPoints: [
         Uri.file(
           path.join(

--- a/pkgs/ffigen/test/native_objc_test/ns_range_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/ns_range_test.dart
@@ -34,7 +34,7 @@ void main() {
             wrapperName: 'NSRangeTestObjCLibrary',
           ),
         ),
-        headers: Headers(
+        input: Input(
           entryPoints: [
             Uri.file(
               path.join(

--- a/pkgs/ffigen/test/native_objc_test/swift_unavailable_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/swift_unavailable_test.dart
@@ -35,7 +35,7 @@ void main() {
             wrapperDocComment: 'Tests SWIFT_UNAVAILABLE annotation',
           ),
         ),
-        headers: Headers(
+        input: Input(
           entryPoints: [
             Uri.file(
               path.join(

--- a/pkgs/ffigen/test/native_objc_test/transitive_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/transitive_test.dart
@@ -35,7 +35,7 @@ String generate({
         wrapperDocComment: 'Tests transitive inclusion',
       ),
     ),
-    headers: Headers(
+    input: Input(
       entryPoints: [
         Uri.file(
           path.join(

--- a/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/tool/ffigen.dart
+++ b/pkgs/hooks_runner/test_data/treeshaking_dylib_record_use/tool/ffigen.dart
@@ -11,7 +11,7 @@ void main() {
 
   // 1. Generate bindings for add.c
   FfiGenerator(
-    headers: Headers(
+    input: Input(
       entryPoints: [packageRoot.resolve('src/add.c')],
     ),
     functions: Functions(
@@ -36,7 +36,7 @@ void main() {
 
   // 2. Generate bindings for multiply.c
   FfiGenerator(
-    headers: Headers(
+    input: Input(
       entryPoints: [packageRoot.resolve('src/multiply.c')],
     ),
     functions: Functions(

--- a/pkgs/swiftgen/lib/src/generator.dart
+++ b/pkgs/swiftgen/lib/src/generator.dart
@@ -120,7 +120,7 @@ extension SwiftGenGenerator on SwiftGenerator {
         categories: ffigen.objectiveC.categories,
         externalVersions: ffigen.objectiveC.externalVersions,
       ),
-      headers: fg.Headers(
+      input: fg.Input(
         entryPoints: [Uri.file(objcHeader)],
         compilerOptions: [
           ...fg.defaultCompilerOpts(logger),


### PR DESCRIPTION
- Rename `Headers` to `Input`
- Remove `libraryImports`, which is dead code
- Remove `useSupportedTypedefs`, treating it as always true

Fixes https://github.com/dart-lang/native/issues/2597