### PR TITLE
[ffigen][jnigen] Clean up dartdoc categories

### DIFF
--- a/pkgs/ffigen/dartdoc_options.yaml
+++ b/pkgs/ffigen/dartdoc_options.yaml
@@ -1,5 +1,36 @@
 dartdoc:
   categories:
-    Errors:
+    "Apple APIs":
+      markdown: doc/apple_apis.md
+      name: Generating bindings for Apple APIs
+    "Objective-C Memory Management":
+      markdown: doc/objc_gc.md
+      name: Objective-C memory management considerations
+    "Objective-C Method Filtering":
+      markdown: doc/objc_method_filtering.md
+      name: Objective-C method filtering
+    "Dealing with OS Differences":
+      markdown: doc/objc_os_differences.md
+      name: Dealing with OS differences
+    "Objective-C Runtime Types":
+      markdown: doc/objc_runtime_types.md
+      name: Runtime type checks in Objective-C
+    "Objective-C Threading":
+      markdown: doc/objc_threading.md
+      name: Objective-C threading considerations
+    "Errors":
       markdown: doc/errors.md
       name: Common errors in ffigen
+    "FAQ":
+      markdown: doc/faq.md
+      name: Frequently Asked Questions
+
+  categoryOrder:
+    - "Apple APIs"
+    - "Objective-C Memory Management"
+    - "Objective-C Method Filtering"
+    - "Dealing with OS Differences"
+    - "Objective-C Runtime Types"
+    - "Objective-C Threading"
+    - "Errors"
+    - "FAQ"

--- a/pkgs/ffigen/lib/ffigen.dart
+++ b/pkgs/ffigen/lib/ffigen.dart
@@ -8,8 +8,6 @@
 /// For most use cases the YAML based API is simpler. See
 /// https://pub.dev/packages/ffigen for details.
 ///
-/// {@category Errors}
-///
 /// @docImport 'src/config_provider.dart';
 library;
 

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -14,6 +14,15 @@ import 'public_ast.dart';
 
 /// The generator that generates bindings for `dart:ffi` from C and Objective-C
 /// headers.
+///
+/// {@category Apple APIs}
+/// {@category Objective-C Memory Management}
+/// {@category Objective-C Method Filtering}
+/// {@category Dealing with OS Differences}
+/// {@category Objective-C Runtime Types}
+/// {@category Objective-C Threading}
+/// {@category Errors}
+/// {@category FAQ}
 // TODO: Add a code snippet example.
 final class FfiGenerator {
   /// The configuration for header parsing of [FfiGenerator].

--- a/pkgs/jnigen/dartdoc_options.yaml
+++ b/pkgs/jnigen/dartdoc_options.yaml
@@ -11,7 +11,13 @@ dartdoc:
       name: Threading considerations
     "Interface Implementation":
       markdown: doc/interface_implementation.md
-      name: Interface implementation
+      name: Implementing Java interfaces from Dart
+    "Exceptions":
+      markdown: doc/exceptions.md
+      name: Handling Java Exceptions in Dart
+    "Java Runtime Types":
+      markdown: doc/java_runtime_types.md
+      name: Runtime type checks in Java (JNI)
     "Debugging":
       markdown: doc/debugging.md
       name: Debugging
@@ -21,6 +27,8 @@ dartdoc:
     - "Lifecycle"
     - "Threading"
     - "Interface Implementation"
+    - "Exceptions"
+    - "Java Runtime Types"
     - "Debugging"
 
   showUndocumentedCategories: true

--- a/pkgs/jnigen/example/kotlin_plugin/analysis_options.yaml
+++ b/pkgs/jnigen/example/kotlin_plugin/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
@@ -7,7 +8,6 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:flutter_lints/flutter.yaml
 
 # For additional information about configuring this file, see
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/kotlin_plugin/analysis_options.yaml
+++ b/pkgs/jnigen/example/kotlin_plugin/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # For additional information about configuring this file, see

--- a/pkgs/jnigen/example/kotlin_plugin/example/analysis_options.yaml
+++ b/pkgs/jnigen/example/kotlin_plugin/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/pkgs/jnigen/example/kotlin_plugin/example/analysis_options.yaml
+++ b/pkgs/jnigen/example/kotlin_plugin/example/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
@@ -7,7 +8,6 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/notification_plugin/analysis_options.yaml
+++ b/pkgs/jnigen/example/notification_plugin/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/pkgs/jnigen/example/notification_plugin/analysis_options.yaml
+++ b/pkgs/jnigen/example/notification_plugin/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
@@ -7,7 +8,6 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/notification_plugin/example/analysis_options.yaml
+++ b/pkgs/jnigen/example/notification_plugin/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/pkgs/jnigen/example/notification_plugin/example/analysis_options.yaml
+++ b/pkgs/jnigen/example/notification_plugin/example/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
@@ -7,7 +8,6 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/lib/jnigen.dart
+++ b/pkgs/jnigen/lib/jnigen.dart
@@ -5,11 +5,6 @@
 /// This library exports a high level programmatic API to JNIgen, the entry
 /// point of which is the [JniGenGenerator.generate] method on a [JniGenerator]
 /// object.
-/// {@category Java Differences}
-/// {@category Lifecycle}
-/// {@category Threading}
-/// {@category Interface Implementation}
-/// {@category Debugging}
 ///
 /// @docImport 'src/config/config.dart';
 /// @docImport 'src/generate_bindings.dart';

--- a/pkgs/jnigen/lib/src/config/config_types.dart
+++ b/pkgs/jnigen/lib/src/config/config_types.dart
@@ -374,6 +374,14 @@ void _validateClassName(String className) {
 }
 
 /// Configuration for JNIgen binding generation.
+///
+/// {@category Java Differences}
+/// {@category Lifecycle}
+/// {@category Threading}
+/// {@category Interface Implementation}
+/// {@category Exceptions}
+/// {@category Java Runtime Types}
+/// {@category Debugging}
 final class JniGenerator {
   JniGenerator({
     required this.input,


### PR DESCRIPTION
We're trying to use dartdoc topics/categories to surface our documentation in a prominent place in the pub.dev UI. But it's a bit of a hack and we're kind of misusing them. The main issue is that categories defined in the dartdoc_options.yaml are only shown in the UI if they're used in the library.

Currently we hack around this by applying them on the top level library, but that makes the library section look weird:

<img width="407" height="685" alt="image" src="https://github.com/user-attachments/assets/ea1daeff-a3e6-4091-a4e6-d643bd301ec3" />

Instead, I'm moving them to the top level config object. Then the side bar looks cleaner:

<img width="407" height="685" alt="image" src="https://github.com/user-attachments/assets/ee5c8840-858b-4bef-b44b-9b973f978f2c" />

The main downside of this approach is that the categories then appear as colorful tags on the top level config object. But IMO that's preferable to the old sidebar UI:

<img width="989" height="275" alt="image" src="https://github.com/user-attachments/assets/7407e016-7246-47e0-9889-a151e666fe65" />

The analysis options changes are unrelated. They're an automatic upgrade by the new version of flutter.

Filed https://github.com/dart-lang/sdk/issues/64139 to see if there's a better way.