### PR TITLE
[ffigen] Config update part 6: typedef bits

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -6,12 +6,16 @@
     - `include` and `includeMember` replaced with `.isIncluded` on AST nodes.
     - `Functions/Globals.includeSymbolAddress` replaced with
       `.exposeSymbolAddress` on AST nodes.
+    - `Functions.includeTypedef` replaced with `.generateTypedefs` on
+      `Func` AST node.
     - `Structs.packingOverride` replaced with `Struct.pack`.
     - `Enums.style` and `.silenceWarning` moved to `EnumClass` AST node.
     - `Functions.isLeaf` and `.recordUse` moved to `Func` AST node.
     - `Structs/Unions.dependencies` moved to `Struct/Union` AST nodes.
     - `Interfaces/Protocols.module` moved to `ObjCInterface/ObjCProtocol` AST
       nodes.
+    - `Typedefs.includeUnused` consolidated into `Typealias.isIncluded` using
+      `TypealiasInclude` enum (`never`, `ifUsed`, `always`).
   - Consolidate `imported` fields and `importedTypesByUsr` into
     `FfiGenerator.importType`, switching it to a callback pattern
   - Deleted many now empty sub-config classes

--- a/pkgs/ffigen/lib/ffigen.dart
+++ b/pkgs/ffigen/lib/ffigen.dart
@@ -37,7 +37,7 @@ export 'src/config_provider.dart'
         PackingValue,
         Protocols,
         SymbolFile,
