### PR TITLE
[jnigen] Little bits of cleanup

### DIFF
--- a/pkgs/jni/tool/generate_jni_bindings.dart
+++ b/pkgs/jni/tool/generate_jni_bindings.dart
@@ -74,7 +74,7 @@ Future<void> main() async {
 // ignore_for_file: prefer_relative_imports''';
 
   final packageRoot = Platform.script.resolve('..');
-  await JniGenerator(
+  final generator = JniGenerator(
     input: Input(
       classes: classes,
       androidSdk: AndroidSdk(
@@ -92,5 +92,6 @@ Future<void> main() async {
     ),
     imports: SymbolImports(hide: classes),
     visitors: [Renamer()],
-  ).generate();
+  );
+  await generator.generate();
 }

--- a/pkgs/jni/tool/generate_jni_bindings.dart
+++ b/pkgs/jni/tool/generate_jni_bindings.dart
@@ -21,8 +21,8 @@ const Map<String, String> _constructorAllowList = {
   'Short': 's',
 };
 
-base class Renamer extends Visitor {
-  Renamer() : super.base();
+base class _JniRenamer extends Visitor {
+  _JniRenamer() : super.base();
 
   ClassDecl? _currentClass;
 
@@ -91,7 +91,7 @@ Future<void> main() async {
       generateStubs: false,
     ),
     imports: SymbolImports(hide: classes),
-    visitors: [Renamer()],
+    visitors: [_JniRenamer()],
   );
   await generator.generate();
 }

--- a/pkgs/jni_flutter/tool/generate_jni_bindings.dart
+++ b/pkgs/jni_flutter/tool/generate_jni_bindings.dart
@@ -15,7 +15,7 @@ Future<void> main() async {
 // ignore_for_file: prefer_relative_imports''';
 
   final packageRoot = Platform.script.resolve('..');
-  await JniGenerator(
+  final generator = JniGenerator(
     input: Input(
       classes: ['com.github.dart_lang.jni_flutter.JniFlutterPlugin'],
       androidSdk: AndroidSdk(
@@ -31,5 +31,6 @@ Future<void> main() async {
       preamble: preamble,
       generateStubs: false,
     ),
-  ).generate();
+  );
+  await generator.generate();
 }

--- a/pkgs/jnigen/README.md
+++ b/pkgs/jnigen/README.md
@@ -68,7 +68,7 @@ instructions.
 
    void main(List<String> args) async {
      final packageRoot = Platform.script.resolve('../');
-     await JniGenerator(
+     final generator = JniGenerator(
        input: Input(
          // Required. List of classes or packages for which bindings should be generated.
          classes: ['com.example.in_app_java'],
@@ -85,7 +85,8 @@ instructions.
            structure: OutputStructure.singleFile,
          ),
        ),
-     ).generate();
+     );
+     await generator.generate();
    }
    ```
 

--- a/pkgs/jnigen/example/in_app_java/tool/jnigen.dart
+++ b/pkgs/jnigen/example/in_app_java/tool/jnigen.dart
@@ -4,7 +4,7 @@ import 'package:jnigen/jnigen.dart';
 
 void main(List<String> args) async {
   final packageRoot = Platform.script.resolve('../');
-  await JniGenerator(
+  final generator = JniGenerator(
     input: Input(
       sourcePath: [packageRoot.resolve('android/app/src/main/java')],
       classes: [
@@ -24,5 +24,6 @@ void main(List<String> args) async {
         structure: OutputStructure.singleFile,
       ),
     ),
-  ).generate();
+  );
+  await generator.generate();
 }

--- a/pkgs/jnigen/example/maven_libs/tool/generate_bindings.dart
+++ b/pkgs/jnigen/example/maven_libs/tool/generate_bindings.dart
@@ -9,7 +9,7 @@ import 'package:logging/logging.dart';
 
 void main() async {
   final packageRoot = Platform.script.resolve('../');
-  await JniGenerator(
+  final generator = JniGenerator(
     input: Input(
       classes: ['com.google.gson.Gson', 'okhttp3.OkHttpClient'],
       androidSdk: AndroidSdk(
@@ -23,5 +23,6 @@ void main() async {
         structure: OutputStructure.singleFile,
       ),
     ),
-  ).generate();
+  );
+  await generator.generate();
 }

--- a/pkgs/jnigen/example/maven_libs_groovy/tool/generate_bindings.dart
+++ b/pkgs/jnigen/example/maven_libs_groovy/tool/generate_bindings.dart
@@ -9,7 +9,7 @@ import 'package:logging/logging.dart';
 
 void main() async {
   final packageRoot = Platform.script.resolve('../');
-  await JniGenerator(
+  final generator = JniGenerator(
     input: Input(
       classes: ['com.google.gson.Gson', 'okhttp3.OkHttpClient'],
       androidSdk: AndroidSdk(
@@ -23,5 +23,6 @@ void main() async {
         structure: OutputStructure.singleFile,
       ),
     ),
-  ).generate();
+  );
+  await generator.generate();
 }

--- a/pkgs/jnigen/test/jackson_core_test/generate.dart
+++ b/pkgs/jnigen/test/jackson_core_test/generate.dart
@@ -30,7 +30,6 @@ const deps = ['com.fasterxml.jackson.core:jackson-core:2.13.4'];
 JniGenerator getConfig({
   String? root,
   bool generateFullVersion = false,
-  bool useAsm = false,
   SummarizerBackend? backend,
 }) {
   final rootDir = root ?? thirdPartyDir;
@@ -48,7 +47,7 @@ JniGenerator getConfig({
         sourceDir: Uri.directory(join(thirdPartyDir, 'java')),
         jarDir: Uri.directory(join(thirdPartyDir, 'jar')),
       ),
-      backend: backend ?? (useAsm ? SummarizerBackend.asm : null),
+      backend: backend,
     ),
     output: Output(
       dart: DartOutput(

--- a/pkgs/jnigen/test/jackson_core_test/generated_files_test.dart
+++ b/pkgs/jnigen/test/jackson_core_test/generated_files_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:jnigen/jnigen.dart';
 import 'package:test/test.dart';
 
 import '../test_util/test_util.dart';
@@ -22,7 +23,10 @@ void main() async {
   }, timeout: const Timeout(Duration(minutes: 2)), tags: largeTestTag);
 
   test('generate and analyze bindings using ASM', () async {
-    final config = getConfig(generateFullVersion: true, useAsm: true);
+    final config = getConfig(
+      generateFullVersion: true,
+      backend: SummarizerBackend.asm,
+    );
     await generateAndAnalyzeBindings(config);
   }, timeout: const Timeout(Duration(minutes: 2)), tags: largeTestTag);
 }

--- a/pkgs/jnigen/test/large_java_test/large_java_test.dart
+++ b/pkgs/jnigen/test/large_java_test/large_java_test.dart
@@ -38,7 +38,7 @@ Future<void> main() async {
 
     // Run JNIgen.
     final thisDir = Uri.directory(p.join(pkgDir, 'test', 'large_java_test'));
-    await JniGenerator(
+    final generator = JniGenerator(
       input: Input(
         sourcePath: [thisDir.resolve('java/')],
         classes: ['com.example'],
@@ -49,7 +49,8 @@ Future<void> main() async {
           structure: OutputStructure.singleFile,
         ),
       ),
-    ).generate();
+    );
+    await generator.generate();
 
     // Check for diffs.
     final expPath =

--- a/pkgs/jnigen/test/summary_generation_test.dart
+++ b/pkgs/jnigen/test/summary_generation_test.dart
@@ -59,7 +59,6 @@ Future<void> createJar({
 final random = Random.secure();
 
 void testSuccessCase(String description, JniGenerator config) {
-  config.input.classes = summarizerClassesSpec;
   test(description, () async {
     final classes = await getSummary(config);
     expectSummaryHasAllClasses(classes);
@@ -70,9 +69,9 @@ void testFailureCase(
     String description, JniGenerator config, String nonExistingClass) {
   test(description, () async {
     final insertPosition = random.nextInt(config.input.classes.length + 1);
-    config.input.classes = summarizerClassesSpec.sublist(0, insertPosition) +
+    config.input.classes = config.input.classes.sublist(0, insertPosition) +
         [nonExistingClass] +
-        summarizerClassesSpec.sublist(insertPosition);
+        config.input.classes.sublist(insertPosition);
     try {
       await getSummary(config);
     } on SummaryParseException catch (e) {

--- a/pkgs/jnigen/test/test_util/summary_util.dart
+++ b/pkgs/jnigen/test/test_util/summary_util.dart
@@ -32,23 +32,18 @@ final javaFiles = findFilesWithSuffix(simplePackageDir, '.java');
 /// All Java classes in simple_package_test/java
 final javaClasses = javaFiles.map(getClassNameFromPath).toList();
 
-// Remove individual class listings from one package,
-// and add the package name instead, for testing.
-
-const removalPackageForSummaryTests = 'com.github.dart_lang.jnigen.pkg2';
-
-/// List of FQNs passed to summarizer for simple_package_test.
-final summarizerClassesSpec = [
-  ...javaClasses.where((e) => !e.startsWith('$removalPackageForSummaryTests.')),
-  removalPackageForSummaryTests,
-];
-
 JniGenerator getSummaryGenerationConfig(
     {List<String>? sourcePath, List<String>? classPath}) {
+  const removalPackageForSummaryTests = 'com.github.dart_lang.jnigen.pkg2';
   return JniGenerator(
     input: Input(
-      // Make a defensive copy of class list, if some test mutates the list...
-      classes: summarizerClassesSpec.toList(),
+      // Remove individual class listings from one package,
+      // and add the package name instead, for testing.
+      classes: [
+        ...javaClasses
+            .where((e) => !e.startsWith('$removalPackageForSummaryTests.')),
+        removalPackageForSummaryTests,
+      ],
       sourcePath: sourcePath?.map(Uri.file).toList() ?? const [],
       classPath: classPath?.map(Uri.file).toList() ?? const [],
     ),


### PR DESCRIPTION
Daco's feedback from https://github.com/dart-lang/native/issues/3596, except migrating all the YAML configs.

- Move `await` next to `generate()`
- Make `Renamer` private
- Remove `useAsm`
- Inline some bits into `getSummaryGenerationConfig`
