### PR TITLE
[code_assets] [native_toolchain_c] Add arm64e

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0-wip
+
+- Added `Architecture.arm64e`.
+
 ## 2.0.0
 
 - Validate bundled dynamic libraries by reading their header: when the file is

--- a/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
@@ -20,6 +20,7 @@
           "enum": [
             "arm",
             "arm64",
+            "arm64e",
             "ia32",
             "riscv32",
             "riscv64",

--- a/pkgs/code_assets/lib/src/code_assets/architecture.dart
+++ b/pkgs/code_assets/lib/src/code_assets/architecture.dart
@@ -23,6 +23,10 @@ final class Architecture {
   /// The [AArch64](https://en.wikipedia.org/wiki/AArch64) architecture.
   static const Architecture arm64 = Architecture._('arm64');
 
+  /// The [arm64e](https://developer.apple.com/documentation/security/preparing-your-app-to-work-with-pointer-authentication)
+  /// architecture (ARM64 with pointer authentication).
+  static const Architecture arm64e = Architecture._('arm64e');
+
   /// The [IA-32](https://en.wikipedia.org/wiki/IA-32) architecture.
   static const Architecture ia32 = Architecture._('ia32');
 
@@ -39,6 +43,7 @@ final class Architecture {
   static const List<Architecture> values = [
     arm,
     arm64,
+    arm64e,
     ia32,
     riscv32,
     riscv64,

--- a/pkgs/code_assets/lib/src/code_assets/mach_o_validator.dart
+++ b/pkgs/code_assets/lib/src/code_assets/mach_o_validator.dart
@@ -41,12 +41,13 @@ final class MachOValidator implements NativeLibraryValidator {
   static const _cpuTypeX64 = 0x01000007;
   static const _cpuTypeArm = 0x0000000c;
   static const _cpuTypeArm64 = 0x0100000c;
+  static const _cpuSubtypeMask = 0xff000000;
+  static const _cpuSubtypeArm64e = 2;
 
-  // The magic number and the 32-bit field after it (the CPU type for a thin
-  // binary, or the slice count for a fat binary) occupy the first 8 bytes. The
-  // fat path re-reads the architecture entries from the file directly, so
-  // nothing past this is read from the header here.
-  static const _minLength = 8;
+  // The magic number, CPU type, and CPU subtype for a thin binary occupy the
+  // first 12 bytes. The fat path re-reads the architecture entries from the
+  // file directly, so nothing past this is read from the header here.
+  static const _minLength = 12;
 
   @override
   Future<NativeLibraryValidation> validate(
@@ -91,8 +92,9 @@ final class MachOValidator implements NativeLibraryValidator {
         return const NativeLibraryValidation.notRecognized();
       }
       final cpuType = data.getUint32(4, endian);
+      final cpuSubtype = data.getUint32(8, endian);
       return _checkArchitecture(
-        _architectureForCpuType(cpuType),
+        _architectureForCpu(cpuType: cpuType, cpuSubtype: cpuSubtype),
         cpuType,
         context.config.targetArchitecture,
       );
@@ -123,24 +125,27 @@ final class MachOValidator implements NativeLibraryValidator {
     }
     if (sliceCount > 1) return _multiArchitecture();
 
-    final cpuType = ByteData.sublistView(entries).getUint32(0, Endian.big);
+    final sliceData = ByteData.sublistView(entries);
+    final cpuType = sliceData.getUint32(0, Endian.big);
+    final cpuSubtype = sliceData.getUint32(4, Endian.big);
     return _checkArchitecture(
-      _architectureForCpuType(cpuType),
+      _architectureForCpu(cpuType: cpuType, cpuSubtype: cpuSubtype),
       cpuType,
       target,
     );
   }
 
-  static Architecture? _architectureForCpuType(
-    int cpuType,
-  ) => switch (cpuType) {
+  static Architecture? _architectureForCpu({
+    required int cpuType,
+    required int cpuSubtype,
+  }) => switch (cpuType) {
     _cpuTypeX86 => Architecture.ia32,
     _cpuTypeX64 => Architecture.x64,
     _cpuTypeArm => Architecture.arm,
-    // arm64e uses CPU_TYPE_ARM64 and identifies the ABI in cpusubtype. Until
-    // TODO(https://github.com/dart-lang/native/issues/3379) reads that subtype,
-    // treat arm64e as arm64 rather than claiming to validate its ABI.
-    _cpuTypeArm64 => Architecture.arm64,
+    _cpuTypeArm64 =>
+      (cpuSubtype & ~_cpuSubtypeMask) == _cpuSubtypeArm64e
+          ? Architecture.arm64e
+          : Architecture.arm64,
     _ => null,
   };
 

--- a/pkgs/code_assets/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/code_assets/lib/src/code_assets/syntax.g.dart
@@ -45,6 +45,8 @@ class ArchitectureSyntax {
 
   static const arm64 = ArchitectureSyntax._('arm64');
 
+  static const arm64e = ArchitectureSyntax._('arm64e');
+
   static const ia32 = ArchitectureSyntax._('ia32');
 
   static const riscv32 = ArchitectureSyntax._('riscv32');
@@ -56,6 +58,7 @@ class ArchitectureSyntax {
   static const List<ArchitectureSyntax> values = [
     arm,
     arm64,
+    arm64e,
     ia32,
     riscv32,
     riscv64,

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling native code
   with Dart packages.
 
-version: 2.0.0
+version: 2.1.0-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 

--- a/pkgs/code_assets/test/code_assets/asset_test.dart
+++ b/pkgs/code_assets/test/code_assets/asset_test.dart
@@ -159,4 +159,11 @@ void main() {
     final current = Architecture.current;
     expect(current.toString(), Abi.current().toString().split('_')[1]);
   });
+
+  test('Architecture arm64e', () async {
+    expect(Architecture.arm64e.name, 'arm64e');
+    expect(Architecture.arm64e.toString(), 'arm64e');
+    expect(Architecture.fromString('arm64e'), Architecture.arm64e);
+    expect(Architecture.values, contains(Architecture.arm64e));
+  });
 }

--- a/pkgs/code_assets/test/code_assets/validation_architecture_test.dart
+++ b/pkgs/code_assets/test/code_assets/validation_architecture_test.dart
@@ -159,6 +159,54 @@ void main() {
       expect(records, isEmpty);
     });
 
+    test('thin arm64e matches macOS arm64e', () async {
+      final (errors, records) = await validate(
+        machOHeader(cpuType: 0x0100000c, cpuSubtype: 2),
+        targetOS: OS.macOS,
+        targetArchitecture: Architecture.arm64e,
+      );
+      expect(errors, isEmpty);
+      expect(records, isEmpty);
+    });
+
+    test('thin arm64e with PAC flags matches macOS arm64e', () async {
+      final (errors, records) = await validate(
+        machOHeader(cpuType: 0x0100000c, cpuSubtype: 0x80000002),
+        targetOS: OS.macOS,
+        targetArchitecture: Architecture.arm64e,
+      );
+      expect(errors, isEmpty);
+      expect(records, isEmpty);
+    });
+
+    test('thin arm64 mismatches macOS arm64e', () async {
+      final (errors, _) = await validate(
+        machOHeader(cpuType: 0x0100000c, cpuSubtype: 0),
+        targetOS: OS.macOS,
+        targetArchitecture: Architecture.arm64e,
+      );
+      expect(
+        errors,
+        contains(
+          contains('is built for arm64, but the target architecture is arm64e'),
+        ),
+      );
+    });
+
+    test('thin arm64e mismatches macOS arm64', () async {
+      final (errors, _) = await validate(
+        machOHeader(cpuType: 0x0100000c, cpuSubtype: 2),
+        targetOS: OS.macOS,
+        targetArchitecture: Architecture.arm64,
+      );
+      expect(
+        errors,
+        contains(
+          contains('is built for arm64e, but the target architecture is arm64'),
+        ),
+      );
+    });
+
     test('thin x64 mismatches macOS arm64', () async {
       final (errors, _) = await validate(
         machOHeader(cpuType: 0x01000007),
@@ -193,6 +241,16 @@ void main() {
         targetArchitecture: Architecture.arm64,
       );
       expect(errors, contains(contains('is built for x64')));
+    });
+
+    test('fat arm64e matches iOS arm64e', () async {
+      final (errors, records) = await validate(
+        machOFatHeader(cpuTypes: [0x0100000c], cpuSubtypes: [2]),
+        targetOS: OS.iOS,
+        targetArchitecture: Architecture.arm64e,
+      );
+      expect(errors, isEmpty);
+      expect(records, isEmpty);
     });
   });
 
@@ -340,24 +398,33 @@ Uint8List elfHeader({
   return bytes;
 }
 
-/// A minimal 32-byte thin Mach-O header with [cpuType] after the magic.
-Uint8List machOHeader({required int cpuType, bool littleEndian = true}) {
+/// A minimal 32-byte thin Mach-O header with [cpuType] and [cpuSubtype].
+Uint8List machOHeader({
+  required int cpuType,
+  int cpuSubtype = 0,
+  bool littleEndian = true,
+}) {
   final bytes = Uint8List(32);
   final data = bytes.buffer.asByteData();
   final endian = littleEndian ? Endian.little : Endian.big;
   data.setUint32(0, 0xfeedfacf, endian);
   data.setUint32(4, cpuType, endian);
+  data.setUint32(8, cpuSubtype, endian);
   return bytes;
 }
 
 /// A minimal big-endian fat Mach-O header with one slice per cpu type.
-Uint8List machOFatHeader({required List<int> cpuTypes}) {
+Uint8List machOFatHeader({
+  required List<int> cpuTypes,
+  List<int>? cpuSubtypes,
+}) {
   final bytes = Uint8List(8 + cpuTypes.length * 20);
   final data = bytes.buffer.asByteData();
   data.setUint32(0, 0xcafebabe);
   data.setUint32(4, cpuTypes.length);
   for (var slice = 0; slice < cpuTypes.length; slice++) {
     data.setUint32(8 + slice * 20, cpuTypes[slice]);
+    data.setUint32(8 + slice * 20 + 4, cpuSubtypes?[slice] ?? 0);
   }
   return bytes;
 }

--- a/pkgs/hooks_runner/test_data/wrong_architecture_asset/hook/build.dart
+++ b/pkgs/hooks_runner/test_data/wrong_architecture_asset/hook/build.dart
@@ -11,7 +11,7 @@ void main(List<String> arguments) async {
     final codeConfig = input.config.code;
     final wrongArchitecture =
         codeConfig.targetArchitecture == Architecture.arm64
-        ? Architecture.x64
+        ? Architecture.arm64e
         : Architecture.arm64;
     final wrongInputBuilder = BuildInputBuilder()
       ..setupShared(

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.19.5-wip
 
+- Support `Architecture.arm64e` for macOS and iOS.
 - Access all file system state through a `package:file` `FileSystem`, exposed as
   an optional parameter on `CBuilder.run`, `CLinker.run`, `CLibrary.build`, and
   `CLibrary.link` (defaulting to `LocalFileSystem`), so file system access can be

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -527,6 +527,7 @@ class RunCBuilder {
 
   static final appleClangMacosTargetFlags = {
     Architecture.arm64: 'arm64-apple-darwin',
+    Architecture.arm64e: 'arm64e-apple-darwin',
     Architecture.x64: 'x86_64-apple-darwin',
   };
 
@@ -534,6 +535,10 @@ class RunCBuilder {
     Architecture.arm64: {
       IOSSdk.iPhoneOS: 'arm64-apple-ios',
       IOSSdk.iPhoneSimulator: 'arm64-apple-ios-simulator',
+    },
+    Architecture.arm64e: {
+      IOSSdk.iPhoneOS: 'arm64e-apple-ios',
+      IOSSdk.iPhoneSimulator: 'arm64e-apple-ios-simulator',
     },
     Architecture.x64: {IOSSdk.iPhoneSimulator: 'x86_64-apple-ios-simulator'},
   };

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -27,16 +27,21 @@ const name = 'add';
 ///
 /// | #   | Architecture | IOSSdk          | IOSVersion | Link Mode | Language    | Optimization Level |
 /// |-----|--------------|-----------------|------------|-----------|-------------|--------------------|
-/// | 1   | arm64        | iphoneos        | 16         | bundled   | c           | Os                 |
+/// | 1   | arm64        | iphoneos        | 16         | bundled   | objective c | Os                 |
 /// | 2   | arm64        | iphoneos        | 16         | static    | c           | unspecified        |
-/// | 3   | arm64        | iphoneos        | 17         | bundled   | c           | O3                 |
-/// | 4   | arm64        | iphonesimulator | 16         | static    | objective c | O0                 |
-/// | 5   | x64          | iphonesimulator | 17         | bundled   | objective c | O1                 |
-/// | 6   | x64          | iphonesimulator | 17         | static    | c           | O2                 |
+/// | 3   | arm64        | iphonesimulator | 16         | bundled   | objective c | O3                 |
+/// | 4   | arm64e       | iphoneos        | 17         | static    | c           | O2                 |
+/// | 5   | arm64e       | iphonesimulator | 17         | bundled   | objective c | O1                 |
+/// | 6   | x64          | iphonesimulator | 16         | static    | objective c | O0                 |
+/// | 7   | x64          | iphonesimulator | 17         | bundled   | c           | Os                 |
 final configurations =
     TestCaseSelector(
       dimensions: {
-        Architecture: [Architecture.arm64, Architecture.x64],
+        Architecture: [
+          Architecture.arm64,
+          Architecture.arm64e,
+          Architecture.x64,
+        ],
         IOSSdk: [IOSSdk.iPhoneOS, IOSSdk.iPhoneSimulator],
         IOSVersion: [
           IOSVersion.flutterHighestBestEffort,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -28,6 +28,7 @@ import '../helpers.dart';
 // Dont include 'mach-o' or 'Mach-O', different spelling is used.
 final objdumpFileFormat = {
   (OS.macOS, Architecture.arm64): 'arm64',
+  (OS.macOS, Architecture.arm64e): 'arm64',
   (OS.macOS, Architecture.x64): '64-bit x86-64',
   (OS.linux, Architecture.arm): 'elf32-littlearm',
   (OS.linux, Architecture.arm64): 'elf64-littleaarch64',
@@ -42,14 +43,16 @@ final objdumpFileFormat = {
 ///
 /// | #   | OS    | Architecture | Link Mode | Language    | Optimization Level |
 /// |-----|-------|--------------|-----------|-------------|--------------------|
-/// | 1   | linux | arm          | bundled   | c           | O2                 |
+/// | 1   | linux | arm          | bundled   | c           | Os                 |
 /// | 2   | linux | arm          | static    | c           | O0                 |
 /// | 3   | linux | arm64        | static    | c           | O2                 |
-/// | 4   | linux | ia32         | bundled   | c           | Os                 |
-/// | 5   | linux | ia32         | static    | c           | O1                 |
-/// | 6   | linux | x64          | static    | c           | unspecified        |
-/// | 7   | macos | arm64        | bundled   | c           | O3                 |
-/// | 8   | macos | x64          | bundled   | objective c | O1                 |
+/// | 4   | linux | ia32         | bundled   | c           | O3                 |
+/// | 5   | linux | ia32         | static    | c           | O0                 |
+/// | 6   | linux | x64          | static    | c           | O1                 |
+/// | 7   | macos | arm64        | bundled   | c           | unspecified        |
+/// | 8   | macos | arm64e       | bundled   | objective c | O1                 |
+/// | 9   | macos | arm64e       | static    | c           | O3                 |
+/// | 10  | macos | x64          | bundled   | c           | O3                 |
 final configurations =
     TestCaseSelector(
       dimensions: {
@@ -57,6 +60,7 @@ final configurations =
         Architecture: [
           Architecture.arm,
           Architecture.arm64,
+          Architecture.arm64e,
           Architecture.ia32,
           Architecture.x64,
           // Risc-V not supported by Apple Clang right now.

--- a/pkgs/native_toolchain_c/test/clinker/rust_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/rust_test.dart
@@ -47,6 +47,9 @@ Future<void> main() async {
           targetOS: targetOS,
           targetArchitecture: targetArchitecture,
           linkModePreference: LinkModePreference.dynamic,
+          macOS: targetOS == OS.macOS
+              ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+              : null,
         ),
       );
 

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_cross_ios_test.dart
@@ -22,13 +22,18 @@ const targetOS = OS.iOS;
 /// | #   | Architecture | IOSSdk          | IOSVersion |
 /// |-----|--------------|-----------------|------------|
 /// | 1   | arm64        | iphoneos        | 16         |
-/// | 2   | arm64        | iphoneos        | 17         |
-/// | 3   | arm64        | iphonesimulator | 16         |
-/// | 4   | x64          | iphonesimulator | 17         |
+/// | 2   | arm64        | iphonesimulator | 17         |
+/// | 3   | arm64e       | iphoneos        | 17         |
+/// | 4   | arm64e       | iphonesimulator | 17         |
+/// | 5   | x64          | iphonesimulator | 16         |
 final configurations =
     TestCaseSelector(
       dimensions: {
-        Architecture: [Architecture.arm64, Architecture.x64],
+        Architecture: [
+          Architecture.arm64,
+          Architecture.arm64e,
+          Architecture.x64,
+        ],
         IOSSdk: [IOSSdk.iPhoneOS, IOSSdk.iPhoneSimulator],
         IOSVersion: [
           IOSVersion.flutterHighestBestEffort,

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -398,12 +398,14 @@ final objdumpFileFormatAndroid = {
 
 final objdumpFileFormatMacOS = {
   Architecture.arm64: 'mach-o arm64',
+  Architecture.arm64e: 'mach-o arm64',
   Architecture.x64: 'mach-o 64-bit x86-64',
 };
 
 // Don't include 'mach-o' or 'Mach-O', different spelling is used.
 final objdumpFileFormatIOS = {
   Architecture.arm64: 'arm64',
+  Architecture.arm64e: 'arm64',
   Architecture.x64: '64-bit x86-64',
 };
 
@@ -521,7 +523,7 @@ Future<void> expectMachineArchitecture(
 }
 
 List<Architecture> supportedArchitecturesFor(OS targetOS) => switch (targetOS) {
-  .macOS || .iOS => [.arm64, .x64],
+  .macOS || .iOS => [.arm64, .arm64e, .x64],
   .windows => [
     // TODO(https://github.com/dart-lang/native/issues/170): Support arm64.
     // Architecture.arm64,

--- a/pkgs/objective_c/hook/build.dart
+++ b/pkgs/objective_c/hook/build.dart
@@ -219,6 +219,7 @@ String toTargetTriple(CodeConfig codeConfig) {
 
 final appleClangMacosTargetFlags = {
   Architecture.arm64: 'arm64-apple-darwin',
+  Architecture.arm64e: 'arm64e-apple-darwin',
   Architecture.x64: 'x86_64-apple-darwin',
 };
 
@@ -226,6 +227,10 @@ final appleClangIosTargetFlags = {
   Architecture.arm64: {
     IOSSdk.iPhoneOS: 'arm64-apple-ios',
     IOSSdk.iPhoneSimulator: 'arm64-apple-ios-simulator',
+  },
+  Architecture.arm64e: {
+    IOSSdk.iPhoneOS: 'arm64e-apple-ios',
+    IOSSdk.iPhoneSimulator: 'arm64e-apple-ios-simulator',
   },
   Architecture.x64: {IOSSdk.iPhoneSimulator: 'x86_64-apple-ios-simulator'},
 };

--- a/pkgs/objective_c/hook/build.dart
+++ b/pkgs/objective_c/hook/build.dart
@@ -65,15 +65,11 @@ void main(List<String> args) async {
     final sysroot = sdkPath(codeConfig);
     final minVersion = minOSVersion(codeConfig);
 
-    // TODO(https://github.com/flutter/flutter/issues/186856): Remove this
-    // workaround and just use -target. Atm this is necessary for AOT testing.
-    final useArm64e =
-        testMode && codeConfig.targetArchitecture == Architecture.arm64;
-
     final cFlags = <String>[
       '-isysroot',
       sysroot,
-      if (useArm64e) ...['-arch', 'arm64e'] else ...['-target', target],
+      '-target',
+      target,
       minVersion,
     ];
     final mFlags = [...cFlags, ...objCFlags];
@@ -219,6 +215,7 @@ String toTargetTriple(CodeConfig codeConfig) {
 
 final appleClangMacosTargetFlags = {
   Architecture.arm64: 'arm64-apple-darwin',
+  Architecture.arm64e: 'arm64e-apple-darwin',
   Architecture.x64: 'x86_64-apple-darwin',
 };
 
@@ -226,6 +223,10 @@ final appleClangIosTargetFlags = {
   Architecture.arm64: {
     IOSSdk.iPhoneOS: 'arm64-apple-ios',
     IOSSdk.iPhoneSimulator: 'arm64-apple-ios-simulator',
+  },
+  Architecture.arm64e: {
+    IOSSdk.iPhoneOS: 'arm64e-apple-ios',
+    IOSSdk.iPhoneSimulator: 'arm64e-apple-ios-simulator',
   },
   Architecture.x64: {IOSSdk.iPhoneSimulator: 'x86_64-apple-ios-simulator'},
 };

--- a/pkgs/objective_c/hook/build.dart
+++ b/pkgs/objective_c/hook/build.dart
@@ -65,11 +65,15 @@ void main(List<String> args) async {
     final sysroot = sdkPath(codeConfig);
     final minVersion = minOSVersion(codeConfig);
 
+    // TODO(https://github.com/flutter/flutter/issues/186856): Remove this
+    // workaround and just use -target. Atm this is necessary for AOT testing.
+    final useArm64e =
+        testMode && codeConfig.targetArchitecture == Architecture.arm64;
+
     final cFlags = <String>[
       '-isysroot',
       sysroot,
-      '-target',
-      target,
+      if (useArm64e) ...['-arch', 'arm64e'] else ...['-target', target],
       minVersion,
     ];
     final mFlags = [...cFlags, ...objCFlags];
@@ -215,7 +219,6 @@ String toTargetTriple(CodeConfig codeConfig) {
 
 final appleClangMacosTargetFlags = {
   Architecture.arm64: 'arm64-apple-darwin',
-  Architecture.arm64e: 'arm64e-apple-darwin',
   Architecture.x64: 'x86_64-apple-darwin',
 };
 
@@ -223,10 +226,6 @@ final appleClangIosTargetFlags = {
   Architecture.arm64: {
     IOSSdk.iPhoneOS: 'arm64-apple-ios',
     IOSSdk.iPhoneSimulator: 'arm64-apple-ios-simulator',
-  },
-  Architecture.arm64e: {
-    IOSSdk.iPhoneOS: 'arm64e-apple-ios',
-    IOSSdk.iPhoneSimulator: 'arm64e-apple-ios-simulator',
   },
   Architecture.x64: {IOSSdk.iPhoneSimulator: 'x86_64-apple-ios-simulator'},
 };


### PR DESCRIPTION
Bug:

* https://github.com/dart-lang/native/issues/3379

This PR.

* Adds the architecture to the code assets package for the protocol.
* Consume it in native_toolchain_c`.
* Validates the mach-o headers in the protocol.
* And changes the macho validator test to test against arm64 arm64e mismatch.