### PR TITLE
[hooks_runner] Add `PATHEXT` to environment variables allowlist

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Report a format error instead of throwing a `TypeError` when a hook's cached
   `output.json` contains valid JSON that is not an object.
 - Bump `package:code_assets` dependency to `^2.0.0`.
+- Add `PATHEXT` to the environment variables allowlist.
 ## 1.6.1
 
 - Support versions 3.x of `package:package_config`.

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -646,6 +646,7 @@ class NativeAssetsBuildRunner {
       'LIBCLANG_PATH', // Needed for Rust's bindgen + clang-sys.
       'LOCALAPPDATA', // Needed for dart_data_home and pub.
       'PATH', // Needed to invoke native tools.
+      'PATHEXT', // Needed to resolve executable file extensions on Windows.
       'PROGRAMDATA', // Needed for vswhere.exe.
       'PROCESSOR_ARCHITECTURE', // Needed for CMake Android on Windows.
       'SYSTEMDRIVE', // Needed for CMake.

--- a/pkgs/hooks_runner/test/build_runner/environment_filter_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/environment_filter_test.dart
@@ -75,6 +75,10 @@ void main() {
       isTrue,
     );
     expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('PATHEXT'),
+      isTrue,
+    );
+    expect(
       NativeAssetsBuildRunner.includeHookEnvironmentVariable('HOME'),
       isTrue,
     );


### PR DESCRIPTION
When using `package:process` it tries to look at `PATHEXT` before doing process invocations. And we're trying to start to use that in `package:native_toolchain_c`.

Context:

* https://github.com/dart-lang/native/pull/3531#issuecomment-5243937616