### PR TITLE
[hooks] [code_assets] [native_toolchain_c] [record_use] Publish

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-wip
+## 2.0.0
 
 - Validate bundled dynamic libraries by reading their header: when the file is
   a recognized ELF, Mach-O, or PE binary, check that it was built for the
@@ -6,7 +6,7 @@
   run once per target architecture. A file the built-in validators do not
   recognize, or a recognized library built for an architecture they do not
   know, warns on the supplied logger instead of failing.
-- Bump the dependency on `package:hooks` to `^2.2.0-wip`.
+- Bump the dependency on `package:hooks` to `^2.2.0`.
 - **Breaking change**: Overrode `==` and `hashCode` in `OS`, `Architecture`, and `Sanitizer` to support custom targets. These objects can no longer be used as keys of `const` maps and sets.
   - *Migration*: Use `final` (runtime) maps and sets instead of `const`, or use the string representations (e.g., `OS.name`, `Architecture.name`) as keys if `const` is required.
 - Support custom target OS, architecture, and santizer in protocol extension.

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling native code
   with Dart packages.
 
-version: 2.0.0-wip
+version: 2.0.0
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 
@@ -21,7 +21,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  hooks: ^2.2.0-wip
+  hooks: ^2.2.0
   logging: ^1.3.0
 
 dev_dependencies:

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -21,7 +21,7 @@ environment:
 dependencies:
   args: ^2.6.0
   cli_util: ^0.4.2
-  code_assets: ^2.0.0-wip
+  code_assets: ^2.0.0
   collection: ^1.18.0
   dart_style: ^3.0.0
   ffi: ^2.0.1

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0-wip
+## 2.2.0
 
 - Add `ProtocolExtension.setupLogger`, which the hooks runner calls to provide
   the logger used for validation diagnostics before any other method is invoked

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 2.2.0-wip
+version: 2.2.0
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 
@@ -29,7 +29,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.6.0
-  code_assets: ^2.0.0-wip # Used for running tests with real asset types.
+  code_assets: ^2.0.0 # Used for running tests with real asset types.
   dart_flutter_team_lints: ^3.5.2
   data_assets: any # Used for running tests with real asset types.
   file_testing: ^3.0.2

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.2-wip
+## 1.6.2
 
 - Provide the runner's logger to protocol extensions before any other method is
   invoked, so they can emit validation diagnostics.

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.6.2-wip
+version: 1.6.2
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 
@@ -12,12 +12,12 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  code_assets: ^2.0.0-wip # Needed for OS for Target for KernelAssets.
+  code_assets: ^2.0.0 # Needed for OS for Target for KernelAssets.
   collection: ^1.19.1
   crypto: ^3.0.6
   file: ^7.0.1
   graphs: ^2.3.2
-  hooks: ^2.2.0-wip
+  hooks: ^2.2.0
   logging: ^1.3.0
   meta: ^1.19.0
   package_config: '>=2.1.0 <4.0.0'

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.19.4-wip
+## 0.19.4
 
 - Fix [native_toolchain_c failing with MSSSMS installed](https://github.com/dart-lang/native/issues/3327) by requiring vswhere to only show output that includes the necessary build tools
 - Link frameworks for C and C++ sources targeting macOS or iOS.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.19.4-wip
+version: 0.19.4
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  code_assets: ^2.0.0-wip
+  code_assets: ^2.0.0
   glob: ^2.1.1
   hooks: ^2.0.0
   logging: ^1.3.0

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  code_assets: ^2.0.0-wip
+  code_assets: ^2.0.0
   collection: ^1.19.1
   ffi: ^2.1.0
   hooks: ^2.0.0

--- a/pkgs/record_use/CHANGELOG.md
+++ b/pkgs/record_use/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1-wip
+## 1.1.1
 
 - Fix quadratic deserialization performance and index corruption in
   `Recordings.fromJson`.

--- a/pkgs/record_use/pubspec.yaml
+++ b/pkgs/record_use/pubspec.yaml
@@ -1,7 +1,7 @@
 name: record_use
 description: >
   Dart API to access `@RecordUse()` recorded usages in link hooks.
-version: 1.1.1-wip
+version: 1.1.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/record_use
 
 environment:


### PR DESCRIPTION
Publish a bunch of packages.

N.b. This pushes out code_assets v2.0.0 with the breaking change to make OS and Architecture extensible.