### PR TITLE
[hooks] Remove unused meta dependency (fixes Flutter compat)

### DIFF
--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   collection: ^1.19.1
   crypto: ^3.0.6
   logging: ^1.3.0
-  meta: ^1.19.0
   pub_semver: ^2.2.0
   record_use: ^1.0.0
   yaml: ^3.1.3 # Used for reading pubspec.yaml to obtain the package name.


### PR DESCRIPTION
## Problem

The `hooks` package lists `meta: ^1.19.0` as a dependency but **never imports `package:meta` anywhere** in its `lib/` or `test/` directories.

This unused dependency causes version conflicts for Flutter packages that use build hooks:

```
Because my_package depends on hooks ^2.1.0 which depends on meta ^1.19.0,
every version of my_package requires meta ^1.19.0.
And because every version of flutter_test from sdk depends on meta 1.17.0,
my_package is incompatible with flutter_test from sdk.
```

Flutter stable (3.41.9, Dart 3.11.5) pins `meta 1.17.0` via `flutter_test`. Since pub.dev enforces that `hook/` imports must be in `dependencies` (not `dev_dependencies`), there is no workaround — any Flutter package using build hooks is blocked.

## Verification

```bash
# Zero imports of package:meta in hooks lib/ or test/
$ grep -rn "import.*package:meta" pkgs/hooks/lib/ pkgs/hooks/test/ --include='*.dart'
# (no output)
```

Note: `hooks_runner` legitimately uses `package:meta` — this PR only removes it from `hooks`.

## Fix

Remove `meta: ^1.19.0` from `pkgs/hooks/pubspec.yaml` `dependencies`.

Fixes #3551