-        Typedefs,
+        TypealiasInclude,
         VarArgFunction,
         Version,
         Versions,

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -45,7 +45,7 @@ import 'writer.dart';
 class Func extends LookUpBinding with HasLocalScope {
   final FunctionType functionType;
   bool exposeSymbolAddress;
-  final bool exposeFunctionTypedefs;
+  bool generateTypedefs;
   bool isLeaf;
   final bool objCReturnsRetained;
   final bool useNameForLookup;
@@ -61,7 +61,7 @@ class Func extends LookUpBinding with HasLocalScope {
 
   bool get needsWrapper => !functionType.sameDartAndFfiDartType && !isInternal;
 
-  /// Contains typealias for function type if [exposeFunctionTypedefs] is true.
+  /// Contains typealias for function type if [generateTypedefs] is true.
   Typealias? _exposedFunctionTypealias;
 
   bool isIncluded = false;
@@ -77,7 +77,7 @@ class Func extends LookUpBinding with HasLocalScope {
     List<Parameter> parameters = const [],
     List<Parameter> varArgParameters = const [],
     this.exposeSymbolAddress = false,
-    this.exposeFunctionTypedefs = false,
+    this.generateTypedefs = false,
     this.isLeaf = false,
     this.objCReturnsRetained = false,
     this.useNameForLookup = false,
@@ -96,17 +96,19 @@ class Func extends LookUpBinding with HasLocalScope {
         functionType.parameters[i].symbol = Symbol('arg$i', SymbolKind.field);
       }
     }
+  }
 
-    // Get function name with first letter in upper case.
-    final upperCaseName = name[0].toUpperCase() + name.substring(1);
-    if (exposeFunctionTypedefs) {
-      _exposedFunctionTypealias = Typealias(
-        name: upperCaseName,
-        type: functionType,
-        genFfiDartType: true,
-        isInternal: true,
-      );
-    }
+  Typealias? fillExposedFunctionTypealias() {
+    if (!generateTypedefs) return null;
+    final upperCaseName = symbol.oldName.isEmpty
+        ? ''
+        : symbol.oldName[0].toUpperCase() + symbol.oldName.substring(1);
+    return _exposedFunctionTypealias ??= Typealias(
+      name: upperCaseName,
+      type: functionType,
+      genFfiDartType: true,
+      isInternal: true,
+    );
   }
 
   @override

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../code_generator.dart';
+import '../config_provider/config_types.dart';
 import '../config_provider/public_ast.dart' as public_ast;
 import '../context.dart';
 import '../strings.dart' as strings;
@@ -27,7 +28,7 @@ class Typealias extends BindingType {
   // Don't code gen this alias at all, just use the [type] directly.
   bool isAnonymous;
 
-  bool isIncluded = false;
+  TypealiasInclude isIncluded = TypealiasInclude.never;
 
   /// Creates a Typealias.
   ///

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -30,9 +30,6 @@ final class FfiGenerator {
   /// may change or be removed in a future version without a deprecation notice.
   final Cpp? cpp;
 
-  /// Configuration for typedefs.
-  final Typedefs typedefs;
-
   /// Objective-C specific configuration.
   ///
   /// If `null`, will only generate for C.
@@ -89,7 +86,6 @@ final class FfiGenerator {
     this.input = const Input(),
     this.functions = const Functions(),
     this.cpp,
-    this.typedefs = const Typedefs(),
     this.objectiveC,
     required this.output,
     this.visitors = const [],
@@ -146,11 +142,6 @@ enum EnumStyle {
 
 /// Configuration for function declarations.
 final class Functions {
-  /// Whether to generate a typedef for a given function's native type.
-  final bool Function(Declaration declaration) includeTypedef;
-
-  static bool _includeTypedefDefault(Declaration declaration) => false;
-
   /// Map from function's original name to [VarArgFunction]s.
   ///
   /// Dart doesn't support variadic functions. Instead, variadic functions are
@@ -159,18 +150,7 @@ final class Functions {
   /// signatures.
   final Map<String, List<VarArgFunction>> varArgs;
 
-  const Functions({
-    this.includeTypedef = _includeTypedefDefault,
-    this.varArgs = const <String, List<VarArgFunction>>{},
-  });
-}
-
-/// Configuration for typedefs.
-final class Typedefs {
-  /// If enabled, unused typedefs will also be generated.
-  final bool includeUnused;
-
-  const Typedefs({this.includeUnused = false});
+  const Functions({this.varArgs = const <String, List<VarArgFunction>>{}});
 }
 
 /// Configuration for C++.

--- a/pkgs/ffigen/lib/src/config_provider/config_types.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config_types.dart
@@ -42,6 +42,26 @@ enum CommentLength { none, brief, full }
 
 enum CompoundDependencies { full, opaque }
 
+/// Controls whether and how a [Typealias] (typedef) is included in generated
+/// code.
+enum TypealiasInclude {
+  /// Never generate a typedef declaration for this typealias.
+  ///
+  /// Any generated functions, structs, or other bindings that reference this
+  /// typealias will inline the underlying aliased type instead.
+  never,
+
+  /// Generate a typedef declaration only if this typealias is referenced by
+  /// another generated binding.
+  ///
+  /// If no generated bindings reference this typealias, it is omitted.
+  ifUsed,
+
+  /// Always generate a typedef declaration for this typealias, even if no
+  /// other generated bindings reference it.
+  always,
+}
+
 /// Holds config for how Structs Packing will be overriden.
 class StructPackingOverride {
   final List<(RegExp, int?)> _matchers;

--- a/pkgs/ffigen/lib/src/config_provider/public_ast.dart
+++ b/pkgs/ffigen/lib/src/config_provider/public_ast.dart
@@ -71,6 +71,10 @@ class Func extends DeclNode {
   bool get exposeSymbolAddress => _func.exposeSymbolAddress;
   set exposeSymbolAddress(bool value) => _func.exposeSymbolAddress = value;
 
+  /// Whether to generate a typedef for this function's native type.
+  bool get generateTypedefs => _func.generateTypedefs;
+  set generateTypedefs(bool value) => _func.generateTypedefs = value;
+
   @override
   void accept(Visitor visitor) {
     visitor.visitFunc(this);
@@ -312,9 +316,11 @@ class Typealias extends DeclNode {
   @override
   set name(String value) => _typealias.symbol.oldName = value;
 
-  /// Whether this Typealias should be included in code generation.
-  bool get isIncluded => _typealias.isIncluded;
-  set isIncluded(bool value) => _typealias.isIncluded = value;
+  /// Controls whether and how this [Typealias] is included in code generation.
+  ///
+  /// See [TypealiasInclude] for the available options.
+  TypealiasInclude get isIncluded => _typealias.isIncluded;
+  set isIncluded(TypealiasInclude value) => _typealias.isIncluded = value;
 }
 
 /// An Objective-C interface (class) declaration.

--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -1262,11 +1262,7 @@ final class YamlConfig {
                 wrapperDocComment: wrapperDocComment,
               ),
       ),
-      functions: Functions(
-        varArgs: varArgFunctions,
-        includeTypedef: shouldExposeFunctionTypedef,
-      ),
-      typedefs: Typedefs(includeUnused: includeUnusedTypedefs),
+      functions: Functions(varArgs: varArgFunctions),
       importType: importType,
       objectiveC: language == Language.objc
           ? ObjectiveC(
@@ -1310,6 +1306,9 @@ final class YamlConfigAstVisitor extends public_ast.Visitor {
     }
     if (config.functionDecl.shouldIncludeSymbolAddress(_decl(node))) {
       node.exposeSymbolAddress = true;
+    }
+    if (config.shouldExposeFunctionTypedef(_decl(node))) {
+      node.generateTypedefs = true;
     }
   }
 
@@ -1375,7 +1374,9 @@ final class YamlConfigAstVisitor extends public_ast.Visitor {
 
   @override
   void visitTypealias(public_ast.Typealias node) {
-    node.isIncluded = config.typedefs.shouldInclude(_decl(node));
+    node.isIncluded = !config.typedefs.shouldInclude(_decl(node))
+        ? .never
+        : (config.includeUnusedTypedefs ? .always : .ifUsed);
     if (config.typedefs.rename(_decl(node)) case final rename?) {
       node.name = rename;
     }

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -32,7 +32,6 @@ List<Func> parseFunctionDeclaration(
     return funcs;
   }
 
-  final decl = Declaration(usr: funcUsr, originalName: funcName);
   final cachedFunc = context.bindingsIndex.getSeenFunc(funcUsr);
   if (cachedFunc != null) {
     funcs.add(cachedFunc);
@@ -121,7 +120,6 @@ List<Func> parseFunctionDeclaration(
             for (final ta in vaFunc?.types ?? const <Type>[])
               Parameter(type: ta, name: 'va', objCConsumed: false),
           ],
-          exposeFunctionTypedefs: config.functions.includeTypedef(decl),
           objCReturnsRetained: objCReturnsRetained,
           loadFromNativeAsset: config.output.style is NativeExternalBindings,
           apiAvailability: apiAvailability,

--- a/pkgs/ffigen/lib/src/visitor/apply_config_filters.dart
+++ b/pkgs/ffigen/lib/src/visitor/apply_config_filters.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../code_generator.dart';
+import '../config_provider/config_types.dart';
 import '../context.dart';
 
 import 'ast.dart';
@@ -111,6 +112,6 @@ class ApplyConfigFiltersVisitation extends Visitation {
   @override
   void visitTypealias(Typealias node) {
     if (node.isAnonymous) return;
-    _visitImpl(node, node.isIncluded);
+    _visitImpl(node, node.isIncluded != TypealiasInclude.never);
   }
 }

--- a/pkgs/ffigen/lib/src/visitor/fill_method_dependencies.dart
+++ b/pkgs/ffigen/lib/src/visitor/fill_method_dependencies.dart
@@ -29,6 +29,7 @@ class FillMethodDependenciesVisitation extends Visitation {
   void visitFunc(Func node) {
     if (!finalBindings.contains(node)) return;
     node.fillFuncVarSymbol();
+    _adder.visit(node.fillExposedFunctionTypealias());
   }
 
   @override
@@ -125,6 +126,7 @@ class _MethodDepAdderVisitation extends Visitation {
   @override
   void visitFunc(Func node) {
     node.fillFuncVarSymbol();
+    visitor.visit(node.fillExposedFunctionTypealias());
     finalBindings.add(node);
   }
 

--- a/pkgs/ffigen/lib/src/visitor/list_bindings.dart
+++ b/pkgs/ffigen/lib/src/visitor/list_bindings.dart
@@ -4,6 +4,7 @@
 
 import '../code_generator.dart';
 import '../config_provider/config.dart' show FfiGenerator;
+import '../config_provider/config_types.dart';
 import '../strings.dart' as strings;
 
 import 'ast.dart';
@@ -124,10 +125,12 @@ class ListBindingsVisitation extends Visitation {
     final _IncludeBehavior includeBehavior;
     if (node.isInternal) {
       includeBehavior = _IncludeBehavior.transitive;
-    } else if (config.typedefs.includeUnused) {
-      includeBehavior = _IncludeBehavior.configOnly;
     } else {
-      includeBehavior = _IncludeBehavior.configAndTransitive;
+      includeBehavior = switch (node.isIncluded) {
+        TypealiasInclude.always => _IncludeBehavior.configOnly,
+        TypealiasInclude.ifUsed => _IncludeBehavior.configAndTransitive,
+        TypealiasInclude.never => _IncludeBehavior.configOnly,
+      };
     }
     _visitImpl(node, includeBehavior);
 

--- a/pkgs/ffigen/test/code_generator_tests/code_generator_test.dart
+++ b/pkgs/ffigen/test/code_generator_tests/code_generator_test.dart
@@ -38,7 +38,7 @@ void main() {
                   enumClass: (node) => node.isIncluded = true,
                   global: (node) => node.isIncluded = true,
                   macroConstant: (node) => node.isIncluded = true,
-                  typealias: (node) => node.isIncluded = true,
+                  typealias: (node) => node.isIncluded = .always,
                 ),
               ],
         ),

--- a/pkgs/ffigen/test/collision_tests/decl_decl_collision_test.dart
+++ b/pkgs/ffigen/test/collision_tests/decl_decl_collision_test.dart
@@ -24,7 +24,7 @@ void main() {
               struct: (node) => node.isIncluded = true,
               enumClass: (node) => node.isIncluded = true,
               macroConstant: (node) => node.isIncluded = true,
-              typealias: (node) => node.isIncluded = true,
+              typealias: (node) => node.isIncluded = .always,
             ),
           ],
         ),

--- a/pkgs/ffigen/test/collision_tests/decl_symbol_address_collision_test.dart
+++ b/pkgs/ffigen/test/collision_tests/decl_symbol_address_collision_test.dart
@@ -27,7 +27,7 @@ void main() {
               enumClass: (node) => node.isIncluded = true,
               global: (node) => node.isIncluded = true,
               macroConstant: (node) => node.isIncluded = true,
-              typealias: (node) => node.isIncluded = true,
+              typealias: (node) => node.isIncluded = .always,
             ),
           ],
         ),
@@ -43,7 +43,7 @@ void main() {
             name: '_library',
             returnType: NativeType(SupportedNativeType.voidType),
             exposeSymbolAddress: true,
-            exposeFunctionTypedefs: true,
+            generateTypedefs: true,
           ),
           Func(
             name: '_SymbolAddresses_1',

--- a/pkgs/ffigen/test/collision_tests/reserved_keyword_collision_test.dart
+++ b/pkgs/ffigen/test/collision_tests/reserved_keyword_collision_test.dart
@@ -29,7 +29,7 @@ void main() {
                 enumClass: (node) => node.isIncluded = true,
                 global: (node) => node.isIncluded = true,
                 macroConstant: (node) => node.isIncluded = true,
-                typealias: (node) => node.isIncluded = true,
+                typealias: (node) => node.isIncluded = .always,
               ),
             ],
             input: Input(
@@ -44,7 +44,6 @@ void main() {
                 ),
               ],
             ),
-            typedefs: const Typedefs(includeUnused: true),
           ),
         ),
       );

--- a/pkgs/ffigen/test/header_parser_tests/globals_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/globals_test.dart
@@ -100,7 +100,7 @@ Library expectedLibrary() {
         Visitor(
           global: (node) => node.isIncluded = true,
           struct: (node) => node.isIncluded = true,
-          typealias: (node) => node.isIncluded = true,
+          typealias: (node) => node.isIncluded = .always,
         ),
       ],
     ),
@@ -155,7 +155,11 @@ Library expectedLibrary() {
     ),
   ];
   for (final b in rawBindings) {
-    (b as dynamic).isIncluded = true;
+    if (b is Typealias) {
+      b.isIncluded = .always;
+    } else {
+      (b as dynamic).isIncluded = true;
+    }
   }
   return Library(
     context: context,

--- a/pkgs/ffigen/test/header_parser_tests/sort_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/sort_test.dart
@@ -32,12 +32,11 @@ void main() {
                 ),
               ],
             ),
-            typedefs: const Typedefs(includeUnused: true),
             visitors: [
               Visitor(
                 struct: (node) => node.isIncluded = true,
                 union: (node) => node.isIncluded = true,
-                typealias: (node) => node.isIncluded = true,
+                typealias: (node) => node.isIncluded = .always,
               ),
             ],
           ),

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -114,8 +114,8 @@ void main() {
           ),
           global: (node) =>
               node.isIncluded = stableRandomInclude('globals', node),
