### PR TITLE
[jnigen] Expose editable documentation on the visitor API #3496

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.0.0-wip
 
+- Expose editable documentation on the visitor API for classes, methods,
+  fields, and parameters.
 - **Breaking Change**: Restructured Dart `Config` API to align with
   `package:ffigen`. The YAML format has not changed.
   - Rename `Config` class to `JniGenerator`, matching FFIgen's approach.

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -15,11 +15,9 @@ import '../util/string_util.dart';
 import 'resolver.dart';
 import 'visitor.dart';
 
-JavaDocComment? _docsFor(JavaDocComment? original, String? userDefined) {
-  if (userDefined != null) {
-    return userDefined.isEmpty ? null : JavaDocComment(comment: userDefined);
-  }
-  return original;
+JavaDocComment? _docsFor(JavaDocComment? docs) {
+  if (docs == null || docs.comment.isEmpty) return null;
+  return docs;
 }
 
 /// Version of jnigen. Keep in sync with `pubspec.yaml` removing the `-wip`
@@ -443,8 +441,7 @@ ${modifier}final $classRef = $_jni.JClass.forName(r'$internalName');
     }
     // Docs.
     s.write('/// from: `${node.binaryName}`\n');
-    _docsFor(node.javadoc, node.userDefinedJavadoc)
-        ?.accept(_DocGenerator(s, depth: 0));
+    _docsFor(node.javadoc)?.accept(_DocGenerator(s, depth: 0));
 
     // Class definition.
     final name = node.finalName;
@@ -676,8 +673,7 @@ final class _$interfaceMixinName$typeParamsDef with $interfaceMixinName$typePara
 /// $javaName in your config's classes list.
 ///
 ''');
-    _docsFor(node.javadoc, node.userDefinedJavadoc)
-        ?.accept(_DocGenerator(s, depth: 0));
+    _docsFor(node.javadoc)?.accept(_DocGenerator(s, depth: 0));
 
     final superName = node.superclass!.accept(
       _TypeGenerator(resolver, includeNullability: false),
@@ -1127,8 +1123,7 @@ ${modifier}final _id_$name =
     if (node.type is! PrimitiveType && writeReleaseInstructions) {
       s.writeln(_releaseInstruction);
     }
-    _docsFor(node.javadoc, node.userDefinedJavadoc)
-        ?.accept(_DocGenerator(s, depth: 1));
+    _docsFor(node.javadoc)?.accept(_DocGenerator(s, depth: 1));
   }
 
   @override
@@ -1294,8 +1289,7 @@ ${modifier}final _$idName = $_protectedExtension
     if (node.returnType is! PrimitiveType || node.isConstructor) {
       s.writeln(_releaseInstruction);
     }
-    _docsFor(node.javadoc, node.userDefinedJavadoc)
-        ?.accept(_DocGenerator(s, depth: 1));
+    _docsFor(node.javadoc)?.accept(_DocGenerator(s, depth: 1));
 
     // This is needed to keep the references alive in the scope while waiting
     // for the FFI call.
@@ -1352,10 +1346,9 @@ ${modifier}final _$idName = $_protectedExtension
     }
     final params = defArgs.delimited(', ');
     if (node.isDeprecated) {
-      final message =
-          _docsFor(node.javadoc, node.userDefinedJavadoc)?.deprecatedMessage ??
-              node.javadoc?.deprecatedMessage ??
-              'This Java method is deprecated.';
+      final message = _docsFor(node.javadoc)?.deprecatedMessage ??
+          node.javadoc?.deprecatedMessage ??
+          'This Java method is deprecated.';
 
       s.writeln(
         "  @core\$_.Deprecated('${escapeDartString(message)}')",

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -15,6 +15,13 @@ import '../util/string_util.dart';
 import 'resolver.dart';
 import 'visitor.dart';
 
+JavaDocComment? _docsFor(JavaDocComment? original, String? userDefined) {
+  if (userDefined != null) {
+    return userDefined.isEmpty ? null : JavaDocComment(comment: userDefined);
+  }
+  return original;
+}
+
 /// Version of jnigen. Keep in sync with `pubspec.yaml` removing the `-wip`
 /// suffix.
 @visibleForTesting
@@ -436,7 +443,8 @@ ${modifier}final $classRef = $_jni.JClass.forName(r'$internalName');
     }
     // Docs.
     s.write('/// from: `${node.binaryName}`\n');
-    node.javadoc?.accept(_DocGenerator(s, depth: 0));
+    _docsFor(node.javadoc, node.userDefinedJavadoc)
+        ?.accept(_DocGenerator(s, depth: 0));
 
     // Class definition.
     final name = node.finalName;
@@ -668,7 +676,8 @@ final class _$interfaceMixinName$typeParamsDef with $interfaceMixinName$typePara
 /// $javaName in your config's classes list.
 ///
 ''');
