### PR TITLE
[hooks] Handle absolute paths in UserDefines.path()

### DIFF
--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Add `ProtocolExtension.setupLogger`, which the hooks runner calls to provide
   the logger used for validation diagnostics before any other method is invoked
   on the extension.
+- Fix `HookInputUserDefines.path` mangling absolute Windows paths: the drive
+  letter was parsed as a URI scheme. Absolute paths are now returned as-is;
+  relative paths are resolved against the source of the path.
 
 ## 2.1.0
 

--- a/pkgs/hooks/lib/src/config.dart
+++ b/pkgs/hooks/lib/src/config.dart
@@ -237,12 +237,14 @@ final class HookInputUserDefines {
     return pubspecSource?.defines[key];
   }
 
-  /// Resolves the relative path provided in the user-define for [key] to an
-  /// absolute [Uri] pointing to the file or directory on the host filesystem.
+  /// Resolves the path provided in the user-define for [key] to an absolute
+  /// [Uri] pointing to the file or directory on the host filesystem.
   ///
-  /// The relative path is resolved against the directory containing the
-  /// `pubspec.yaml` where the user-define was declared (or the command-line
-  /// working directory if provided via command-line arguments).
+  /// Absolute paths are converted to a file [Uri] without further
+  /// resolution. Relative paths are resolved against the directory
+  /// containing the `pubspec.yaml` where the user-define was declared (or
+  /// the command-line working directory if provided via command-line
+  /// arguments).
   ///
   /// If the user-define is `null` or not a [String], returns `null`.
   ///
