### PR TITLE
[ffigen] Fix `matchFileWithExpected`

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/library.dart
+++ b/pkgs/ffigen/lib/src/code_generator/library.dart
@@ -117,6 +117,9 @@ class Library {
   /// Generates [file] with the Objective C code needed for the bindings, if
   /// any.
   ///
+  /// Any relative path `#include` statements are written relative to
+  /// [headerPath], or [file] if it isn't provided.
+  ///
   /// Returns whether bindings were generated.
   bool generateObjCFile(File file, {String? headerPath}) {
     final objCString = writer.generateObjC(headerPath ?? file.path);
@@ -134,6 +137,9 @@ class Library {
   }
 
   /// Generates [file] with the Cpp glue code needed for the bindings, if any.
+  ///
+  /// Any relative path `#include` statements are written relative to
+  /// [headerPath], or [file] if it isn't provided.
   ///
   /// Returns whether bindings were generated.
   bool generateCppFile(File file, {String? headerPath}) {

--- a/pkgs/ffigen/lib/src/code_generator/library.dart
+++ b/pkgs/ffigen/lib/src/code_generator/library.dart
@@ -118,8 +118,8 @@ class Library {
   /// any.
   ///
   /// Returns whether bindings were generated.
-  bool generateObjCFile(File file) {
-    final objCString = writer.generateObjC(file.path);
+  bool generateObjCFile(File file, {String? headerPath}) {
+    final objCString = writer.generateObjC(headerPath ?? file.path);
 
     if (objCString == null) {
       // No ObjC code needed. If there's already a file (eg from an earlier
@@ -136,8 +136,8 @@ class Library {
   /// Generates [file] with the Cpp glue code needed for the bindings, if any.
   ///
   /// Returns whether bindings were generated.
-  bool generateCppFile(File file) {
-    final cppString = writer.generateCpp(file.path);
+  bool generateCppFile(File file, {String? headerPath}) {
+    final cppString = writer.generateCpp(headerPath ?? file.path);
 
     if (cppString == null) {
       // No C++ glue needed. If there's already a file (eg from an earlier

--- a/pkgs/ffigen/test/config_tests/json_schema_test.dart
+++ b/pkgs/ffigen/test/config_tests/json_schema_test.dart
@@ -27,7 +27,7 @@ void main() {
         context: context,
         pathForActual: 'ffigen.schema.json',
         pathToExpected: [strings.ffigenJsonSchemaFileName],
-        fileWriter: (File file) {
+        fileWriter: (File file, _) {
           final actualJsonSchema =
               const JsonEncoder.withIndent(
                 strings.ffigenJsonSchemaIndent,

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -138,7 +138,7 @@ void matchLibraryWithExpected(
     context: context,
     pathForActual: pathForActual,
     pathToExpected: pathToExpected,
-    fileWriter: (File file) => library.generateFile(file, format: format),
+    fileWriter: (File file, _) => library.generateFile(file, format: format),
     codeNormalizer: codeNormalizer,
     verify: verify,
   );
@@ -159,7 +159,7 @@ void matchLibrarySymbolFileWithExpected(
     context: context,
     pathForActual: pathForActual,
     pathToExpected: pathToExpected,
-    fileWriter: (File file) {
+    fileWriter: (File file, _) {
       if (!library.writer.canGenerateSymbolOutput) library.generate();
       library.generateSymbolOutputFile(file, importPath);
     },
@@ -181,7 +181,9 @@ void matchObjCFileWithExpected(
     context: context,
     pathForActual: pathForActual,
     pathToExpected: pathToExpected,
-    fileWriter: (File file) => library.generateObjCFile(file),
+    fileWriter:
+        (File file, String expectedPath) =>
+            library.generateObjCFile(file, headerPath: expectedPath),
     verify: verify,
   );
 }
@@ -200,7 +202,9 @@ void matchCppFileWithExpected(
     context: context,
     pathForActual: pathForActual,
     pathToExpected: pathToExpected,
-    fileWriter: (File file) => library.generateCppFile(file),
+    fileWriter:
+        (File file, String expectedPath) =>
+            library.generateCppFile(file, headerPath: expectedPath),
     verify: verify,
   );
 }
@@ -222,7 +226,7 @@ void matchRecordUseMappingWithExpected(
     context: context,
     pathForActual: pathForActual,
     pathToExpected: pathToExpected,
-    fileWriter: (File file) =>
+    fileWriter: (File file, _) =>
         library.generateRecordUseMappingFile(file, format: format),
     codeNormalizer: codeNormalizer,
     verify: verify,
@@ -246,7 +250,7 @@ void matchFileWithExpected({
   required Context context,
   required String pathForActual,
   required List<String> pathToExpected,
-  required void Function(File file) fileWriter,
+  required void Function(File actualFile, String expectedPath) fileWriter,
   String Function(String)? codeNormalizer,
   bool Function(String expected, String actual)? verify,
 }) {
@@ -259,22 +263,7 @@ void matchFileWithExpected({
 
   verify ??= (expected, actual) => expected == actual;
 
-  // Generate the actual file in the expected location so that the generated
-  // relative import paths are correct. In case the expected and actual files
-  // have the same name, move the expected file to a backup location first.
-  final backupFile = File(path.join(tmpDirPath, '$pathForActual.backup'));
-  if (expectedFile.existsSync()) {
-    expectedFile.renameSync(backupFile.path);
-  }
-  fileWriter(expectedFile);
-
-  // Move the expected and actual files to their correct locations.
-  if (expectedFile.existsSync()) {
-    expectedFile.renameSync(actualPath);
-  }
-  if (backupFile.existsSync()) {
-    backupFile.renameSync(expectedPath);
-  }
+  fileWriter(actualFile, expectedPath);
 
   if (updateExpectations) {
     print('Updating expectations: ${path.relative(expectedPath)}');

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -181,9 +181,8 @@ void matchObjCFileWithExpected(
     context: context,
     pathForActual: pathForActual,
     pathToExpected: pathToExpected,
-    fileWriter:
-        (File file, String expectedPath) =>
-            library.generateObjCFile(file, headerPath: expectedPath),
+    fileWriter: (File file, String expectedPath) =>
+        library.generateObjCFile(file, headerPath: expectedPath),
     verify: verify,
   );
 }
@@ -202,9 +201,8 @@ void matchCppFileWithExpected(
     context: context,
     pathForActual: pathForActual,
     pathToExpected: pathToExpected,
-    fileWriter:
-        (File file, String expectedPath) =>
-            library.generateCppFile(file, headerPath: expectedPath),
+    fileWriter: (File file, String expectedPath) =>
+        library.generateCppFile(file, headerPath: expectedPath),
     verify: verify,
   );
 }


### PR DESCRIPTION
There's is a bug in test_utils.dart's `matchFileWithExpected`, affecting ffigen's ObjC and C++ bindings verification tests, causing flaky errors. native_cpp_test happened to trigger it more often, making it easier to reproduce and fix.

The generated .m and .cpp files `#include` the source file using relative paths. The expected bindings files are adjacent to the tests, but the actual files are output to a `tmp` directory, so the relative path would be incorrect. As a hacky workaround, I had written `matchFileWithExpected` to move the expected bindings to a `.backup` file, then generate the actual bindings to the expected path.

Meanwhile `dart test` doesn't compile the test file until right before it's run. So if the tests that depend on these bindings happened to be run while the bindings were being moved around, the file might not exist, or might be empty, or contain partial bindings, causing compile errors.

Fixed it by updating `Library.generateObjCFile` and `Library.generateCppFile` to allow overriding the relative include path.

Fixes https://github.com/dart-lang/native/issues/3534