### PR TITLE
[ffigen] Run weekly bot on macos-15-intel

### DIFF
--- a/.github/workflows/ffigen_weekly.yml
+++ b/.github/workflows/ffigen_weekly.yml
@@ -1,5 +1,4 @@
-# Run the ffigen tests on apple silicon once a week. Unlike the other GitHub
-# CI hosts, this one isn't free, so we don't run it on every commit.
+# Run the ffigen tests on x64 macos once a week.
 
 name: ffigen_weekly
 
@@ -22,7 +21,7 @@ env:
 jobs:
   # Keep in sync with ffigen.yaml:test-mac
   test-mac-x64:
-    runs-on: 'macos-14-large' # x64
+    runs-on: 'macos-15-intel' # x64
     permissions:
       contents: read
     defaults:


### PR DESCRIPTION
This runner should also be x64, and it should be free, in contrast to the previously used runner.