### PR TITLE
[hooks] [code_assets] Update docs to use link hooks

### DIFF
--- a/pkgs/code_assets/README.md
+++ b/pkgs/code_assets/README.md
@@ -43,24 +43,36 @@ void main(List<String> args) async {
 ```
 
 When compiling C, C++ or Objective-C code from source, consider using
-[`package:native_toolchain_c`](https://pub.dev/packages/native_toolchain_c):
+[`package:native_toolchain_c`](https://pub.dev/packages/native_toolchain_c)
+with a build hook and a link hook. First, define the C library specification in
+a shared file:
 
-<!-- file://./example/sqlite_no_link/hook/build.dart -->
+<!-- file://./example/sqlite/lib/src/c_library.dart -->
 ```dart
-import 'package:code_assets/code_assets.dart';
-import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-final builder = CBuilder.library(
+/// The C build specification for the sqlite library.
+///
+/// It is used by the build and link hooks in the `hook/` directory.
+final cLibrary = CLibrary(
   name: 'sqlite3',
   assetName: 'src/third_party/sqlite3.g.dart',
   sources: ['third_party/sqlite/sqlite3.c'],
 );
+```
+
+Next, compile the library in the build hook:
+
+<!-- file://./example/sqlite/hook/build.dart -->
+```dart
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:sqlite/src/c_library.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (input.config.buildCodeAssets) {
-      await builder.run(
+      await cLibrary.build(
         input: input,
         output: output,
         defines: {
@@ -70,6 +82,31 @@ void main(List<String> args) async {
         },
       );
     }
+  });
+}
+```
+
+Finally, tree-shake and link the library in the link hook:
+
+<!-- file://./example/sqlite/hook/link.dart -->
+```dart
+import 'package:hooks/hooks.dart';
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:record_use/record_use.dart';
+import 'package:sqlite/src/c_library.dart';
+import 'package:sqlite/src/third_party/record_use_mapping.dart';
+
+void main(List<String> arguments) async {
+  await link(arguments, (input, output) async {
+    await cLibrary.link(
+      input: input,
+      output: output,
+      linkerOptions: LinkerOptions.treeshake(
+        symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
+          (e) => recordUseMapping[e.name]!,
+        ),
+      ),
+    );
   });
 }
 ```

--- a/pkgs/code_assets/example/sqlite_no_link/hook/build.dart
+++ b/pkgs/code_assets/example/sqlite_no_link/hook/build.dart
@@ -23,6 +23,9 @@ void main(List<String> args) async {
             // Ensure symbols are exported in dll.
             'SQLITE_API': '__declspec(dllexport)',
         },
+        // No link hook: produce a dynamic library directly for the app bundle.
+        routing: [const ToAppBundle()],
+        linkModePreference: LinkModePreference.dynamic,
       );
     }
   });

--- a/pkgs/code_assets/lib/code_assets.dart
+++ b/pkgs/code_assets/lib/code_assets.dart
@@ -14,9 +14,9 @@
 /// Dart or Flutter application. They can be produced by compiling C, C++,
 /// Objective-C, Rust, or Go code for example.
 ///
-/// This package is used in a build hook (`hook/build.dart`) to inform the Dart
-/// and Flutter SDKs about the code assets that need to be bundled with an
-/// application.
+/// This package is used in a build hook (`hook/build.dart`) or link hook
+/// (`hook/link.dart`) to inform the Dart and Flutter SDKs about the code assets
+/// that need to be bundled with an application.
 ///
 /// A [CodeAsset] can be added to the [BuildOutputBuilder] in a build hook as
 /// follows:
@@ -46,6 +46,112 @@
 /// }
 /// ```
 ///
