### PR TITLE
[hooks_runner] Invalidate cached hook compilation on Dart SDK change

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.3
+
+- Invalidate cached hook compilations when the Dart SDK version changes.
+
 ## 1.6.2
 
 - Provide the runner's logger to protocol extensions before any other method is

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -837,8 +837,11 @@ class NativeAssetsBuildRunner {
     '_compileHookForPackageCached',
     arguments: {'scriptUri': scriptUri.toFilePath(), 'package': packageName},
     () async {
-      // Don't invalidate cache with environment changes.
-      final environmentForCaching = <String, String>{};
+      final environmentForCaching = <String, String>{
+        // Don't invalidate cache with environment changes.
+        // If the Dart version changed, recompile.
+        'DART_VERSION': Platform.version,
+      };
       final kernelFile = _fileSystem.file(buildDirUri.resolve('hook.dill'));
       final depFile = _fileSystem.file(buildDirUri.resolve('hook.dill.d'));
       final dependenciesHashFile = buildDirUri.resolve(
@@ -886,8 +889,6 @@ class NativeAssetsBuildRunner {
             (e) => e != packageLayout.packageConfigUri && !_isImmutable(e),
           ),
           packageLayout.packageConfigUri,
-          // If the Dart version changed, recompile.
-          dartExecutable.resolve('../version'),
         ],
         lastModifiedCutoffTime,
         environmentForCaching,

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.6.2
+version: 1.6.3
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
@@ -429,4 +429,86 @@ void main() async {
       });
     },
   );
+
+  test(
+    'hook recompiled when Dart version changes',
+    timeout: longTimeout,
+    () async {
+      await inTempDir((tempUri) async {
+        await copyTestProjects(targetUri: tempUri);
+        final packageUri = tempUri.resolve('native_add/');
+
+        final logMessages = <String>[];
+        final logger = createCapturingLogger(logMessages);
+
+        await runPubGet(workingDirectory: packageUri, logger: logger);
+        logMessages.clear();
+
+        // 1. Initial build compiles hook.
+        (await build(
+          packageUri,
+          logger,
+          dartExecutable,
+          buildAssetTypes: [.code],
+        )).success;
+        logMessages.clear();
+
+        final hookUri = packageUri.resolve('hook/build.dart');
+
+        // 2. Second build without changes should not recompile hook.
+        (await build(
+          packageUri,
+          logger,
+          dartExecutable,
+          buildAssetTypes: [.code],
+        )).success;
+        expect(
+          logMessages.join('\n'),
+          isNot(contains('Recompiling ${hookUri.toFilePath()}')),
+        );
+        logMessages.clear();
+
+        // 3. Simulate Dart version change by modifying DART_VERSION in
+        // hook.dependencies_hash_file.json.
+        final hookDependenciesHashFile = File.fromUri(
+          (Directory.fromUri(
+                    packageUri.resolve('.dart_tool/hooks_runner/native_add/'),
+                  ).listSync().single
+                  as Directory)
+              .uri
+              .resolve('hook.dependencies_hash_file.json'),
+        );
+        expect(await hookDependenciesHashFile.exists(), true);
+        final hookDependenciesContent =
+            jsonDecode(await hookDependenciesHashFile.readAsString())
+                as Map<Object, Object?>;
+        final envList =
+            (hookDependenciesContent['environment'] as List<dynamic>)
+                .cast<Map<String, dynamic>>();
+        final dartVersionEntry = envList.firstWhere(
+          (e) => e['key'] == 'DART_VERSION',
+        );
+        dartVersionEntry['hash'] = 123456789;
+        await hookDependenciesHashFile.writeAsString(
+          jsonEncode(hookDependenciesContent),
+        );
+
+        // 4. Build should now recompile the hook due to changed Dart version.
+        (await build(
+          packageUri,
+          logger,
+          dartExecutable,
+          buildAssetTypes: [.code],
+        )).success;
+        expect(
+          logMessages.join('\n'),
+          contains('Recompiling ${hookUri.toFilePath()}'),
+        );
+        expect(
+          logMessages.join('\n'),
+          contains('Environment variable changed: DART_VERSION.'),
+        );
+      });
+    },
+  );
 }


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/3571