### PR TITLE
[hooks_runner] Minimize file hashing by relying on size and last-modified

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Bump `package:code_assets` dependency to `^2.0.0`.
 - Add `PATHEXT` to the environment variables allowlist.
 - Add prefixes `RUSTUP_` and `CARGO_` to the environment variables allowlist.
-
+- Store size and last modification time in dependency hashes to skip content
+  hashing when unchanged.
 ## 1.6.1
 
 - Support versions 3.x of `package:package_config`.

--- a/pkgs/hooks_runner/lib/src/dependencies_hash_file/dependencies_hash_file.dart
+++ b/pkgs/hooks_runner/lib/src/dependencies_hash_file/dependencies_hash_file.dart
@@ -62,6 +62,8 @@ class DependenciesHashFile {
     Uri? modifiedAfterTimeStamp;
     for (final uri in fileSystemEntities) {
       int hash;
+      int? size;
+      DateTime? lastModified;
       if ((await _fileSystem.fileSystemEntity(uri).lastModified(_fileSystem))
           .isAfter(fileSystemValidBeforeLastModified)) {
         hash = _hashLastModifiedAfterCutoff;
@@ -70,19 +72,47 @@ class DependenciesHashFile {
         if (_isDirectoryPath(uri.path)) {
           hash = await _hashDirectory(uri);
         } else {
+          final file = _fileSystem.file(uri);
+          final stat = await file.stat();
+          if (stat.type == FileSystemEntityType.file) {
+            size = stat.size;
+            lastModified = stat.modified;
+          }
           hash = await _hashFile(uri);
         }
       }
-      _hashes.files.add(FilesystemEntityHash(uri, hash));
+      _hashes.files.add(
+        FilesystemEntityHash(
+          uri,
+          hash,
+          size: size,
+          lastModified: lastModified,
+        ),
+      );
     }
     for (final uri in outputFiles) {
       int hash;
+      int? size;
+      DateTime? lastModified;
       if (_isDirectoryPath(uri.path)) {
         hash = await _hashDirectory(uri);
       } else {
+        final file = _fileSystem.file(uri);
+        final stat = await file.stat();
+        if (stat.type == FileSystemEntityType.file) {
+          size = stat.size;
+          lastModified = stat.modified;
+        }
         hash = await _hashFile(uri);
       }
-      _hashes.files.add(FilesystemEntityHash(uri, hash));
+      _hashes.files.add(
+        FilesystemEntityHash(
+          uri,
+          hash,
+          size: size,
+          lastModified: lastModified,
+        ),
+      );
     }
     for (final entry in environment.entries) {
       _hashes.environment.add(
@@ -104,15 +134,12 @@ class DependenciesHashFile {
 
         for (final savedHash in _hashes.files) {
           final uri = savedHash.path;
-          final savedHashValue = savedHash.hash;
           if (_isDirectoryPath(uri.path)) {
-            final hashValue = await _hashDirectory(uri);
-            if (savedHashValue != hashValue) {
+            if (await _directoryContentsChanged(savedHash)) {
               return 'Directory contents changed: ${uri.toFilePath()}.';
             }
           } else {
-            final hashValue = await _hashFile(uri);
-            if (savedHashValue != hashValue) {
+            if (await _fileContentsChanged(savedHash)) {
               return 'File contents changed: ${uri.toFilePath()}.';
             }
           }
@@ -136,6 +163,39 @@ class DependenciesHashFile {
 
         return null;
       });
+
+  /// Checks whether the contents of the file described by [savedHash] have
+  /// changed.
+  ///
+  /// Fast path: if the file had a valid recorded size and modification time,
+  /// and they still match, content hashing is skipped to avoid reading files
+  /// from disk.
+  ///
+  /// Fallback: if the size or modification time changed (or was not recorded),
+  /// the file is hashed to verify whether its contents actually changed.
+  Future<bool> _fileContentsChanged(FilesystemEntityHash savedHash) async {
+    final size = savedHash.size;
+    final lastModified = savedHash.lastModified;
+    if (size != null &&
+        lastModified != null &&
+        savedHash.hash != _hashLastModifiedAfterCutoff &&
+        savedHash.hash != _hashNotExists) {
+      final stat = await _fileSystem.file(savedHash.path).stat();
+      if (stat.type == FileSystemEntityType.file &&
+          stat.size == size &&
+          stat.modified.isAtSameMomentAs(lastModified)) {
+        return false;
+      }
+    }
+
+    final hashValue = await _hashFile(savedHash.path);
+    return savedHash.hash != hashValue;
+  }
+
+  Future<bool> _directoryContentsChanged(FilesystemEntityHash savedHash) async {
+    final hashValue = await _hashDirectory(savedHash.path);
+    return savedHash.hash != hashValue;
+  }
 
   // A 64 bit hash from an md5 hash.
   int _md5int64(Uint8List bytes) {
@@ -247,26 +307,67 @@ class FileSystemHashes {
 ///
 /// [Directory] hashes are a hash of the names of the direct children.
 class FilesystemEntityHash {
-  FilesystemEntityHash(this.path, this.hash);
+  FilesystemEntityHash(
+    this.path,
+    this.hash, {
+    this.size,
+    this.lastModified,
+  });
 
   factory FilesystemEntityHash._fromJson(Map<String, Object> json) =>
       FilesystemEntityHash(
         _fileSystemPathToUri(json[_pathKey] as String),
         json[_hashKey] as int,
+        size: json[_sizeKey] as int?,
+        lastModified: switch (json[_lastModifiedKey]) {
+          final int us => DateTime.fromMicrosecondsSinceEpoch(us),
+          _ => null,
+        },
       );
 
   static const _pathKey = 'path';
   static const _hashKey = 'hash';
+  static const _sizeKey = 'size';
+  static const _lastModifiedKey = 'last_modified';
 
   final Uri path;
 
   /// A 64 bit hash.
   final int hash;
 
+  /// File size in bytes, or null if not applicable or not recorded.
+  final int? size;
+
+  /// Last modification timestamp, or null if not applicable or not recorded.
+  final DateTime? lastModified;
+
   Object toJson() => <String, Object>{
     _pathKey: path.toFilePath(),
     _hashKey: hash,
+    _sizeKey: ?size,
+    _lastModifiedKey: ?lastModified?.microsecondsSinceEpoch,
   };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! FilesystemEntityHash) return false;
+    if (other.path != path) return false;
+    if (other.hash != hash) return false;
+    if (other.size != size) return false;
+    if (other.lastModified == null || lastModified == null) {
+      return other.lastModified == lastModified;
+    }
+    return other.lastModified!.isAtSameMomentAs(lastModified!);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    path,
+    hash,
+    size,
+    lastModified?.microsecondsSinceEpoch,
+  );
 }
 
 class EnvironmentVariableHash {

--- a/pkgs/hooks_runner/test/dependencies_hash_file/dependencies_hash_file_test.dart
+++ b/pkgs/hooks_runner/test/dependencies_hash_file/dependencies_hash_file_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io' show Platform;
 
 import 'package:file/local.dart';
@@ -17,14 +18,140 @@ void main() async {
 
   test('json format', () async {
     await inTempDir((tempUri) async {
+      final now = DateTime.now();
       final hashes = FileSystemHashes(
-        files: [FilesystemEntityHash(tempUri.resolve('foo.dll'), 1337)],
+        files: [
+          FilesystemEntityHash(
+            tempUri.resolve('foo.dll'),
+            1337,
+            size: 42,
+            lastModified: now,
+          ),
+          FilesystemEntityHash(tempUri.resolve('bar.dll'), 4242),
+        ],
       );
       final hashes2 = FileSystemHashes.fromJson(hashes.toJson());
-      expect(hashes.files.single.path, equals(hashes2.files.single.path));
-      expect(hashes.files.single.hash, equals(hashes2.files.single.hash));
+      expect(hashes.files[0].path, equals(hashes2.files[0].path));
+      expect(hashes.files[0].hash, equals(hashes2.files[0].hash));
+      expect(hashes.files[0].size, equals(hashes2.files[0].size));
+      expect(
+        hashes.files[0].lastModified!.isAtSameMomentAs(
+          hashes2.files[0].lastModified!,
+        ),
+        isTrue,
+      );
+
+      expect(hashes.files[1].path, equals(hashes2.files[1].path));
+      expect(hashes.files[1].hash, equals(hashes2.files[1].hash));
+      expect(hashes.files[1].size, isNull);
+      expect(hashes.files[1].lastModified, isNull);
     });
   });
+
+  test('skips content hash when size and lastModified match', () async {
+    await inTempDir((tempUri) async {
+      final tempFile = fileSystem.file(tempUri.resolve('foo.txt'));
+      await tempFile.writeAsString('hello');
+
+      final hashesFileUri = tempUri.resolve('hashes.json');
+      final hashes = DependenciesHashFile(fileSystem, fileUri: hashesFileUri);
+
+      await hashes.updateHashes(
+        [tempFile.uri],
+        (await tempFile.lastModified()).add(const Duration(minutes: 1)),
+        environment,
+      );
+
+      // Fresh build: size and mtime match, so findOutdatedDependency returns
+      // null.
+      expect(await hashes.findOutdatedDependency(environment), isNull);
+
+      // Even if the saved hash in the file were corrupt/dummy, matching size
+      // and lastModified skips computing the content hash.
+      final hashesFile = fileSystem.file(hashesFileUri);
+      final dynamic initialDecoded = json.decode(
+        hashesFile.readAsStringSync(),
+      );
+      final initialHashes = FileSystemHashes.fromJson(
+        (initialDecoded as Map).cast<String, Object>(),
+      );
+      final fileStat = await tempFile.stat();
+      final corruptedHashes = FileSystemHashes(
+        files: [
+          FilesystemEntityHash(
+            tempFile.uri,
+            99999999, // intentionally mismatched hash
+            size: fileStat.size,
+            lastModified: fileStat.modified,
+          ),
+        ],
+        environment: initialHashes.environment,
+      );
+      await hashesFile.writeAsString(
+        const JsonEncoder.withIndent('  ').convert(corruptedHashes.toJson()),
+      );
+
+      expect(await hashes.findOutdatedDependency(environment), isNull);
+
+      // If mtime changes, content hashing runs and detects the mismatch.
+      await tempFile.setLastModified(
+        fileStat.modified.add(const Duration(seconds: 5)),
+      );
+      expect(
+        await hashes.findOutdatedDependency(environment),
+        contains(tempFile.uri.toFilePath()),
+      );
+    });
+  });
+
+  test(
+    'backward compatibility with hash files without size/lastModified',
+    () async {
+      await inTempDir((tempUri) async {
+        final tempFile = fileSystem.file(tempUri.resolve('foo.txt'));
+        await tempFile.writeAsString('hello');
+
+        final hashesFileUri = tempUri.resolve('hashes.json');
+        final hashes = DependenciesHashFile(fileSystem, fileUri: hashesFileUri);
+
+        await hashes.updateHashes(
+          [tempFile.uri],
+          (await tempFile.lastModified()).add(const Duration(minutes: 1)),
+          environment,
+        );
+
+        // Save without size and last_modified (legacy format).
+        final hashesFile = fileSystem.file(hashesFileUri);
+        final dynamic decodedJson = json.decode(hashesFile.readAsStringSync());
+        final parsedHashes = FileSystemHashes.fromJson(
+          (decodedJson as Map).cast<String, Object>(),
+        );
+        final oldFormatJson = <String, Object>{
+          'file_system': <Object>[
+            <String, Object>{
+              'path': tempFile.path,
+              'hash': parsedHashes.files.first.hash,
+            },
+          ],
+          'environment': [
+            for (final env in parsedHashes.environment) env.toJson(),
+          ],
+        };
+        await hashesFile.writeAsString(json.encode(oldFormatJson));
+
+        // Without size and lastModified, it falls back to hashing the file
+        // content.
+        expect(await hashes.findOutdatedDependency(environment), isNull);
+
+        // If file content changes, it detects the change.
+        await tempFile.writeAsString('world');
+        expect(
+          await hashes.findOutdatedDependency(environment),
+          contains(tempFile.uri.toFilePath()),
+        );
+      });
+    },
+  );
 
   test('dependencies hash file', () async {
     await inTempDir((tempUri) async {


### PR DESCRIPTION
Use file size and last modified for deciding whether a file has changed. This avoids reading the file and hashing. (There is a small chance of false positives on "unchanged" if you purposefully write a different file with exactly the same size and set the last modified timestamp to the previous timestamp. If you happen to do so, your loss. 😄 )

Closes: https://github.com/dart-lang/native/issues/3540

Some benchmark on a M4 MBP:

Sequential:

| File Size | 1,000 `stat()` calls | 1,000 `readAsBytes()` + MD5 | Slowdown Ratio | Time per single file (`readAsBytes` + MD5) |
| :--- | :--- | :--- | :--- | :--- |
| **100 B** | 16.96 ms | 72.75 ms | **4.3x** | ~72.8 µs |
| **1 KB** | 10.78 ms | 69.67 ms | **6.5x** | ~69.7 µs |
| **4 KB** | 10.93 ms | 80.75 ms | **7.4x** | ~80.7 µs |
| **16 KB** | 11.02 ms | 125.67 ms | **11x** | ~0.13 ms |
| **64 KB** | 10.22 ms | 362.18 ms | **35x** | ~0.36 ms |
| **1 MB** | 11.85 ms | 4.37 s | **369x** | ~4.37 ms |
| **10 MB** | 12.77 ms | 38.64 s | **3,027x** | ~38.64 ms |
| **100 MB** | 33.00 ms | 391.95 s | **11,877x** | ~391.95 ms (~0.39 s) |
| **1 GB** | 15.67 ms | 4,035.65 s | **257,595x** | **~4.04 s** |
 
100 files in parallel, so we don't wait so much on system calls:

| File Size | Parallel `stat()` (100 files) | Parallel `readAsBytes()` + MD5 (100 files) | Slowdown Ratio |
| :--- | :--- | :--- | :--- |
| **100 B** | 0.87 ms | 3.02 ms | **3.5x** |
| **1 KB** | 0.72 ms | 3.34 ms | **4.6x** |
| **4 KB** | 0.69 ms | 4.20 ms | **6.1x** |
| **16 KB** | 0.71 ms | 8.06 ms | **11.4x** |
| **64 KB** | 0.77 ms | 25.11 ms | **32.6x** |
| **1 MB** | 0.74 ms | 383.27 ms | **517.9x** |

The ~5x speedup for small files is probably still worth it to also avoid hashing small files.