+/// When compiling C, C++ or Objective-C code from source, consider using
+/// [`package:native_toolchain_c`](https://pub.dev/packages/native_toolchain_c)
+/// with a build hook and a link hook. First, define the C library
+/// specification in a shared file:
+///
+/// <!-- file://./../example/sqlite/lib/src/c_library.dart -->
+/// ```dart
+/// import 'package:native_toolchain_c/native_toolchain_c.dart';
+///
+/// /// The C build specification for the sqlite library.
+/// ///
+/// /// It is used by the build and link hooks in the `hook/` directory.
+/// final cLibrary = CLibrary(
+///   name: 'sqlite3',
+///   assetName: 'src/third_party/sqlite3.g.dart',
+///   sources: ['third_party/sqlite/sqlite3.c'],
+/// );
+/// ```
+///
+/// Next, compile the library in the build hook:
+///
+/// <!-- file://./../example/sqlite/hook/build.dart -->
+/// ```dart
+/// import 'package:code_assets/code_assets.dart';
+/// import 'package:hooks/hooks.dart';
+/// import 'package:sqlite/src/c_library.dart';
+///
+/// void main(List<String> args) async {
+///   await build(args, (input, output) async {
+///     if (input.config.buildCodeAssets) {
+///       await cLibrary.build(
+///         input: input,
+///         output: output,
+///         defines: {
+///           if (input.config.code.targetOS == OS.windows)
+///             // Ensure symbols are exported in dll.
+///             'SQLITE_API': '__declspec(dllexport)',
+///         },
+///       );
+///     }
+///   });
+/// }
+/// ```
+///
+/// Finally, tree-shake and link the library in the link hook:
+///
+/// <!-- file://./../example/sqlite/hook/link.dart -->
+/// ```dart
+/// import 'package:hooks/hooks.dart';
+/// import 'package:native_toolchain_c/native_toolchain_c.dart';
+/// import 'package:record_use/record_use.dart';
+/// import 'package:sqlite/src/c_library.dart';
+/// import 'package:sqlite/src/third_party/record_use_mapping.dart';
+///
+/// void main(List<String> arguments) async {
+///   await link(arguments, (input, output) async {
+///     await cLibrary.link(
+///       input: input,
+///       output: output,
+///       linkerOptions: LinkerOptions.treeshake(
+///         symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
+///           (e) => recordUseMapping[e.name]!,
+///         ),
+///       ),
+///     );
+///   });
+/// }
+/// ```
+///
+/// See the full example in [example/sqlite/](../example/sqlite/).
+///
+/// When interfacing with system libraries, the API in this package is enough:
+///
+/// <!-- file://./../example/host_name/hook/build.dart -->
+/// ```dart
+/// import 'package:code_assets/code_assets.dart';
+/// import 'package:hooks/hooks.dart';
+///
+/// void main(List<String> args) async {
+///   await build(args, (input, output) async {
+///     if (input.config.buildCodeAssets) {
+///       switch (input.config.code.targetOS) {
+///         case OS.android || OS.iOS || OS.linux || OS.macOS:
+///           output.assets.code.add(
+///             CodeAsset(
+///               package: 'host_name',
+///               name: 'src/third_party/unix.dart',
+///               linkMode: LookupInProcess(),
+///             ),
+///           );
+///         case OS.windows:
+///           output.assets.code.add(
+///             CodeAsset(
+///               package: 'host_name',
+///               name: 'src/third_party/windows.dart',
+///               linkMode: DynamicLoadingSystem(Uri.file('ws2_32.dll')),
+///             ),
+///           );
+///         case final os:
+///           throw UnsupportedError('Unsupported OS: ${os.name}.');
+///       }
+///     }
+///   });
+/// }
+/// ```
+///
 /// The [CodeConfig] nested in the [HookInput] gives access to configuration
 /// specifically for compiling code assets. For example [CodeConfig.targetOS]
 /// and [CodeConfig.targetArchitecture] give access to the target OS and
@@ -69,7 +175,7 @@
 /// }
 /// ```
 ///
-/// For more information about build hooks see
+/// For more information about build and link hooks see
 /// [dart.dev/tools/hooks](https://dart.dev/tools/hooks).
 library;
 

--- a/pkgs/hooks/README.md
+++ b/pkgs/hooks/README.md
@@ -7,9 +7,15 @@ This package provides the API for hooks in Dart. Hooks are Dart
 scripts placed in the `hook/` directory of a Dart package, designed to automate
 tasks for a Dart package.
 
