### PR TITLE
[objective_c] Don't abort the process when NSInputStream is read or closed after the Dart port is gone

### DIFF
--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 9.6.1-wip
+
+- Fix a crash in the `NSInputStream` returned by `toNSInputStream`: reading
+  from or closing the stream after its Dart side had already closed it raised
+  `NSInternalInconsistencyException` ("DartInputStreamAdapter:
+  Dart_PostCObject_DL failed") and aborted the process. `NSURLSession` does
+  exactly that with a request body stream when the request completes with an
+  error or is cancelled right after it starts. `close` is now idempotent, and
+  a read on a closed stream (or one whose Dart owner is gone) fails with -1
+  instead of asserting.
+
 ## 9.6.0
 
 - Add a bunch more categories to the bindings.

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 9.6.0
+version: 9.6.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aobjective_c
 

--- a/pkgs/objective_c/src/input_stream_adapter.m
+++ b/pkgs/objective_c/src/input_stream_adapter.m
@@ -77,10 +77,23 @@
 
 - (void)close {
   [_dataCondition lock];
+  if (_status == NSStreamStatusClosed) {
+    // Already closed. NSURLSession closes the body stream it was handed when
+    // the task finishes, independently of the Dart owner closing it (e.g.
+    // cupertino_http closes the stream as soon as the request completes or
+    // is cancelled); the second close must be a no-op, not a second message
+    // to a port that the first close already told to shut down.
+    [_dataCondition unlock];
+    return;
+  }
   _status = NSStreamStatusClosed;
   if (!_done && _error == nil) {
-    __unused const bool success = Dart_PostInteger_DL(_sendPort, -1);
-    NSCAssert(success, @"DartInputStreamAdapter: Dart_PostCObject_DL failed.");
+    // A failed post means the Dart side has already closed its port — there
+    // is nobody left to notify, which is fine for a close.
+    if (!Dart_PostInteger_DL(_sendPort, -1)) {
+      os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_DEBUG,
+                       "DartInputStreamAdapter: close after the Dart port was closed");
+    }
   }
   [_dataCondition unlock];
 }
@@ -127,9 +140,28 @@
 
   [_dataCondition lock];
 
+  if (_status == NSStreamStatusClosed) {
+    // NSURLSession can still issue a read for a body stream after the Dart
+    // owner closed it (a request completed with an error or cancelled while
+    // the loader thread was about to resume the body). Closing sent the -1
+    // to Dart, so its port is gone: asking it for data would fail.
+    [_dataCondition unlock];
+    return -1;
+  }
+
   while (([_data length] == 0) && !_done && _error == nil) {
-    __unused const bool success = Dart_PostInteger_DL(_sendPort, len);
-    NSCAssert(success, @"DartInputStreamAdapter: Dart_PostCObject_DL failed.");
+    if (!Dart_PostInteger_DL(_sendPort, len)) {
+      // The Dart port is closed, so no data can ever arrive: fail the read
+      // instead of waiting forever (or aborting the process).
+      _error = [NSError
+          errorWithDomain:@"DartInputStreamAdapter"
+                     code:0
+                 userInfo:@{
+                   NSLocalizedDescriptionKey :
+                       @"The Dart side of the stream is no longer available."
+                 }];
+      break;
+    }
 
     [_dataCondition wait];
   }

--- a/pkgs/objective_c/test/ns_input_stream_test.dart
+++ b/pkgs/objective_c/test/ns_input_stream_test.dart
@@ -175,6 +175,35 @@ void main() {
           expect(inputStream.streamStatus, NSStreamStatus.NSStreamStatusClosed);
           expect(inputStream.streamError, null);
         });
+
+        // NSURLSession can still read from or close a request body stream
+        // after the Dart owner closed it (e.g. when the request completes
+        // with an error or is cancelled right after it starts). By then the
+        // Dart side has received the close message and closed its port, so
+        // these must fail gracefully rather than assert on a failed post.
+        test('read after close', () async {
+          inputStream.open();
+          inputStream.close();
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          final (count, data, hasBytesAvailable, status, error) = await read(
+            inputStream,
+            10,
+          );
+          expect(count, -1);
+          expect(data, isEmpty);
+          expect(hasBytesAvailable, false);
+          expect(status, NSStreamStatus.NSStreamStatusClosed);
+          expect(error, isNull);
+        });
+
+        test('close twice', () async {
+          inputStream.open();
+          inputStream.close();
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          inputStream.close();
+          expect(inputStream.streamStatus, NSStreamStatus.NSStreamStatusClosed);
+          expect(inputStream.streamError, null);
+        });
       });
     });
 


### PR DESCRIPTION
Fixes #3618.

`DartInputStreamAdapter` (the `NSInputStream` behind `Stream.toNSInputStream()`) asserted that every `Dart_PostInteger_DL` to its Dart owner succeeds. It doesn't once the Dart side has closed its port — which happens legitimately: `NSInputStream.close` from Dart posts `-1` and the Dart listener closes the port, but an `NSURLSession` that was handed the stream as `HTTPBodyStream` still owns it and may issue one more `read:maxLength:` (`RequestBodyStream::_onqueue_resume`) or `close` (`RequestBodyStream::cleanup`) on its loader thread afterwards. `package:cupertino_http` closes the body stream as soon as the task completes, so a request that completes with an error or is cancelled right after `resume` hits this reliably. The build hook compiles without `NS_BLOCK_ASSERTIONS`, so the `NSCAssert` is live in release builds and the failed post raised `NSInternalInconsistencyException` on a CFNetwork thread, killing the app (details and field stacks in the issue).

Changes:

- `close` is idempotent: a second close is a no-op instead of a second message to a port the first close already told to shut down.
- `read:maxLength:` on a closed stream returns -1 without touching the port.
- A failed post inside `read:` marks the stream errored (`streamStatus == NSStreamStatusError`, `streamError` set) and returns -1 instead of asserting, so a stream whose Dart side is gone fails the request rather than aborting the process.

Tests: two regression tests in `ns_input_stream_test.dart` (`read after close`, `close twice`). Both let the Dart side process the close first — that is what makes the unpatched adapter assert.

Verified locally (macOS arm64, Dart 3.11.0): `dart test test/ns_input_stream_test.dart` — 22/22 pass with the patch; with the unpatched `input_stream_adapter.m` the two new tests abort the test process (`libc++abi: terminating due to uncaught exception of type NSException`), which is the field crash.