-          typealias: (node) =>
-              node.isIncluded = stableRandomInclude('typedefs', node),
+          typealias: (node) => node.isIncluded =
+              stableRandomInclude('typedefs', node) ? .ifUsed : .never,
           macroConstant: (node) => node.isIncluded = false,
           objCInterface: (node) =>
               node.isIncluded = stableRandomInclude('objcInterfaces', node),

--- a/pkgs/ffigen/test/large_integration_tests/large_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_test.dart
@@ -74,7 +74,7 @@ void main() {
             unnamedEnumConstant: (node) => node.isIncluded = true,
             global: (node) => node.isIncluded = true,
             macroConstant: (node) => node.isIncluded = true,
-            typealias: (node) => node.isIncluded = true,
+            typealias: (node) => node.isIncluded = .ifUsed,
           ),
         ],
       );
@@ -162,7 +162,7 @@ void main() {
             unnamedEnumConstant: (node) => node.isIncluded = true,
             global: (node) => node.isIncluded = true,
             macroConstant: (node) => node.isIncluded = true,
-            typealias: (node) => node.isIncluded = true,
+            typealias: (node) => node.isIncluded = .ifUsed,
           ),
         ],
       );
@@ -225,9 +225,9 @@ void main() {
             },
             typealias: (node) {
               if (vaRegex.hasMatch(node.originalName)) {
-                node.isIncluded = false;
+                node.isIncluded = .never;
               } else {
-                node.isIncluded = true;
+                node.isIncluded = .ifUsed;
               }
             },
             union: (node) => node.isIncluded = true,

