### PR TITLE
[ffigen] Config update part 7: includeTransitive

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -12,6 +12,9 @@
     - `Structs/Unions.dependencies` moved to `Struct/Union` AST nodes.
     - `Interfaces/Protocols.module` moved to `ObjCInterface/ObjCProtocol` AST
       nodes.
+    - `Interfaces/Protocols.includeTransitive` removed (always false).
+    - `Categories.includeTransitive` replaced with
+      `ObjCInterface.includeCategories`.
   - Consolidate `imported` fields and `importedTypesByUsr` into
     `FfiGenerator.importType`, switching it to a callback pattern
   - Deleted many now empty sub-config classes

--- a/pkgs/ffigen/example/objective_c/README.md
+++ b/pkgs/ffigen/example/objective_c/README.md
@@ -25,7 +25,7 @@ In this example, we're only interested in `AVAudioPlayer`, so we've filtered out
 everything else. FFIgen will automatically pull in anything referenced by
 any of the fields or methods of `AVAudioPlayer`, but by default they're
 generated as stubs. To generate full bindings for the transient dependencies,
-set `node.isIncluded = true` for them in your visitor, or set `Interfaces.includeTransitive` to `true`.
+set `node.isIncluded = true` for them in your visitor.
 
 ## Generating bindings
 

--- a/pkgs/ffigen/lib/ffigen.dart
+++ b/pkgs/ffigen/lib/ffigen.dart
@@ -17,7 +17,6 @@ export 'src/code_generator/imports.dart' show ImportedType, LibraryImport;
 export 'src/config_provider.dart'
     show
         BindingStyle,
-        Categories,
         CommentLength,
         CommentStyle,
         CommentType,
@@ -30,12 +29,10 @@ export 'src/config_provider.dart'
         FfiGenerator,
         Functions,
         Input,
-        Interfaces,
         NativeExternalBindings,
         ObjectiveC,
         Output,
         PackingValue,