@@ -284,9 +286,12 @@ final class HookInputUserDefines {
     // TODO(https://github.com/dart-lang/native/issues/2215): Add commandline
     // arguments.
     for (final source in sources) {
-      final relativepath = source.defines[key];
-      if (relativepath is String) {
-        return source.basePath.resolve(relativepath);
+      final path = source.defines[key];
+      if (path is String) {
+        if (File(path).isAbsolute) {
+          return Uri.file(path);
+        }
+        return source.basePath.resolve(path);
       }
     }
     return null;

--- a/pkgs/hooks/test/user_defines_test.dart
+++ b/pkgs/hooks/test/user_defines_test.dart
@@ -65,6 +65,14 @@ void main() {
       expect(uri, Uri.parse('file:///D:/proj/example/some/dir/model.bin'));
       expect(uri.toFilePath(), r'D:\proj\example\some\dir\model.bin');
     });
+
+    test('relative path with Windows separators resolves against basePath', () {
+      if (!Platform.isWindows) return;
+      final input = makeInput({'file': r'some\dir\model.bin'}, basePath);
+      final uri = input.userDefines.path('file')!;
+      expect(uri, Uri.parse('file:///D:/proj/example/some/dir/model.bin'));
+      expect(uri.toFilePath(), r'D:\proj\example\some\dir\model.bin');
+    });
   });
 
   group('path() on POSIX', () {
@@ -81,6 +89,17 @@ void main() {
     test('relative path resolves against basePath', () {
       if (Platform.isWindows) return;
       final input = makeInput({'file': 'some/dir/model.bin'}, basePath);
+      final uri = input.userDefines.path('file')!;
+      expect(
+        uri,
+        Uri.parse('file:///home/user/proj/example/some/dir/model.bin'),
+      );
+      expect(uri.toFilePath(), '/home/user/proj/example/some/dir/model.bin');
+    });
+
+    test('relative path with Windows separators resolves against basePath', () {
+      if (Platform.isWindows) return;
+      final input = makeInput({'file': r'some\dir\model.bin'}, basePath);
       final uri = input.userDefines.path('file')!;
       expect(
         uri,

--- a/pkgs/hooks/test/user_defines_test.dart
+++ b/pkgs/hooks/test/user_defines_test.dart
@@ -1,0 +1,120 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:hooks/hooks.dart';
+import 'package:test/test.dart';
+
+void main() {
+  BuildInput makeInput(Map<String, Object?> defines, Uri basePath) {
+    final tempUri = Directory.systemTemp.uri;
+    final builder = BuildInputBuilder()
+      ..setupShared(
+        packageName: 'my_package',
+        packageRoot: tempUri.resolve('my_package/'),
+        outputFile: tempUri.resolve('output.json'),
+        outputDirectoryShared: tempUri.resolve('out_shared/'),
+        userDefines: PackageUserDefines(
+          workspacePubspec: PackageUserDefinesSource(
+            defines: defines,
+            basePath: basePath,
+          ),
+        ),
+      )
+      ..config.addBuildAssetTypes(['my-asset-type'])
+      ..config.setupBuild(linkingEnabled: false);
+    return builder.build();
+  }
+
+  group('path() on Windows', () {
+    final basePath = Uri.parse('file:///D:/proj/example/pubspec.yaml');
+
+    // Skips are done with early returns instead of `testOn`, because these
+    // tests also run on the Dart SDK CI which does not respect `package:test`
+    // annotations.
+    test('absolute path with Windows separators is returned as-is', () {
+      if (!Platform.isWindows) return;
+      final input = makeInput({'lib': r'D:\some\dir\lib.dll'}, basePath);
+      final uri = input.userDefines.path('lib')!;
+      expect(uri, Uri.parse('file:///D:/some/dir/lib.dll'));
+      expect(uri.toFilePath(), r'D:\some\dir\lib.dll');
+    });
+
+    test('absolute path with forward slashes is returned as-is', () {
+      if (!Platform.isWindows) return;
+      final input = makeInput({'lib': 'D:/some/dir/lib.dll'}, basePath);
+      final uri = input.userDefines.path('lib')!;
+      expect(uri, Uri.parse('file:///D:/some/dir/lib.dll'));
+      expect(uri.toFilePath(), r'D:\some\dir\lib.dll');
+    });
+
+    test('UNC path is returned as-is', () {
+      if (!Platform.isWindows) return;
+      final input = makeInput({'lib': r'\\server\share\lib.dll'}, basePath);
+      final uri = input.userDefines.path('lib')!;
+      expect(uri, Uri.parse('file://server/share/lib.dll'));
+      expect(uri.toFilePath(), r'\\server\share\lib.dll');
+    });
+
+    test('relative path with Linux separators resolves against basePath', () {
+      if (!Platform.isWindows) return;
+      final input = makeInput({'file': 'some/dir/model.bin'}, basePath);
+      final uri = input.userDefines.path('file')!;
+      expect(uri, Uri.parse('file:///D:/proj/example/some/dir/model.bin'));
+      expect(uri.toFilePath(), r'D:\proj\example\some\dir\model.bin');
+    });
+  });
+
+  group('path() on POSIX', () {
+    final basePath = Uri.parse('file:///home/user/proj/example/pubspec.yaml');
+
+    test('absolute path is returned as-is', () {
+      if (Platform.isWindows) return;
+      final input = makeInput({'lib': '/some/dir/lib.so'}, basePath);
+      final uri = input.userDefines.path('lib')!;
+      expect(uri, Uri.parse('file:///some/dir/lib.so'));
+      expect(uri.toFilePath(), '/some/dir/lib.so');
+    });
+
+    test('relative path resolves against basePath', () {
+      if (Platform.isWindows) return;
+      final input = makeInput({'file': 'some/dir/model.bin'}, basePath);
+      final uri = input.userDefines.path('file')!;
+      expect(
+        uri,
+        Uri.parse('file:///home/user/proj/example/some/dir/model.bin'),
+      );
+      expect(uri.toFilePath(), '/home/user/proj/example/some/dir/model.bin');
+    });
+  });
+
+  group('path()', () {
+    final basePath = Uri.parse('file:///base/dir/pubspec.yaml');
+
+    test('returns null for a missing key', () {
+      final input = makeInput({}, basePath);
+      expect(input.userDefines.path('missing'), isNull);
+    });
+
+    test('returns null for a non-String value', () {
+      final input = makeInput({'key': 1}, basePath);
+      expect(input.userDefines.path('key'), isNull);
+    });
+
+    test('returns null without user-defines', () {
+      final tempUri = Directory.systemTemp.uri;
+      final builder = BuildInputBuilder()
+        ..setupShared(
+          packageName: 'my_package',
+          packageRoot: tempUri.resolve('my_package/'),
+          outputFile: tempUri.resolve('output.json'),
+          outputDirectoryShared: tempUri.resolve('out_shared/'),
+        )
+        ..config.addBuildAssetTypes(['my-asset-type'])
+        ..config.setupBuild(linkingEnabled: false);
+      expect(builder.build().userDefines.path('key'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description

`UserDefines.path()` passed every value through `basePath.resolve()`. A Windows drive letter is a valid URI scheme, so an absolute Windows path was parsed as an already-absolute URI: `D:\a\b.dll` became a URI with scheme `d`, and `toFilePath()` on the result throws.

`path()` now returns absolute paths as-is and keeps the existing `resolve()` behavior for relative paths. Absolute paths are detected with `File(path).isAbsolute`, which uses the platform's native path semantics, so no OS-specific branching is needed. The doc comment states this contract.

Tests cover the two separator cases raised in the issue, both on Windows: backslashes with an absolute path, and forward slashes with a relative path. They also cover UNC paths, POSIX paths, and the `null` cases.

## Related Issues

Fixes #3518

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [x] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [x] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
