### PR TITLE
[ffigen] Fix infinite recursion when parsing cyclic C++ class references

### DIFF
--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/classdecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/classdecl_parser.dart
@@ -52,20 +52,13 @@ CppClass? parseClassDeclaration(Context context, clang_types.CXCursor cursor) {
     '++++ Adding C++ Class: Name: $className, ${cursor.completeStringRepr()}',
   );
 
-  final methods = <CppMethod>[];
-
-  cursor.visitChildren((child) {
-    final kind = clang.clang_getCursorKind(child);
-    if (kind == clang_types.CXCursorKind.CXCursor_CXXMethod) {
-      _parseAnyMethod(context, child, decl, methods, CppMethodKind.method);
-    } else if (kind == clang_types.CXCursorKind.CXCursor_Constructor) {
-      _parseAnyMethod(context, child, decl, methods, CppMethodKind.constructor);
-    }
-  });
-
-  // Parse public base classes (only public specifiers; non-public are ignored).
-  final bases = _parsePublicBases(context, cursor);
-
+  // The class is added to the seen index before its members are parsed. A
+  // member signature can name the class it belongs to, directly or through a
+  // cycle of classes, and resolving such a type re-enters this function for a
+  // class that is still being parsed. Registering first lets that re-entrant
+  // call return this same binding, instead of recursing until the stack is
+  // exhausted. The members only need the identity of the class, so handing
+  // them one whose methods and bases are not filled in yet is fine.
   final cppClass = CppClass(
     usr: usr,
     dartDoc: getCursorDocComment(
@@ -76,12 +69,36 @@ CppClass? parseClassDeclaration(Context context, clang_types.CXCursor cursor) {
     originalName: className,
     name: className,
     context: context,
-    methods: methods,
+    methods: <CppMethod>[],
     fields: <CppMember>[],
-    bases: bases,
+    bases: <CppClass>[],
   );
 
   context.bindingsIndex.addCppClassToSeen(usr, cppClass);
+
+  cursor.visitChildren((child) {
+    final kind = clang.clang_getCursorKind(child);
+    if (kind == clang_types.CXCursorKind.CXCursor_CXXMethod) {
+      _parseAnyMethod(
+        context,
+        child,
+        decl,
+        cppClass.methods,
+        CppMethodKind.method,
+      );
+    } else if (kind == clang_types.CXCursorKind.CXCursor_Constructor) {
+      _parseAnyMethod(
+        context,
+        child,
+        decl,
+        cppClass.methods,
+        CppMethodKind.constructor,
+      );
+    }
+  });
+
+  // Parse public base classes (only public specifiers; non-public are ignored).
+  cppClass.bases.addAll(_parsePublicBases(context, cursor));
 
   return cppClass;
 }

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/classdecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/classdecl_parser.dart
@@ -52,13 +52,6 @@ CppClass? parseClassDeclaration(Context context, clang_types.CXCursor cursor) {
     '++++ Adding C++ Class: Name: $className, ${cursor.completeStringRepr()}',
   );
 
-  // The class is added to the seen index before its members are parsed. A
-  // member signature can name the class it belongs to, directly or through a
-  // cycle of classes, and resolving such a type re-enters this function for a
-  // class that is still being parsed. Registering first lets that re-entrant
-  // call return this same binding, instead of recursing until the stack is
-  // exhausted. The members only need the identity of the class, so handing
-  // them one whose methods and bases are not filled in yet is fine.
   final cppClass = CppClass(
     usr: usr,
     dartDoc: getCursorDocComment(

--- a/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class.h
+++ b/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include <memory>
+
+// Classes whose own member signatures refer back to them. Parsing one of these
+// re-enters the class parser for a class that is still being parsed, so the
+// parser must recognize the class it is already working on instead of
+// recursing until the stack is exhausted.
+
+// Self-reference through a return type.
+class Node {
+ public:
+  virtual ~Node() = default;
+  virtual Node* clone() = 0;
+};
+
+// Self-reference through a parameter type.
+class Merger {
+ public:
+  virtual void merge(Merger* other) = 0;
+};
+
+// Self-reference through a smart pointer return type.
+class Owner {
+ public:
+  virtual std::unique_ptr<Owner> take() = 0;
+};
+
+// Mutual recursion between two classes.
+class Branch;
+
+class Leaf {
+ public:
+  virtual Branch* parent() = 0;
+};
+
+class Branch {
+ public:
+  virtual Leaf* firstLeaf() = 0;
+};
+
+Node* node_create(void);
+Merger* merger_create(void);
+Owner* owner_create(void);
+Leaf* leaf_create(void);
+Branch* branch_create(void);

--- a/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class.h
+++ b/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class.h
@@ -4,11 +4,6 @@
 
 #include <memory>
 
-// Classes whose own member signatures refer back to them. Parsing one of these
-// re-enters the class parser for a class that is still being parsed, so the
-// parser must recognize the class it is already working on instead of
-// recursing until the stack is exhausted.
-
 // Self-reference through a return type.
 class Node {
  public:

--- a/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:ffigen/ffigen.dart';
+import 'package:ffigen/src/code_generator.dart' as cg;
+import 'package:ffigen/src/header_parser.dart' as parser;
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+/// A C++ class whose own member signatures name that same class is parsed by
+/// re-entering the class parser for a class that is still being parsed. The
+/// parser has to recognize the class it is already working on: without that,
+/// parsing recurses until the stack is exhausted, which takes the whole process
+/// down (a segfault, or an exception thrown through the libclang visitor
+/// callback) rather than failing the test.
+/// The header's own classes: self-reference through a return type, through a
+/// parameter, through a std::unique_ptr, and a cycle between two classes.
+const _cyclicClasses = {'Node', 'Merger', 'Owner', 'Leaf', 'Branch'};
+
+void main() {
+  group('cpp_cyclic_class', () {
+    late cg.Library library;
+
+    setUpAll(() {
+      library = parser.parse(
+        testContext(
+          FfiGenerator(
+            output: Output(dartFile: Uri.file('unused')),
+            input: Input(
+              entryPoints: [
+                Uri.file(absPath('test/header_parser_tests/cpp_cyclic_class.h')),
+              ],
+              compilerOptions: const ['-x', 'c++', '-std=c++17'],
+            ),
+            cpp: const Cpp(),
+            visitors: [
+              // A C++ class is excluded by default. Only the header's own
+              // classes are included: <memory> drags the whole standard library
+              // in behind std::unique_ptr, and what it declares differs per
+              // toolchain.
+              Visitor(
+                cppClass: (node) => node.isIncluded = _cyclicClasses.contains(
+                  node.originalName,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    });
+
+    test('classes that name themselves are parsed exactly once', () {
+      final names =
+          library.bindings
+              .whereType<cg.CppClass>()
+              .map((c) => c.originalName)
+              .toList()
+            ..sort();
+
+      // Every class of the header, once each: a member type that closes a cycle
+      // must resolve to the class already being parsed, not to a second copy of
+      // it.
+      expect(names, _cyclicClasses.toList()..sort());
+    });
+
+    test('a cyclic member resolves to the class already being parsed', () {
+      cg.CppClass classNamed(String name) =>
+          library.bindings.whereType<cg.CppClass>().firstWhere(
+            (c) => c.originalName == name,
+          );
+
+      final node = classNamed('Node');
+      final leaf = classNamed('Leaf');
+      final branch = classNamed('Branch');
+
+      expect(
+        node.methods.map((m) => m.originalName),
+        contains('clone'),
+        reason: 'the member whose type closes the cycle is still parsed',
+      );
+      expect(leaf.methods.map((m) => m.originalName), contains('parent'));
+      expect(branch.methods.map((m) => m.originalName), contains('firstLeaf'));
+    });
+  });
+}

--- a/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
@@ -19,7 +19,7 @@ void main() {
       library = parser.parse(
         testContext(
           FfiGenerator(
-            output: Output(dartFile: Uri.file('unused')),
+            output: Output(dart: DartOutput(path: Uri.file('unused'))),
             input: Input(
               entryPoints: [
                 Uri.file(

--- a/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
@@ -26,7 +26,12 @@ void main() {
                   absPath('test/header_parser_tests/cpp_cyclic_class.h'),
                 ),
               ],
-              compilerOptions: const ['-x', 'c++', '-std=c++17'],
+              compilerOptions: const [
+                '-x',
+                'c++',
+                '-std=c++17',
+                if (Platform.isMacOS) ...['-isysroot', macSdkPath],
+              ],
             ),
             cpp: const Cpp(),
             visitors: [

--- a/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
@@ -9,14 +9,6 @@ import 'package:test/test.dart';
 
 import '../test_utils.dart';
 
-/// A C++ class whose own member signatures name that same class is parsed by
-/// re-entering the class parser for a class that is still being parsed. The
-/// parser has to recognize the class it is already working on: without that,
-/// parsing recurses until the stack is exhausted, which takes the whole process
-/// down (a segfault, or an exception thrown through the libclang visitor
-/// callback) rather than failing the test.
-/// The header's own classes: self-reference through a return type, through a
-/// parameter, through a std::unique_ptr, and a cycle between two classes.
 const _cyclicClasses = {'Node', 'Merger', 'Owner', 'Leaf', 'Branch'};
 
 void main() {
@@ -30,16 +22,14 @@ void main() {
             output: Output(dartFile: Uri.file('unused')),
             input: Input(
               entryPoints: [
-                Uri.file(absPath('test/header_parser_tests/cpp_cyclic_class.h')),
+                Uri.file(
+                  absPath('test/header_parser_tests/cpp_cyclic_class.h'),
+                ),
               ],
               compilerOptions: const ['-x', 'c++', '-std=c++17'],
             ),
             cpp: const Cpp(),
             visitors: [
-              // A C++ class is excluded by default. Only the header's own
-              // classes are included: <memory> drags the whole standard library
-              // in behind std::unique_ptr, and what it declares differs per
-              // toolchain.
               Visitor(
                 cppClass: (node) => node.isIncluded = _cyclicClasses.contains(
                   node.originalName,
@@ -66,22 +56,30 @@ void main() {
     });
 
     test('a cyclic member resolves to the class already being parsed', () {
-      cg.CppClass classNamed(String name) =>
-          library.bindings.whereType<cg.CppClass>().firstWhere(
-            (c) => c.originalName == name,
-          );
+      cg.CppClass classNamed(String name) => library.bindings
+          .whereType<cg.CppClass>()
+          .firstWhere((c) => c.originalName == name);
+
+      cg.CppClass returnedClass(cg.CppClass cls, String methodName) {
+        final method = cls.methods.firstWhere(
+          (m) => m.originalName == methodName,
+          orElse: () => fail('${cls.originalName} has no method $methodName'),
+        );
+        expect(method.returnType, isA<cg.CppClassPointerType>());
+        return (method.returnType as cg.CppClassPointerType).cppClass;
+      }
 
       final node = classNamed('Node');
       final leaf = classNamed('Leaf');
       final branch = classNamed('Branch');
 
       expect(
-        node.methods.map((m) => m.originalName),
-        contains('clone'),
-        reason: 'the member whose type closes the cycle is still parsed',
+        returnedClass(node, 'clone'),
+        same(node),
+        reason: 'a cyclic return type must not be a second copy of the class',
       );
-      expect(leaf.methods.map((m) => m.originalName), contains('parent'));
-      expect(branch.methods.map((m) => m.originalName), contains('firstLeaf'));
+      expect(returnedClass(leaf, 'parent'), same(branch));
+      expect(returnedClass(branch, 'firstLeaf'), same(leaf));
     });
   });
 }

--- a/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:ffigen/ffigen.dart';
 import 'package:ffigen/src/code_generator.dart' as cg;
 import 'package:ffigen/src/header_parser.dart' as parser;

--- a/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/cpp_cyclic_class_test.dart
@@ -26,7 +26,7 @@ void main() {
                   absPath('test/header_parser_tests/cpp_cyclic_class.h'),
                 ),
               ],
-              compilerOptions: const [
+              compilerOptions: [
                 '-x',
                 'c++',
                 '-std=c++17',


### PR DESCRIPTION
## Description

When a C++ class member signature referenced the class itself (or another
class in a reference cycle), the header parser re-entered
`parseClassDeclaration` for a class still being parsed and recursed until
the stack was exhausted.

This change registers the `CppClass` in the seen-bindings index *before*
parsing its methods and bases, so a re-entrant lookup returns the
partially-constructed binding instead of recursing. Members only need the
class's identity, so filling in methods and bases afterwards is safe.

Adds a test header with self-referencing, mutually-referencing, and
inheritance-cycle classes, plus tests covering them.

## Related Issues

No linked issue

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [x] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [ ] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [ ] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
