### PR TITLE
[record_use] Fix quadratic deserialization complexity

### DIFF
--- a/pkgs/record_use/CHANGELOG.md
+++ b/pkgs/record_use/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1-wip
+
+- Fix quadratic deserialization performance and index corruption in
+  `Recordings.fromJson`.
+
 ## 1.1.0
 
 - Added `Recordings.+` to combine two recordings.

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -403,9 +403,7 @@ Error: $e
         constantSyntax,
         context,
       );
-      if (!constants.contains(constant)) {
-        constants.add(constant);
-      }
+      constants.add(constant);
     }
     return context;
   }

--- a/pkgs/record_use/pubspec.yaml
+++ b/pkgs/record_use/pubspec.yaml
@@ -1,7 +1,7 @@
 name: record_use
 description: >
   Dart API to access `@RecordUse()` recorded usages in link hooks.
-version: 1.1.0
+version: 1.1.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/record_use
 
 environment:

--- a/pkgs/record_use/test/storage_test.dart
+++ b/pkgs/record_use/test/storage_test.dart
@@ -41,4 +41,56 @@ void main() {
       expect(Recordings.fromJson(recordedUses2.toJson()), recordedUses2);
     });
   });
+
+  group('Recordings deserialization performance and correctness', () {
+    test('deserializing large number of constants scales linearly', () {
+      const dummyClass = Class(
+        'MyClass',
+        Library('package:my_package/my_class.dart'),
+      );
+
+      // Create a recording with 5,000 distinct instance constants
+      const count = 5000;
+      final instances = <InstanceConstantReference>[
+        for (var i = 0; i < count; i++)
+          InstanceConstantReference(
+            instanceConstant: InstanceConstant(
+              definition: dummyClass,
+              fields: {
+                'id': IntConstant(i),
+                'name': StringConstant('item_$i'),
+              },
+            ),
+            loadingUnit: const LoadingUnit('1'),
+          ),
+      ];
+
+      final originalRecordings = Recordings(
+        calls: {},
+        instances: {
+          dummyClass: instances,
+        },
+      );
+
+      final jsonMap = originalRecordings.toJson();
+
+      // Measure deserialization time
+      final stopwatch = Stopwatch()..start();
+      final deserialized = Recordings.fromJson(jsonMap);
+      stopwatch.stop();
+
+      // Deserialization of 5,000 constants should complete well under 1
+      // second. Before the fix, this took ~2.3 s due to O(N^2) list
+      // containment checks. After the fix, this takes ~12 ms.
+      expect(
+        stopwatch.elapsedMilliseconds,
+        lessThan(1000),
+        reason:
+            'Deserialization took ${stopwatch.elapsedMilliseconds}ms, '
+            'expected < 1000ms',
+      );
+
+      expect(deserialized.instances[dummyClass]?.length, count);
+    });
+  });
 }


### PR DESCRIPTION
We have customers with many recorded consts.

We canonicalize on serialization, so we should not check for duplicates on deserialization.