-        Protocols,
         SymbolFile,
         Typedefs,
         VarArgFunction,

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -32,6 +32,7 @@ class ObjCInterface extends BindingType with ObjCMethods, HasLocalScope {
   bool generateAsStub = false;
 
   bool isIncluded = false;
+  bool includeCategories = true;
 
   ObjCInterface({
     super.usr,

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -180,15 +180,6 @@ final class Cpp {
 
 /// Configuration for Objective-C.
 final class ObjectiveC {
-  /// Declaration filters for Objective-C categories.
-  final Categories categories;
-
-  /// Declaration filters for Objective-C interfaces.
-  final Interfaces interfaces;
-
-  /// Declaration filters for Objective-C protocols.
-  final Protocols protocols;
-
   // Undocumented option that changes code generation for package:objective_c.
   // The main difference is whether NSObject etc are imported from
   // package:objective_c (the default) or code genned like any other class.
@@ -202,38 +193,10 @@ final class ObjectiveC {
   final ExternalVersions externalVersions;
 
   const ObjectiveC({
-    this.categories = const Categories(),
-    this.interfaces = const Interfaces(),
-    this.protocols = const Protocols(),
     this.externalVersions = const ExternalVersions(),
     @Deprecated('Only for internal use.')
     this.generateForPackageObjectiveC = false,
   });
-}
-
-/// Configuration for Objective-C categories.
-final class Categories {
-  /// If enabled, Objective-C categories that are not explicitly included,
-  /// but extend interfaces that are included, will be code-genned as if they
-  /// were included. If disabled, these transitively included categories will
-  /// not be generated at all.
-  final bool includeTransitive;
-
-  const Categories({this.includeTransitive = true});
-}
-
-/// Configuration for Objective-C interfaces.
-final class Interfaces {
-  final bool includeTransitive;
-
-  const Interfaces({this.includeTransitive = false});
-}
-
-/// Configuration for Objective-C protocols.
-final class Protocols {
-  final bool includeTransitive;
-
-  const Protocols({this.includeTransitive = false});
 }
 
 /// Configuration for outputting bindings.

--- a/pkgs/ffigen/lib/src/config_provider/public_ast.dart
+++ b/pkgs/ffigen/lib/src/config_provider/public_ast.dart
@@ -353,6 +353,17 @@ class ObjCInterface extends DeclNode {
   /// Whether this ObjCInterface should be included in code generation.
   bool get isIncluded => _interface.isIncluded;
   set isIncluded(bool value) => _interface.isIncluded = value;
+
+  /// Whether categories extending this interface are all included transitively.
+  ///
+  /// If true, all of this interface's categories will be included if this
+  /// interface is included. This is the default behavior, because it's common
+  /// for ObjC API documentation to say that a method is a direct member of an
+  /// interface, when in fact it's a method on an undocumented category of the
+  /// interface. This leads to confusing issues where the bindings are missing
+  /// methods seemingly for no reason.
+  bool get includeCategories => _interface.includeCategories;
+  set includeCategories(bool value) => _interface.includeCategories = value;
 }
 
 /// An Objective-C protocol declaration.
@@ -426,6 +437,10 @@ class ObjCCategory extends DeclNode {
   set name(String value) => _category.symbol.oldName = value;
 
   /// Whether this ObjCCategory should be included in code generation.
+  ///
+  /// If you have set this field to false, but the category is still being
+  /// generated, you may need to set [interface]`.includeCategories` to false
+  /// too.
   bool get isIncluded => _category.isIncluded;
   set isIncluded(bool value) => _category.isIncluded = value;
 }

--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -1270,15 +1270,6 @@ final class YamlConfig {
       importType: importType,
       objectiveC: language == Language.objc
           ? ObjectiveC(
-              interfaces: Interfaces(
-                includeTransitive: includeTransitiveObjCInterfaces,
-              ),
-              protocols: Protocols(
-                includeTransitive: includeTransitiveObjCProtocols,
-              ),
-              categories: Categories(
-                includeTransitive: includeTransitiveObjCCategories,
-              ),
               externalVersions: externalVersions,
               // ignore: deprecated_member_use_from_same_package
               generateForPackageObjectiveC: generateForPackageObjectiveC,
@@ -1390,6 +1381,7 @@ final class YamlConfigAstVisitor extends public_ast.Visitor {
     if (config.interfaceModule(_decl(node)) case final module?) {
       node.module = module;
     }
+    node.includeCategories = config.includeTransitiveObjCCategories;
   }
 
   @override

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objccategorydecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objccategorydecl_parser.dart
@@ -15,8 +15,7 @@ ObjCCategory? parseObjCCategoryDeclaration(
   Context context,
   clang_types.CXCursor cursor,
 ) {
-  final objcCategories = context.config.objectiveC?.categories;
-  if (objcCategories == null) {
+  if (context.config.objectiveC == null) {
     return null;
   }
 

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -23,8 +23,7 @@ Type? parseObjCInterfaceDeclaration(
   final apiAvailability = ApiAvailability.fromCursor(cursor, context);
 
   final config = context.config;
-  final objcInterfaces = config.objectiveC?.interfaces;
-  if (objcInterfaces == null) {
+  if (config.objectiveC == null) {
     return null;
   }
 

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart
@@ -21,8 +21,7 @@ ObjCProtocol? parseObjCProtocolDeclaration(
     return null;
   }
 
-  final objcProtocols = config.objectiveC?.protocols;
-  if (objcProtocols == null) {
+  if (config.objectiveC == null) {
     return null;
   }
 

--- a/pkgs/ffigen/lib/src/visitor/find_transitive_deps.dart
+++ b/pkgs/ffigen/lib/src/visitor/find_transitive_deps.dart
@@ -55,7 +55,7 @@ class FindDirectTransitiveDepsVisitation extends Visitation {
 
   @override
   void visitObjCInterface(ObjCInterface node) {
-    _visitImpl(node, config.objectiveC?.interfaces.includeTransitive ?? false);
+    _visitImpl(node, false);
 
     // Always visit the super type, regardless of whether the node is directly
     // included. This ensures that super types of stubs are also stubs, rather
@@ -74,7 +74,7 @@ class FindDirectTransitiveDepsVisitation extends Visitation {
 
   @override
   void visitObjCCategory(ObjCCategory node) {
-    _visitImpl(node, config.objectiveC?.categories.includeTransitive ?? false);
+    _visitImpl(node, node.parent.includeCategories);
 
     // Same as visitObjCInterface's visit of superType.
     visitor.visit(node.parent);
@@ -82,7 +82,7 @@ class FindDirectTransitiveDepsVisitation extends Visitation {
 
   @override
   void visitObjCProtocol(ObjCProtocol node) {
-    _visitImpl(node, config.objectiveC?.protocols.includeTransitive ?? false);
+    _visitImpl(node, false);
 
     // Same as visitObjCInterface's visit of superType.
     visitor.visitAll(node.superProtocols);

--- a/pkgs/ffigen/lib/src/visitor/list_bindings.dart
+++ b/pkgs/ffigen/lib/src/visitor/list_bindings.dart
@@ -65,14 +65,9 @@ class ListBindingsVisitation extends Visitation {
 
   @override
   void visitObjCInterface(ObjCInterface node) {
-    final _IncludeBehavior includeBehavior;
-    if (node.isInternal) {
-      includeBehavior = _IncludeBehavior.transitive;
-    } else if (config.objectiveC?.interfaces.includeTransitive ?? false) {
-      includeBehavior = _IncludeBehavior.configOrTransitive;
-    } else {
-      includeBehavior = _IncludeBehavior.configOnly;
-    }
+    final includeBehavior = node.isInternal
+        ? _IncludeBehavior.transitive
+        : _IncludeBehavior.configOnly;
     final omit = node.unavailable || !_visitImpl(node, includeBehavior);
 
     if (omit && directTransitives.contains(node)) {
@@ -94,7 +89,7 @@ class ListBindingsVisitation extends Visitation {
   @override
   void visitObjCCategory(ObjCCategory node) => _visitImpl(
     node,
-    config.objectiveC?.categories.includeTransitive ?? false
+    node.parent.includeCategories
         ? _IncludeBehavior.configOrDirectTransitive
         : _IncludeBehavior.configOnly,
   );
@@ -102,13 +97,7 @@ class ListBindingsVisitation extends Visitation {
   @override
   void visitObjCProtocol(ObjCProtocol node) {
     final omit =
-        node.unavailable ||
-        !_visitImpl(
-          node,
-          config.objectiveC?.protocols.includeTransitive ?? false
-              ? _IncludeBehavior.configOrTransitive
-              : _IncludeBehavior.configOnly,
-        );
+        node.unavailable || !_visitImpl(node, _IncludeBehavior.configOnly);
 
     if (omit && directTransitives.contains(node)) {
       node.generateAsStub = true;

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -90,9 +90,6 @@ void main() {
 ''',
       ),
       objectiveC: ObjectiveC(
-        interfaces: const Interfaces(includeTransitive: false),
-        protocols: const Protocols(includeTransitive: false),
-        categories: const Categories(includeTransitive: false),
         externalVersions: ExternalVersions(
           ios: Versions(min: Version(12, 0, 0)),
           macos: Versions(min: Version(10, 14, 0)),
@@ -117,8 +114,10 @@ void main() {
           typealias: (node) =>
               node.isIncluded = stableRandomInclude('typedefs', node),
           macroConstant: (node) => node.isIncluded = false,
-          objCInterface: (node) =>
-              node.isIncluded = stableRandomInclude('objcInterfaces', node),
+          objCInterface: (node) {
+            node.includeCategories = false;
+            node.isIncluded = stableRandomInclude('objcInterfaces', node);
+          },
           objCProtocol: (node) => node.isIncluded = stableRandomInclude(
             'objcProtocols',
             node,

--- a/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
@@ -45,15 +45,17 @@ String bindingsForVersion({Versions? iosVers, Versions? macosVers}) {
       ],
     ),
     objectiveC: ObjectiveC(
-      categories: const Categories(includeTransitive: false),
       externalVersions: ExternalVersions(ios: iosVers, macos: macosVers),
     ),
     visitors: [
       Visitor(
-        objCInterface: (node) => node.isIncluded = {
-          'DeprecatedInterfaceMethods',
-          'DeprecatedInterface',
-        }.contains(node.originalName),
+        objCInterface: (node) {
+          node.includeCategories = false;
+          node.isIncluded = {
+            'DeprecatedInterfaceMethods',
+            'DeprecatedInterface',
+          }.contains(node.originalName);
+        },
         objCProtocol: (node) => node.isIncluded = {
           'DeprecatedProtocolMethods',
           'DeprecatedProtocol',

--- a/pkgs/ffigen/test/native_objc_test/transitive_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/transitive_test.dart
@@ -14,11 +14,7 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import '../test_utils.dart';
 
-String generate({
-  bool includeTransitiveObjCInterfaces = false,
-  bool includeTransitiveObjCProtocols = false,
-  bool includeTransitiveObjCCategories = false,
-}) {
+String generate({bool includeTransitiveObjCCategories = true}) {
   FfiGenerator(
     output: Output(
       dartFile: Uri.file(
@@ -47,23 +43,18 @@ String generate({
         ),
       ],
     ),
-    objectiveC: ObjectiveC(
-      interfaces: Interfaces(
-        includeTransitive: includeTransitiveObjCInterfaces,
-      ),
-      protocols: Protocols(includeTransitive: includeTransitiveObjCProtocols),
-      categories: Categories(
-        includeTransitive: includeTransitiveObjCCategories,
-      ),
-    ),
+    objectiveC: const ObjectiveC(),
     visitors: [
       Visitor(
-        objCInterface: (node) => node.isIncluded = {
-          'DirectlyIncluded',
-          'DirectlyIncludedWithProtocol',
-          'DirectlyIncludedIntForCat',
-          'Bug2935DirectInterface',
-        }.contains(node.originalName),
+        objCInterface: (node) {
+          node.includeCategories = includeTransitiveObjCCategories;
+          node.isIncluded = {
+            'DirectlyIncluded',
+            'DirectlyIncludedWithProtocol',
+            'DirectlyIncludedIntForCat',
+            'Bug2935DirectInterface',
+          }.contains(node.originalName);
+        },
         objCProtocol: (node) =>
             node.isIncluded = node.originalName == 'DirectlyIncludedProtocol',
         objCCategory: (node) =>
@@ -130,45 +121,8 @@ void main() {
     }
 
     group('transitive interfaces', () {
-      test('included', () {
-        bindings = generate(includeTransitiveObjCInterfaces: true);
-
-        expect(incItf('DoublyTransitive'), Inclusion.included);
-        expect(incItf('TransitiveSuper'), Inclusion.included);
-        expect(incItf('Transitive'), Inclusion.included);
-        expect(incItf('SuperSuperType'), Inclusion.included);
-        expect(incItf('DoublySuperTransitive'), Inclusion.included);
-        expect(incItf('SuperTransitive'), Inclusion.included);
-        expect(incItf('SuperType'), Inclusion.included);
-        expect(incItf('DirectlyIncluded'), Inclusion.included);
-        expect(incItf('NotIncludedSuperType'), Inclusion.omitted);
-        expect(incItf('NotIncludedTransitive'), Inclusion.omitted);
-        expect(incItf('NotIncludedSuperType'), Inclusion.omitted);
-        expect(incItf('Bug2935DirectInterface'), Inclusion.included);
-        expect(incItf('Bug2935TransitiveInterface'), Inclusion.included);
-        expect(incItf('Bug2935TransitiveBlockInterface'), Inclusion.included);
-
-        expect(bindings.contains('doubleMethod'), isTrue);
-        expect(bindings.contains('transitiveSuperMethod'), isTrue);
-        expect(bindings.contains('transitiveMethod'), isTrue);
-        expect(bindings.contains('superSuperMethod'), isTrue);
-        expect(bindings.contains('doublySuperMethod'), isTrue);
-        expect(bindings.contains('superTransitiveMethod'), isTrue);
-        expect(bindings.contains('superMethod'), isTrue);
-        expect(bindings.contains('directMethod'), isTrue);
-        expect(bindings.contains('notIncludedSuperMethod'), isFalse);
-        expect(bindings.contains('notIncludedTransitiveMethod'), isFalse);
-        expect(bindings.contains('notIncludedMethod'), isFalse);
-        expect(bindings.contains('bug2935DirectInterfaceMethod'), isTrue);
-        expect(bindings.contains('bug2935TransitiveInterfaceMethod'), isTrue);
-        expect(
-          bindings.contains('bug2935TransitiveBlockInterfaceMethod'),
-          isTrue,
-        );
-      });
-
       test('stubbed', () {
-        bindings = generate(includeTransitiveObjCInterfaces: false);
+        bindings = generate();
 
         expect(incItf('DoublyTransitive'), Inclusion.omitted);
         expect(incItf('TransitiveSuper'), Inclusion.stubbed);
@@ -206,46 +160,8 @@ void main() {
     });
 
     group('transitive protocols', () {
-      test('included', () {
-        bindings = generate(includeTransitiveObjCProtocols: true);
-
-        expect(incProto('DoublyTransitiveProtocol'), Inclusion.included);
-        expect(incProto('TransitiveSuperProtocol'), Inclusion.included);
-        expect(incProto('TransitiveProtocol'), Inclusion.included);
-        expect(incProto('SuperSuperProtocol'), Inclusion.included);
-        expect(incProto('DoublySuperTransitiveProtocol'), Inclusion.included);
-        expect(incProto('SuperTransitiveProtocol'), Inclusion.included);
-        expect(incProto('SuperProtocol'), Inclusion.included);
-        expect(incProto('AnotherSuperProtocol'), Inclusion.included);
-        expect(incProto('DirectlyIncludedProtocol'), Inclusion.included);
-        expect(incProto('NotIncludedSuperProtocol'), Inclusion.omitted);
-        expect(incProto('NotIncludedTransitiveProtocol'), Inclusion.omitted);
-        expect(incProto('NotIncludedProtocol'), Inclusion.omitted);
-        expect(incProto('SuperFromInterfaceProtocol'), Inclusion.included);
-        expect(incProto('TransitiveFromInterfaceProtocol'), Inclusion.included);
-        expect(incItf('DirectlyIncludedWithProtocol'), Inclusion.included);
-        expect(incProto('Bug2935TransitiveProtocol'), Inclusion.included);
-
-        expect(bindings.contains('doubleProtoMethod'), isTrue);
-        expect(bindings.contains('transitiveSuperProtoMethod'), isTrue);
-        expect(bindings.contains('transitiveProtoMethod'), isTrue);
-        expect(bindings.contains('superSuperProtoMethod'), isTrue);
-        expect(bindings.contains('doublySuperProtoMethod'), isTrue);
-        expect(bindings.contains('superTransitiveProtoMethod'), isTrue);
-        expect(bindings.contains('superProtoMethod'), isTrue);
-        expect(bindings.contains('anotherSuperProtoMethod'), isTrue);
-        expect(bindings.contains('directProtoMethod'), isTrue);
-        expect(bindings.contains('notIncludedSuperProtoMethod'), isFalse);
-        expect(bindings.contains('notIncludedTransitiveProtoMethod'), isFalse);
-        expect(bindings.contains('notIncludedProtoMethod'), isFalse);
-        expect(bindings.contains('superFromInterfaceProtoMethod'), isTrue);
-        expect(bindings.contains('transitiveFromInterfaceProtoMethod'), isTrue);
-        expect(bindings.contains('directlyIncludedWithProtoMethod'), isTrue);
-        expect(bindings.contains('bug2935TransitiveProtocolMethod'), isTrue);
-      });
-
       test('not included', () {
-        bindings = generate(includeTransitiveObjCProtocols: false);
+        bindings = generate();
 
         expect(incProto('DoublyTransitiveProtocol'), Inclusion.omitted);
         expect(incProto('TransitiveSuperProtocol'), Inclusion.stubbed);

--- a/pkgs/swiftgen/lib/src/generator.dart
+++ b/pkgs/swiftgen/lib/src/generator.dart
@@ -78,8 +78,6 @@ extension SwiftGenGenerator on SwiftGenerator {
   ], absTempDir);
 
   void _generateDartFile(Logger logger, String objcHeader) {
-    final interfaces = ffigen.objectiveC.interfaces;
-    final protocols = ffigen.objectiveC.protocols;
     fg.FfiGenerator(
       output: fg.Output(
         dartFile: output.dartFile,
@@ -90,11 +88,6 @@ extension SwiftGenGenerator on SwiftGenerator {
       functions: ffigen.functions,
       typedefs: ffigen.typedefs,
       objectiveC: fg.ObjectiveC(
-        interfaces: fg.Interfaces(
-          includeTransitive: interfaces.includeTransitive,
-        ),
-        protocols: fg.Protocols(includeTransitive: protocols.includeTransitive),
-        categories: ffigen.objectiveC.categories,
         externalVersions: ffigen.objectiveC.externalVersions,
       ),
       visitors: [


### PR DESCRIPTION
- Remove `Interfaces/Protocols.includeTransitive`, treating them as always false.
- Replace `Categories.includeTransitive` with `ObjCInterface.includeCategories` (categories can only be transitively referenced from their interface).