-Currently, the main supported hook is the build hook (`hook/build.dart`). The
-build hook is executed during a Dart build and enables you to bundle assets with
-a Dart package.
+This API supports two hooks: the build hook (`hook/build.dart`) and the link
+hook (`hook/link.dart`).
+
+The build hook is executed during a Dart build and enables you to build or
+gather assets for a Dart package. The link hook is executed after all build
+hooks and enables you to perform whole-application optimization and linking
+(such as tree-shaking dead native code based on
+[`@RecordUse()`](https://pub.dev/documentation/meta/latest/meta/RecordUse-class.html)
+usages).
 
 The main supported asset type is a code asset, code written in other languages
 that are compiled into machine code. You can use a build hook to do things such
@@ -20,24 +26,36 @@ API is an extension to this package and is available in
 [`package:code_assets`](https://pub.dev/packages/code_assets).
 
 When compiling C, C++ or Objective-C code from source, consider using
-[`package:native_toolchain_c`](https://pub.dev/packages/native_toolchain_c):
+[`package:native_toolchain_c`](https://pub.dev/packages/native_toolchain_c)
+with a build hook and a link hook. First, define the C library specification in
+a shared file:
 
-<!-- file://./../code_assets/example/sqlite_no_link/hook/build.dart -->
+<!-- file://./../code_assets/example/sqlite/lib/src/c_library.dart -->
 ```dart
-import 'package:code_assets/code_assets.dart';
-import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-final builder = CBuilder.library(
+/// The C build specification for the sqlite library.
+///
+/// It is used by the build and link hooks in the `hook/` directory.
+final cLibrary = CLibrary(
   name: 'sqlite3',
   assetName: 'src/third_party/sqlite3.g.dart',
   sources: ['third_party/sqlite/sqlite3.c'],
 );
+```
+
+Next, compile the library in the build hook:
+
+<!-- file://./../code_assets/example/sqlite/hook/build.dart -->
+```dart
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:sqlite/src/c_library.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (input.config.buildCodeAssets) {
-      await builder.run(
+      await cLibrary.build(
         input: input,
         output: output,
         defines: {
@@ -47,6 +65,31 @@ void main(List<String> args) async {
         },
       );
     }
+  });
+}
+```
+
+Finally, tree-shake and link the library in the link hook:
+
+<!-- file://./../code_assets/example/sqlite/hook/link.dart -->
+```dart
+import 'package:hooks/hooks.dart';
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:record_use/record_use.dart';
+import 'package:sqlite/src/c_library.dart';
+import 'package:sqlite/src/third_party/record_use_mapping.dart';
+
+void main(List<String> arguments) async {
+  await link(arguments, (input, output) async {
+    await cLibrary.link(
+      input: input,
+      output: output,
+      linkerOptions: LinkerOptions.treeshake(
+        symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
+          (e) => recordUseMapping[e.name]!,
+        ),
+      ),
+    );
   });
 }
 ```

--- a/pkgs/hooks/lib/hooks.dart
+++ b/pkgs/hooks/lib/hooks.dart
@@ -8,32 +8,49 @@
 /// placed in the `hook/` directory of a Dart package, designed to automate
 /// tasks for a Dart package.
 ///
-/// Currently, the main supported hook is the build hook (`hook/build.dart`).
-/// The build hook is executed during a Dart build and enables you to bundle
-/// assets with a Dart package. The main entrypoint for build hooks is [build].
+/// This API supports two hooks: the build hook (`hook/build.dart`) and the link
+/// hook (`hook/link.dart`).
 ///
-/// The second hook available in this API is the link hook  (`hook/link.dart`).
-/// The main entrypoint for link hooks is [link].
+/// The build hook is executed during a Dart build and enables you to build or
+/// gather assets for a Dart package. The main entrypoint for build hooks is
+/// [build].
 ///
-/// Hooks can for example be used to bundle native source code with a Dart
-/// package:
+/// The link hook is executed after all build hooks and enables you to perform
+/// whole-application optimization and linking (such as tree-shaking dead
+/// native code based on
+/// [`@RecordUse()`](https://pub.dev/documentation/meta/latest/meta/RecordUse-class.html)
+/// usages). The main entrypoint for link hooks is [link].
 ///
-/// <!-- file://./../../code_assets/example/sqlite_no_link/hook/build.dart -->
+/// Hooks can for example be used to compile native source code with a Dart
+/// package using a build hook and a link hook. First, define the C library
+/// specification in a shared file:
+///
+/// <!-- file://./../../code_assets/example/sqlite/lib/src/c_library.dart -->
 /// ```dart
-/// import 'package:code_assets/code_assets.dart';
-/// import 'package:hooks/hooks.dart';
 /// import 'package:native_toolchain_c/native_toolchain_c.dart';
 ///
-/// final builder = CBuilder.library(
+/// /// The C build specification for the sqlite library.
+/// ///
+/// /// It is used by the build and link hooks in the `hook/` directory.
+/// final cLibrary = CLibrary(
 ///   name: 'sqlite3',
 ///   assetName: 'src/third_party/sqlite3.g.dart',
 ///   sources: ['third_party/sqlite/sqlite3.c'],
 /// );
+/// ```
+///
+/// Next, compile the library in the build hook:
+///
+/// <!-- file://./../../code_assets/example/sqlite/hook/build.dart -->
+/// ```dart
+/// import 'package:code_assets/code_assets.dart';
+/// import 'package:hooks/hooks.dart';
+/// import 'package:sqlite/src/c_library.dart';
 ///
 /// void main(List<String> args) async {
 ///   await build(args, (input, output) async {
 ///     if (input.config.buildCodeAssets) {
-///       await builder.run(
+///       await cLibrary.build(
 ///         input: input,
 ///         output: output,
 ///         defines: {
@@ -43,6 +60,31 @@
 ///         },
 ///       );
 ///     }
+///   });
+/// }
+/// ```
+///
+/// Finally, tree-shake and link the library in the link hook:
+///
+/// <!-- file://./../../code_assets/example/sqlite/hook/link.dart -->
+/// ```dart
+/// import 'package:hooks/hooks.dart';
+/// import 'package:native_toolchain_c/native_toolchain_c.dart';
+/// import 'package:record_use/record_use.dart';
+/// import 'package:sqlite/src/c_library.dart';
+/// import 'package:sqlite/src/third_party/record_use_mapping.dart';
+///
+/// void main(List<String> arguments) async {
+///   await link(arguments, (input, output) async {
+///     await cLibrary.link(
+///       input: input,
+///       output: output,
+///       linkerOptions: LinkerOptions.treeshake(
+///         symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
+///           (e) => recordUseMapping[e.name]!,
+///         ),
+///       ),
+///     );
 ///   });
 /// }
 /// ```


### PR DESCRIPTION
Update the hooks and code_assets README and library doc to use the link hook and tree-shaking examples now that they are in stable.

(Also, fix the no-link-hook sample. It was broken if link hooks are not used.)