### PR TITLE
[jnigen] Fall back to current isolate package config in findPackage

### DIFF
--- a/pkgs/jnigen/lib/src/util/find_package.dart
+++ b/pkgs/jnigen/lib/src/util/find_package.dart
@@ -7,7 +7,7 @@ import 'dart:isolate';
 
 import 'package:package_config/package_config.dart';
 
-Future<Package?> findPackage(String packageName, [Directory? directory]) async {
+Future<Package?> findPackage(String packageName, {Directory? directory}) async {
   final packageConfig = await findPackageConfig(directory ?? Directory.current);
   if (packageConfig != null && packageConfig[packageName] != null) {
     return packageConfig[packageName];
@@ -21,8 +21,8 @@ Future<Package?> findPackage(String packageName, [Directory? directory]) async {
   return null;
 }
 
-Future<Uri?> findPackageRoot(String packageName, [Directory? directory]) async {
-  return (await findPackage(packageName, directory))?.root;
+Future<Uri?> findPackageRoot(String packageName, {Directory? directory}) async {
+  return (await findPackage(packageName, directory: directory))?.root;
 }
 
 Future<bool> isPackageModifiedAfter(String packageName, DateTime time,

--- a/pkgs/jnigen/lib/src/util/find_package.dart
+++ b/pkgs/jnigen/lib/src/util/find_package.dart
@@ -3,19 +3,26 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:package_config/package_config.dart';
 
-Future<Package?> findPackage(String packageName) async {
-  final packageConfig = await findPackageConfig(Directory.current);
-  if (packageConfig == null) {
-    return null;
+Future<Package?> findPackage(String packageName, [Directory? directory]) async {
+  final packageConfig = await findPackageConfig(directory ?? Directory.current);
+  if (packageConfig != null && packageConfig[packageName] != null) {
+    return packageConfig[packageName];
   }
-  return packageConfig[packageName];
+  final isolatePackageConfigUri = await Isolate.packageConfig;
+  if (isolatePackageConfigUri != null) {
+    final isolatePackageConfig =
+        await loadPackageConfigUri(isolatePackageConfigUri);
+    return isolatePackageConfig[packageName];
+  }
+  return null;
 }
 
-Future<Uri?> findPackageRoot(String packageName) async {
-  return (await findPackage(packageName))?.root;
+Future<Uri?> findPackageRoot(String packageName, [Directory? directory]) async {
+  return (await findPackage(packageName, directory))?.root;
 }
 
 Future<bool> isPackageModifiedAfter(String packageName, DateTime time,

--- a/pkgs/jnigen/test/find_package_test.dart
+++ b/pkgs/jnigen/test/find_package_test.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:jnigen/src/util/find_package.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('findPackage and findPackageRoot in current directory', () async {
+    final pkg = await findPackage('jnigen');
+    expect(pkg, isNotNull);
+    expect(pkg!.name, equals('jnigen'));
+
+    final root = await findPackageRoot('jnigen');
+    expect(root, isNotNull);
+    expect(root!.toFilePath(), equals(pkg.root.toFilePath()));
+  });
+
+  test('findPackage and findPackageRoot for nonexistent package', () async {
+    final pkg = await findPackage('non_existent_package_12345');
+    expect(pkg, isNull);
+
+    final root = await findPackageRoot('non_existent_package_12345');
+    expect(root, isNull);
+  });
+
+  test(
+      'findPackage falls back to Isolate.packageConfig when directory has no '
+      'package_config', () async {
+    final tempDir = Directory.systemTemp.createTempSync('find_package_test_');
+    try {
+      // In tempDir, findPackageConfig(tempDir) returns null.
+      // However, findPackage should fall back to Isolate.packageConfig.
+      final pkg = await findPackage('jnigen', tempDir);
+      expect(pkg, isNotNull);
+      expect(pkg!.name, equals('jnigen'));
+
+      final root = await findPackageRoot('jnigen', tempDir);
+      expect(root, isNotNull);
+      expect(root!.toFilePath(), equals(pkg.root.toFilePath()));
+    } finally {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+}

--- a/pkgs/jnigen/test/find_package_test.dart
+++ b/pkgs/jnigen/test/find_package_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:jnigen/src/util/find_package.dart';
+import 'package:package_config/package_config.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -32,12 +33,14 @@ void main() {
     final tempDir = Directory.systemTemp.createTempSync('find_package_test_');
     try {
       // In tempDir, findPackageConfig(tempDir) returns null.
+      expect(await findPackageConfig(tempDir), isNull);
+
       // However, findPackage should fall back to Isolate.packageConfig.
-      final pkg = await findPackage('jnigen', tempDir);
+      final pkg = await findPackage('jnigen', directory: tempDir);
       expect(pkg, isNotNull);
       expect(pkg!.name, equals('jnigen'));
 
-      final root = await findPackageRoot('jnigen', tempDir);
+      final root = await findPackageRoot('jnigen', directory: tempDir);
       expect(root, isNotNull);
       expect(root!.toFilePath(), equals(pkg.root.toFilePath()));
     } finally {


### PR DESCRIPTION
Find package from the current isolate's package config if it failed to locate the package config from the default location.

This allows jnigen to work in nonstandard Dart environment.