### PR TITLE
[ffigen] Config cleanup

### DIFF
--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -34,6 +34,7 @@ final class FfiGenerator {
   ///
   /// **EXPERIMENTAL**: C++ support is experimental. This part of the API
   /// may change or be removed in a future version without a deprecation notice.
+  @experimental
   final Cpp? cpp;
 
   /// Objective-C specific configuration.
@@ -146,6 +147,7 @@ enum EnumStyle {
 }
 
 /// Configuration for C++.
+@experimental
 final class Cpp {
   const Cpp();
 }

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -15,6 +15,32 @@ import 'public_ast.dart';
 /// The generator that generates bindings for `dart:ffi` from C and Objective-C
 /// headers.
 ///
+/// At a minimum, you must specify the inputs, the outputs, and which APIs you
+/// want to generate bindings for (using visitors).
+///
+/// ### Example
+///
+/// ```dart
+/// import 'package:ffigen/ffigen.dart';
+///
+/// Future<void> main() async {
+///   final generator = FfiGenerator(
+///     output: Output(
+///       dart: DartOutput(path: Uri.file('lib/bindings.dart')),
+///     ),
+///     input: Input(
+///       entryPoints: [Uri.file('src/my_c_header.h')],
+///     ),
+///     visitors: [
+///       Visitor(
+///         func: (node) => node.isIncluded = true,
+///       ),
+///     ],
+///   );
+///   await generator.generate();
+/// }
+/// ```
+///
 /// {@category Apple APIs}
 /// {@category Objective-C Memory Management}
 /// {@category Objective-C Method Filtering}
@@ -23,7 +49,6 @@ import 'public_ast.dart';
 /// {@category Objective-C Threading}
 /// {@category Errors}
 /// {@category FAQ}
-// TODO: Add a code snippet example.
 final class FfiGenerator {
   /// The configuration for header parsing of [FfiGenerator].
   final Input input;

--- a/pkgs/ffigen/lib/src/config_provider/config_types.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config_types.dart
@@ -503,14 +503,45 @@ class Declaration {
   Declaration({required this.usr, required this.originalName});
 }
 
+/// Target OS version constraints for external platform APIs (such as
+/// Objective-C APIs).
+///
+/// Interfaces, methods, and other API elements in headers may include
+/// platform availability annotations indicating when they were introduced,
+/// deprecated, or obsoleted. If an API element is present in all target
+/// versions, it is generated normally. If it's present in some target versions,
+/// a runtime version check is generated. If it's not present in any target
+/// versions, the API element is not generated at all.
+///
+/// If all fields are `null`, no version based filtering is applied. If some
+/// fields are non-`null`, filtering is based on the the non-`null` fields.
 class ExternalVersions {
+  /// Target version range for iOS.
+  ///
+  /// If `null`, no version-based filtering is applied for iOS.
   final Versions? ios;
+
+  /// Target version range for macOS.
+  ///
+  /// If `null`, no version-based filtering is applied for macOS.
   final Versions? macos;
+
   const ExternalVersions({this.ios, this.macos});
 }
 
+/// Represents a version range constraint with an optional minimum and maximum
+/// version.
+///
+/// If [min] and [max] are both `null`, all versions are accepted.
 class Versions {
+  /// The minimum target OS version.
+  ///
+  /// If `null`, there is no minimum version floor.
   final Version? min;
+
+  /// The maximum target OS version.
+  ///
+  /// If `null`, there is no maximum version ceiling.
   final Version? max;
 
   const Versions({this.min, this.max});


### PR DESCRIPTION
Part of https://github.com/dart-lang/native/issues/3595

- Annotate `Cpp` as `@experimental`
- Add a minimal example to `FfiGenerator`'s dart doc, removing a TODO
- Document `ExternalVersions`