-    node.javadoc?.accept(_DocGenerator(s, depth: 0));
+    _docsFor(node.javadoc, node.userDefinedJavadoc)
+        ?.accept(_DocGenerator(s, depth: 0));
 
     final superName = node.superclass!.accept(
       _TypeGenerator(resolver, includeNullability: false),
@@ -1118,7 +1127,8 @@ ${modifier}final _id_$name =
     if (node.type is! PrimitiveType && writeReleaseInstructions) {
       s.writeln(_releaseInstruction);
     }
-    node.javadoc?.accept(_DocGenerator(s, depth: 1));
+    _docsFor(node.javadoc, node.userDefinedJavadoc)
+        ?.accept(_DocGenerator(s, depth: 1));
   }
 
   @override
@@ -1284,7 +1294,8 @@ ${modifier}final _$idName = $_protectedExtension
     if (node.returnType is! PrimitiveType || node.isConstructor) {
       s.writeln(_releaseInstruction);
     }
-    node.javadoc?.accept(_DocGenerator(s, depth: 1));
+    _docsFor(node.javadoc, node.userDefinedJavadoc)
+        ?.accept(_DocGenerator(s, depth: 1));
 
     // This is needed to keep the references alive in the scope while waiting
     // for the FFI call.
@@ -1342,7 +1353,9 @@ ${modifier}final _$idName = $_protectedExtension
     final params = defArgs.delimited(', ');
     if (node.isDeprecated) {
       final message =
-          node.javadoc?.deprecatedMessage ?? 'This Java method is deprecated.';
+          _docsFor(node.javadoc, node.userDefinedJavadoc)?.deprecatedMessage ??
+              node.javadoc?.deprecatedMessage ??
+              'This Java method is deprecated.';
 
       s.writeln(
         "  @core\$_.Deprecated('${escapeDartString(message)}')",

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -111,10 +111,6 @@ class ClassDecl with ClassMember, Annotated implements Element<ClassDecl> {
   @JsonKey(includeFromJson: false)
   String? userDefinedInterfaceMixinName;
 
-  /// Populated by user-defined visitors. Empty string means no comment.
-  @JsonKey(includeFromJson: false)
-  String? userDefinedJavadoc;
-
   @override
   final Set<String> modifiers;
 
@@ -122,7 +118,7 @@ class ClassDecl with ClassMember, Annotated implements Element<ClassDecl> {
   List<Annotation>? annotations;
   final KotlinClass? kotlinClass;
   final KotlinPackage? kotlinPackage;
-  final JavaDocComment? javadoc;
+  JavaDocComment? javadoc;
   final DeclKind declKind;
   final String binaryName;
   List<TypeParam> typeParams;
@@ -719,7 +715,7 @@ class Method with ClassMember, Annotated implements Element<Method> {
   final Set<String> modifiers;
   @override
   List<Annotation>? annotations;
-  final JavaDocComment? javadoc;
+  JavaDocComment? javadoc;
   List<TypeParam> typeParams;
   List<Param> params;
   ReferredType returnType;
@@ -737,10 +733,6 @@ class Method with ClassMember, Annotated implements Element<Method> {
   /// Populated by user-defined visitors.
   @JsonKey(includeFromJson: false)
   String? userDefinedName;
-
-  /// Populated by user-defined visitors. Empty string means no comment.
-  @JsonKey(includeFromJson: false)
-  String? userDefinedJavadoc;
 
   /// Populated by [KotlinProcessor].
   @JsonKey(includeFromJson: false)
@@ -787,7 +779,9 @@ class Method with ClassMember, Annotated implements Element<Method> {
       annotations: [...?annotations],
       descriptor: descriptor,
       userDefinedIsIncluded: userDefinedIsIncluded,
-      javadoc: javadoc,
+      javadoc: javadoc == null
+          ? null
+          : JavaDocComment(comment: javadoc!.originalComment),
       modifiers: {...modifiers},
       params: params.map((param) => param.clone(until: until)).toList(),
       typeParams:
@@ -826,7 +820,7 @@ class Method with ClassMember, Annotated implements Element<Method> {
       case GenerationStage.userVisitors:
         cloned.userDefinedIsIncluded = userDefinedIsIncluded;
         cloned.userDefinedName = userDefinedName;
-        cloned.userDefinedJavadoc = userDefinedJavadoc;
+        cloned.javadoc?.userDefinedComment = javadoc?.userDefinedComment;
       case GenerationStage.unprocessed:
     }
     return cloned;
@@ -850,13 +844,9 @@ class Param with Annotated implements Element<Param> {
   @JsonKey(includeFromJson: false)
   String? userDefinedName;
 
-  /// Populated by user-defined visitors. Empty string means no comment.
-  @JsonKey(includeFromJson: false)
-  String? userDefinedJavadoc;
-
   @override
   List<Annotation>? annotations;
-  final JavaDocComment? javadoc;
+  JavaDocComment? javadoc;
 
   @override
   bool get isNullable => type.isNullable || super.hasNullable;
@@ -882,7 +872,9 @@ class Param with Annotated implements Element<Param> {
       name: name,
       type: type,
       annotations: [...?annotations],
-      javadoc: javadoc,
+      javadoc: javadoc == null
+          ? null
+          : JavaDocComment(comment: javadoc!.originalComment),
     );
     if (GenerationStage.linker <= until) {
       cloned.method = method;
@@ -890,8 +882,10 @@ class Param with Annotated implements Element<Param> {
     if (GenerationStage.renamer <= until) {
       cloned.finalName = finalName;
     }
-    cloned.userDefinedName = userDefinedName;
-    cloned.userDefinedJavadoc = userDefinedJavadoc;
+    if (GenerationStage.userVisitors <= until) {
+      cloned.userDefinedName = userDefinedName;
+      cloned.javadoc?.userDefinedComment = javadoc?.userDefinedComment;
+    }
     return cloned;
   }
 
@@ -919,10 +913,6 @@ class Field with ClassMember, Annotated implements Element<Field> {
   @JsonKey(includeFromJson: false)
   String? userDefinedName;
 
-  /// Populated by user-defined visitors. Empty string means no comment.
-  @JsonKey(includeFromJson: false)
-  String? userDefinedJavadoc;
-
   @override
   final String name;
   @override
@@ -930,7 +920,7 @@ class Field with ClassMember, Annotated implements Element<Field> {
 
   @override
   List<Annotation>? annotations;
-  final JavaDocComment? javadoc;
+  JavaDocComment? javadoc;
   final ReferredType type;
   final Object? defaultValue;
 
@@ -999,12 +989,24 @@ class TypeParam with Annotated implements Element<TypeParam> {
 
 @JsonSerializable(createToJson: false)
 class JavaDocComment implements Element<JavaDocComment> {
-  JavaDocComment({this.comment = ''});
+  JavaDocComment({String comment = ''}) : originalComment = comment;
 
-  final String comment;
+  final String originalComment;
 
-  String? get deprecatedMessage {
-    final lines = comment.split('\n');
+  /// Populated by user-defined visitors. Empty string means no comment.
+  @JsonKey(includeFromJson: false)
+  String? userDefinedComment;
+
+  String get comment => userDefinedComment ?? originalComment;
+
+  String? get deprecatedMessage =>
+      _deprecatedMessageFrom(comment) ??
+      (userDefinedComment != null
+          ? _deprecatedMessageFrom(originalComment)
+          : null);
+
+  static String? _deprecatedMessageFrom(String text) {
+    final lines = text.split('\n');
     final messageLines = <String>[];
     var readingDeprecatedTag = false;
 

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -111,6 +111,10 @@ class ClassDecl with ClassMember, Annotated implements Element<ClassDecl> {
   @JsonKey(includeFromJson: false)
   String? userDefinedInterfaceMixinName;
 
+  /// Populated by user-defined visitors. Empty string means no comment.
+  @JsonKey(includeFromJson: false)
+  String? userDefinedJavadoc;
+
   @override
   final Set<String> modifiers;
 
@@ -734,6 +738,10 @@ class Method with ClassMember, Annotated implements Element<Method> {
   @JsonKey(includeFromJson: false)
   String? userDefinedName;
 
+  /// Populated by user-defined visitors. Empty string means no comment.
+  @JsonKey(includeFromJson: false)
+  String? userDefinedJavadoc;
+
   /// Populated by [KotlinProcessor].
   @JsonKey(includeFromJson: false)
   KotlinFunction? kotlinFunction;
@@ -818,6 +826,7 @@ class Method with ClassMember, Annotated implements Element<Method> {
       case GenerationStage.userVisitors:
         cloned.userDefinedIsIncluded = userDefinedIsIncluded;
         cloned.userDefinedName = userDefinedName;
+        cloned.userDefinedJavadoc = userDefinedJavadoc;
       case GenerationStage.unprocessed:
     }
     return cloned;
@@ -840,6 +849,10 @@ class Param with Annotated implements Element<Param> {
 
   @JsonKey(includeFromJson: false)
   String? userDefinedName;
+
+  /// Populated by user-defined visitors. Empty string means no comment.
+  @JsonKey(includeFromJson: false)
+  String? userDefinedJavadoc;
 
   @override
   List<Annotation>? annotations;
@@ -877,6 +890,8 @@ class Param with Annotated implements Element<Param> {
     if (GenerationStage.renamer <= until) {
       cloned.finalName = finalName;
     }
+    cloned.userDefinedName = userDefinedName;
+    cloned.userDefinedJavadoc = userDefinedJavadoc;
     return cloned;
   }
 
@@ -903,6 +918,10 @@ class Field with ClassMember, Annotated implements Element<Field> {
 
   @JsonKey(includeFromJson: false)
   String? userDefinedName;
+
+  /// Populated by user-defined visitors. Empty string means no comment.
+  @JsonKey(includeFromJson: false)
+  String? userDefinedJavadoc;
 
   @override
   final String name;

--- a/pkgs/jnigen/lib/src/elements/j_elements.dart
+++ b/pkgs/jnigen/lib/src/elements/j_elements.dart
@@ -122,9 +122,11 @@ class ClassDecl implements _Element {
   /// Documentation that appears in the generated Dart.
   ///
   /// Starts as the original Javadoc, if any. Assign an empty string to omit it.
-  String get documentation =>
-      _classDecl.userDefinedJavadoc ?? _classDecl.javadoc?.comment ?? '';
-  set documentation(String value) => _classDecl.userDefinedJavadoc = value;
+  String get documentation => _classDecl.javadoc?.comment ?? '';
+  set documentation(String value) {
+    _classDecl.javadoc ??= ast.JavaDocComment();
+    _classDecl.javadoc!.userDefinedComment = value;
+  }
 
   @override
   void accept(Visitor visitor) {
@@ -163,9 +165,11 @@ class Method implements _Element {
   /// Documentation that appears in the generated Dart.
   ///
   /// Starts as the original Javadoc, if any. Assign an empty string to omit it.
-  String get documentation =>
-      _method.userDefinedJavadoc ?? _method.javadoc?.comment ?? '';
-  set documentation(String value) => _method.userDefinedJavadoc = value;
+  String get documentation => _method.javadoc?.comment ?? '';
+  set documentation(String value) {
+    _method.javadoc ??= ast.JavaDocComment();
+    _method.javadoc!.userDefinedComment = value;
+  }
 
   @override
   void accept(Visitor visitor) {
@@ -194,9 +198,11 @@ class Param implements _Element {
   /// Documentation that appears in the generated Dart.
   ///
   /// Starts as the original Javadoc, if any. Assign an empty string to omit it.
-  String get documentation =>
-      _param.userDefinedJavadoc ?? _param.javadoc?.comment ?? '';
-  set documentation(String value) => _param.userDefinedJavadoc = value;
+  String get documentation => _param.javadoc?.comment ?? '';
+  set documentation(String value) {
+    _param.javadoc ??= ast.JavaDocComment();
+    _param.javadoc!.userDefinedComment = value;
+  }
 
   @override
   void accept(Visitor visitor) {
@@ -225,9 +231,11 @@ class Field implements _Element {
   /// Documentation that appears in the generated Dart.
   ///
   /// Starts as the original Javadoc, if any. Assign an empty string to omit it.
-  String get documentation =>
-      _field.userDefinedJavadoc ?? _field.javadoc?.comment ?? '';
-  set documentation(String value) => _field.userDefinedJavadoc = value;
+  String get documentation => _field.javadoc?.comment ?? '';
+  set documentation(String value) {
+    _field.javadoc ??= ast.JavaDocComment();
+    _field.javadoc!.userDefinedComment = value;
+  }
 
   @override
   void accept(Visitor visitor) {

--- a/pkgs/jnigen/lib/src/elements/j_elements.dart
+++ b/pkgs/jnigen/lib/src/elements/j_elements.dart
@@ -119,6 +119,13 @@ class ClassDecl implements _Element {
   set interfaceMixinName(String? newName) =>
       _classDecl.userDefinedInterfaceMixinName = newName;
 
+  /// Documentation that appears in the generated Dart.
+  ///
+  /// Starts as the original Javadoc, if any. Assign an empty string to omit it.
+  String get documentation =>
+      _classDecl.userDefinedJavadoc ?? _classDecl.javadoc?.comment ?? '';
+  set documentation(String value) => _classDecl.userDefinedJavadoc = value;
+
   @override
   void accept(Visitor visitor) {
     visitor.visitClass(this);
@@ -153,6 +160,13 @@ class Method implements _Element {
   /// Whether this method is a constructor.
   bool get isConstructor => _method.isConstructor;
 
+  /// Documentation that appears in the generated Dart.
+  ///
+  /// Starts as the original Javadoc, if any. Assign an empty string to omit it.
+  String get documentation =>
+      _method.userDefinedJavadoc ?? _method.javadoc?.comment ?? '';
+  set documentation(String value) => _method.userDefinedJavadoc = value;
+
   @override
   void accept(Visitor visitor) {
     visitor.visitMethod(this);
@@ -177,6 +191,13 @@ class Param implements _Element {
   /// The original name of the parameter in Java.
   String get originalName => _param.name;
 
+  /// Documentation that appears in the generated Dart.
+  ///
+  /// Starts as the original Javadoc, if any. Assign an empty string to omit it.
+  String get documentation =>
+      _param.userDefinedJavadoc ?? _param.javadoc?.comment ?? '';
+  set documentation(String value) => _param.userDefinedJavadoc = value;
+
   @override
   void accept(Visitor visitor) {
     visitor.visitParam(this);
@@ -200,6 +221,13 @@ class Field implements _Element {
 
   /// The original name of the field in Java.
   String get originalName => _field.name;
+
+  /// Documentation that appears in the generated Dart.
+  ///
+  /// Starts as the original Javadoc, if any. Assign an empty string to omit it.
+  String get documentation =>
+      _field.userDefinedJavadoc ?? _field.javadoc?.comment ?? '';
+  set documentation(String value) => _field.userDefinedJavadoc = value;
 
   @override
   void accept(Visitor visitor) {

--- a/pkgs/jnigen/test/user_visitor_test.dart
+++ b/pkgs/jnigen/test/user_visitor_test.dart
@@ -371,7 +371,7 @@ void main() {
               comment: 'Original method.\n@deprecated Use other.',
             ),
             annotations: [
-              ast.Annotation(binaryName: 'java.lang.Deprecated'),
+              const ast.Annotation(binaryName: 'java.lang.Deprecated'),
             ],
           ),
           ast.Method(
@@ -426,14 +426,18 @@ void main() {
       ),
     );
 
-    expect(classes.decls['Foo']!.userDefinedJavadoc, 'Replacement class docs.');
-    expect(classes.decls['Foo']!.fields.single.userDefinedJavadoc, '');
     expect(
-      classes.decls['Foo']!.methods.first.userDefinedJavadoc,
+      classes.decls['Foo']!.javadoc?.userDefinedComment,
+      'Replacement class docs.',
+    );
+    expect(classes.decls['Foo']!.fields.single.javadoc?.userDefinedComment, '');
+    expect(
+      classes.decls['Foo']!.methods.first.javadoc?.userDefinedComment,
       'Custom method without the tag.',
     );
     expect(
-      classes.decls['Foo']!.methods[1].params.single.userDefinedJavadoc,
+      classes
+          .decls['Foo']!.methods[1].params.single.javadoc?.userDefinedComment,
       'times',
     );
 

--- a/pkgs/jnigen/test/user_visitor_test.dart
+++ b/pkgs/jnigen/test/user_visitor_test.dart
@@ -355,4 +355,115 @@ void main() {
       isNot(contains(r'abstract base mixin class $Foo')),
     );
   });
+
+  test('Edit documentation using the user visitor', () async {
+    final classes = ast.Classes({
+      'Foo': ast.ClassDecl(
+        binaryName: 'Foo',
+        declKind: ast.DeclKind.classKind,
+        superclass: ast.DeclaredType.object,
+        javadoc: ast.JavaDocComment(comment: 'Original class docs.'),
+        methods: [
+          ast.Method(
+            name: 'run',
+            returnType: ast.PrimitiveType.fromJson({'name': 'void'}),
+            javadoc: ast.JavaDocComment(
+              comment: 'Original method.\n@deprecated Use other.',
+            ),
+            annotations: [
+              ast.Annotation(binaryName: 'java.lang.Deprecated'),
+            ],
+          ),
+          ast.Method(
+            name: 'extra',
+            returnType: ast.PrimitiveType.fromJson({'name': 'void'}),
+            params: [
+              ast.Param(
+                name: 'n',
+                type: ast.PrimitiveType.fromJson({'name': 'int'}),
+                javadoc: ast.JavaDocComment(comment: 'count'),
+              ),
+            ],
+          ),
+        ],
+        fields: [
+          ast.Field(
+            name: 'value',
+            type: ast.DeclaredType.object,
+            javadoc: ast.JavaDocComment(comment: 'Original field.'),
+          ),
+        ],
+      ),
+    });
+
+    Classes(classes).accept(
+      Visitor(
+        classDecl: (c) {
+          expect(c.documentation, 'Original class docs.');
+          c.documentation = 'Replacement class docs.';
+        },
+        method: (method) {
+          if (method.originalName == 'run') {
+            expect(
+              method.documentation,
+              'Original method.\n@deprecated Use other.',
+            );
+            method.documentation = 'Custom method without the tag.';
+          }
+          if (method.originalName == 'extra') {
+            expect(method.documentation, '');
+            method.documentation = 'Inserted method docs.';
+          }
+        },
+        field: (field) {
+          expect(field.documentation, 'Original field.');
+          field.documentation = '';
+        },
+        param: (parameter) {
+          expect(parameter.documentation, 'count');
+          parameter.documentation = 'times';
+        },
+      ),
+    );
+
+    expect(classes.decls['Foo']!.userDefinedJavadoc, 'Replacement class docs.');
+    expect(classes.decls['Foo']!.fields.single.userDefinedJavadoc, '');
+    expect(
+      classes.decls['Foo']!.methods.first.userDefinedJavadoc,
+      'Custom method without the tag.',
+    );
+    expect(
+      classes.decls['Foo']!.methods[1].params.single.userDefinedJavadoc,
+      'times',
+    );
+
+    final tempDirectory = Directory.systemTemp.createTempSync(
+      'jnigen_docs_visitor_test_',
+    );
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+
+    final output = tempDirectory.uri.resolve('bindings.dart');
+    final config = JniGenerator(
+      input: Input(classes: []),
+      output: Output(
+        dart: DartOutput(
+          path: output,
+          structure: OutputStructure.singleFile,
+        ),
+      ),
+    );
+
+    await classes.accept(Linker(config));
+    classes.accept(Renamer(config));
+    await classes.accept(DartGenerator(config));
+
+    final content = File.fromUri(output).readAsStringSync();
+    expect(content, contains('Replacement class docs.'));
+    expect(content, isNot(contains('Original class docs.')));
+    expect(content, contains('Custom method without the tag.'));
+    expect(content, isNot(contains('Original method.')));
+    expect(content, contains('Inserted method docs.'));
+    expect(content, isNot(contains('Original field.')));
+    expect(content, contains("Deprecated('Use other.')"));
+  });
 }


### PR DESCRIPTION
## Description

The visitor API could rename or exclude members but not touch Javadoc. I exposed a `documentation` string on classes, methods, fields, and parameters so a visitor can replace, insert, or drop comments. If the new text has no `@deprecated` tag, the original one is still used for Dart `@Deprecated`.

## Related Issues

Fixes #3496

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [ ] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [ ] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