--- a/pkgs/swiftgen/lib/src/config.dart
+++ b/pkgs/swiftgen/lib/src/config.dart
@@ -219,9 +219,6 @@ class FfiGeneratorOptions {
   /// [ffigen.FfiGenerator.functions]
   final ffigen.Functions functions;
 
-  /// [ffigen.FfiGenerator.typedefs]
-  final ffigen.Typedefs typedefs;
-
   /// [ffigen.FfiGenerator.objectiveC]
   final ffigen.ObjectiveC objectiveC;
 
@@ -230,7 +227,6 @@ class FfiGeneratorOptions {
 
   const FfiGeneratorOptions({
     this.functions = const ffigen.Functions(),
-    this.typedefs = const ffigen.Typedefs(),
     this.objectiveC = const ffigen.ObjectiveC(),
     this.visitors = const [],
   });

--- a/pkgs/swiftgen/lib/src/generator.dart
+++ b/pkgs/swiftgen/lib/src/generator.dart
@@ -88,7 +88,6 @@ extension SwiftGenGenerator on SwiftGenerator {
         style: fg.NativeExternalBindings(assetId: output.assetId),
       ),
       functions: ffigen.functions,
-      typedefs: ffigen.typedefs,
       objectiveC: fg.ObjectiveC(
         interfaces: fg.Interfaces(
           includeTransitive: interfaces.includeTransitive,


### PR DESCRIPTION
Migrate `Functions.includeTypedef` to `Func.generateTypedefs`, and fold `Typedefs.includeUnused` into `Typealias.isIncluded` (which is now a 3 state enum).

Mapping from the old config behavior to the new enum:

| .isIncluded | .includeUnused | TypealiasInclude |
| -- | -- | -- |
| false | * | .never |
| true | false | .ifUsed |
| true | true | .always |

Also had to change `_exposedFunctionTypealias` to be filled later in the pipeline, in fill_method_dependencies, since it depends on `generateTypedefs.