### PR TITLE
[hooks_runner] Add Rustup and Cargo environment variables to allowlist

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -8,6 +8,8 @@
   `output.json` contains valid JSON that is not an object.
 - Bump `package:code_assets` dependency to `^2.0.0`.
 - Add `PATHEXT` to the environment variables allowlist.
+- Add prefixes `RUSTUP_` and `CARGO_` to the environment variables allowlist.
+
 ## 1.6.1
 
 - Support versions 3.x of `package:package_config`.

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -660,10 +660,12 @@ class NativeAssetsBuildRunner {
     };
 
     const variablePrefixesFilter = {
+      'CARGO_', // Needed for the Rust package manager.
       'CCACHE_', // Needed for Ccache.
       'DOTNET_', // Needed for .Net.
       'NIX_', // Needed for Nix-installed toolchains.
       'NUGET_', // Needed for NuGet.
+      'RUSTUP_', // Needed for the Rust toolchain installer.
       'CONAN_', // Needed for Conan Package Manager.
     };
 

--- a/pkgs/hooks_runner/test/build_runner/environment_filter_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/environment_filter_test.dart
@@ -94,4 +94,15 @@ void main() {
       isTrue,
     );
   });
+
+  test('includeHookEnvironmentVariable allows Rust variables', () {
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('CARGO_HOME'),
+      isTrue,
+    );
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('RUSTUP_HOME'),
+      isTrue,
+    );
+  });
 }


### PR DESCRIPTION
## Description

Rustup is Rust's official toolchain manager. Cargo is the Rust package manager.
Rustup and cargo use environment variables for a few things:
- https://rust-lang.github.io/rustup/environment-variables.html
- https://doc.rust-lang.org/cargo/reference/environment-variables.html

In particular, my builds are failing since `CARGO_HOME` is not in the allowlist.
Flatpak builds are done offline, so not being able to access the existing package cache results in a build failure.

This PR adds those environment variables into the whitelist.

## Related Issues

https://github.com/TheAppgineer/flatpak-flutter/issues/125

## PR Checklist

- [X] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [X] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.

  It threw an error for me but it seems unrelated.
  <details>
  <summary>'stddef.h' file not found [Lexical or Preprocessor Issue]</summary>
  
  ```
  ahann@dellpro:~/Documents/GitHub/dart-native$ dart tool/ci.dart --all
  +dart pub get --directory .
  Resolving dependencies... 
  Downloading packages... 
    cli_util 0.4.2 (0.5.2 available)
  ! ffigen 22.0.0-wip from path pkgs/ffigen (overridden)
  Got dependencies!
  1 package has newer versions incompatible with dependency constraints.
  Try `dart pub outdated` for more information.
  +dart pub get --directory pkgs/hooks_runner/test_data/native_add_version_skew/
  Resolving dependencies in `pkgs/hooks_runner/test_data/native_add_version_skew/`... 
  Downloading packages... 
    cli_util 0.4.2 (0.5.2 available)
    ffigen 20.1.1 (21.0.0 available)
    native_assets_cli 0.15.0 (discontinued replaced by hooks)
    native_toolchain_c 0.12.0 (0.19.3 available)
    package_config 2.2.0 (3.0.0 available)
  Got dependencies in `pkgs/hooks_runner/test_data/native_add_version_skew/`!
  1 package is discontinued.
  5 packages have newer versions incompatible with dependency constraints.
  Try `dart pub outdated` for more information.
  +dart pub get --directory pkgs/hooks_runner/test_data/native_add_version_skew_2/
  Resolving dependencies in `pkgs/hooks_runner/test_data/native_add_version_skew_2/`... 
  Downloading packages... 
    cli_util 0.4.2 (0.5.2 available)
    ffigen 20.1.1 (21.0.0 available)
    native_assets_cli 0.6.1 (discontinued replaced by hooks)
    native_toolchain_c 0.5.0 (0.19.3 available)
    package_config 2.2.0 (3.0.0 available)
  Got dependencies in `pkgs/hooks_runner/test_data/native_add_version_skew_2/`!
  1 package is discontinued.
  5 packages have newer versions incompatible with dependency constraints.
  Try `dart pub outdated` for more information.
  +dart pkgs/code_assets/example/host_name/tool/ffigen.dart --set-exit-if-changed
  [INFO]   : Input Headers: [file:///home/ahann/Documents/GitHub/dart-native/pkgs/code_assets/example/host_name/src/unix.h]
  [SEVERE] : Header /home/ahann/Documents/GitHub/dart-native/pkgs/code_assets/example/host_name/src/unix.h: Total errors/warnings: 1.
  [SEVERE] :     /usr/include/unistd.h:226:10: fatal error: 'stddef.h' file not found [Lexical or Preprocessor Issue]
  [WARNING]: The compiler found warnings/errors in source files.
  [WARNING]: This will likely generate invalid bindings.
  [SEVERE] : Skipped generating bindings due to errors in source files. See https://github.com/dart-lang/native/blob/main/pkgs/ffigen/doc/errors.md.
  Unhandled exception:
  HeaderParserException: Skipped generating bindings due to errors in source files.
  #0      parseToBindings (package:ffigen/src/header_parser/parser.dart:141:9)
  #1      parse (package:ffigen/src/header_parser/parser.dart:46:31)
  #2      FfiGenGenerator.generate (package:ffigen/src/ffigen.dart:27:21)
  #3      FfiGenerator.generate (package:ffigen/src/config_provider/config.dart:131:7)
  #4      main (file:///home/ahann/Documents/GitHub/dart-native/pkgs/code_assets/example/host_name/tool/ffigen.dart:54:13)
  #5      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:313:19)
  #6      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
  +dart pkgs/code_assets/example/host_name/tool/ffigen.dart --set-exit-if-changed failed with exitCode 255.
  ```
  </details>

  Ignoring that, I've separately made sure that `dart format` / `dart analyze` don't show anything.
  `dart test` fails several tests on my system with this error: `/usr/bin/ccache: invalid option -- 'f'`. Regardless, the test I added here passes.

- [X] All existing and new tests are passing. I added new tests to check the change I am making.
- [X] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [X] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [X] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
