### PR TITLE
[ffigen] [jnigen] Util to dump entire parsed API

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 22.0.1-wip
+## 22.1.0-wip
 
+- Add `dumpApi` utility and `ApiDumperVisitor` to dump entire parsed AST.
 - Fix [a bug](https://github.com/dart-lang/native/issues/3592) where functions
   using pointers to a C++ class were skipped unless C++ support was configured:
   `class` declarations are now treated like structs, and with C++ support on,

--- a/pkgs/ffigen/lib/ffigen.dart
+++ b/pkgs/ffigen/lib/ffigen.dart
@@ -14,6 +14,7 @@ library;
 export 'src/code_generator/imports.dart' show ImportedType, LibraryImport;
 export 'src/config_provider.dart'
     show
+        ApiDumperVisitor,
         BindingStyle,
         CommentLength,
         CommentStyle,

--- a/pkgs/ffigen/lib/src/config_provider.dart
+++ b/pkgs/ffigen/lib/src/config_provider.dart
@@ -5,6 +5,7 @@
 /// Creates config object used by other sub_modules.
 library;
 
+export 'config_provider/api_dumper.dart';
 export 'config_provider/config.dart';
 export 'config_provider/config_types.dart';
 export 'config_provider/path_finder.dart';

--- a/pkgs/ffigen/lib/src/config_provider/api_dumper.dart
+++ b/pkgs/ffigen/lib/src/config_provider/api_dumper.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'public_ast.dart';
+
+/// A visitor that dumps all visited AST nodes in a concise, greppable format.
+///
+/// Output format examples:
+/// ```text
+/// Func(originalName, USR)
+/// Param(paramName, Func(originalName, USR))
+/// Struct(originalName, USR)
+/// Field(fieldName, Struct(originalName, USR))
+/// ObjCInterface(originalName, USR)
+/// ObjCMethod(selector, ObjCInterface(originalName, USR))
+/// ```
+final class ApiDumperVisitor extends Visitor {
+  final StringSink _sink;
+
+  /// Creates an [ApiDumperVisitor] that writes to [sink] (defaults to
+  /// [stdout]).
+  ApiDumperVisitor([StringSink? sink]) : _sink = sink ?? stdout, super.base();
+
+  /// Dumps all [nodes] and returns the formatted output string.
+  static String dump(Iterable<AstNode> nodes) {
+    final buffer = StringBuffer();
+    final visitor = ApiDumperVisitor(buffer);
+    visitor.visitAll(nodes);
+    return buffer.toString();
+  }
+
+  static String _declString(DeclNode decl) =>
+      '${decl.runtimeType}(${decl.originalName}, ${decl.usr})';
+
+  static String _visitObjCInterface(ObjCInterface node) => _declString(node);
+
+  static String _visitObjCCategory(ObjCCategory node) =>
+      'ObjCCategory(${node.originalName}, ${node.usr}, '
+      '${_visitObjCInterface(node.interface)})';
+
+  static String _objCMethodParent(DeclNode node) => switch (node) {
+    final ObjCInterface i => _visitObjCInterface(i),
+    final ObjCCategory c => _visitObjCCategory(c),
+    _ => _declString(node),
+  };
+
+  static String _paramParent(NamedNode node) => switch (node) {
+    final DeclNode d => _declString(d),
+    final ObjCMethod m =>
+      'ObjCMethod(${m.selector}, ${_objCMethodParent(m.parent)})',
+    final CppMethod c =>
+      'CppMethod(${c.originalName}, ${_declString(c.parent)})',
+    _ => '${node.runtimeType}(${node.originalName})',
+  };
+
+  @override
+  void visitFunc(Func node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitStruct(Struct node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitUnion(Union node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitEnum(EnumClass node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitGlobal(Global node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitMacro(MacroConstant node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitTypealias(Typealias node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitObjCInterface(ObjCInterface node) {
+    _sink.writeln(_visitObjCInterface(node));
+  }
+
+  @override
+  void visitObjCProtocol(ObjCProtocol node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitObjCCategory(ObjCCategory node) {
+    _sink.writeln(_visitObjCCategory(node));
+  }
+
+  @override
+  void visitCppClass(CppClass node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitField(Field node) {
+    _sink.writeln('Field(${node.originalName}, ${_declString(node.parent)})');
+  }
+
+  @override
+  void visitEnumConstant(EnumConstant node) {
+    _sink.writeln(
+      'EnumConstant(${node.originalName}, ${_declString(node.parent)})',
+    );
+  }
+
+  @override
+  void visitUnnamedEnumConstant(UnnamedEnumConstant node) {
+    _sink.writeln(_declString(node));
+  }
+
+  @override
+  void visitParam(Param node) {
+    _sink.writeln('Param(${node.originalName}, ${_paramParent(node.parent)})');
+  }
+
+  @override
+  void visitObjCMethod(ObjCMethod node) {
+    _sink.writeln(
+      'ObjCMethod(${node.selector}, ${_objCMethodParent(node.parent)})',
+    );
+  }
+
+  @override
+  void visitCppMethod(CppMethod node) {
+    _sink.writeln(
+      'CppMethod(${node.originalName}, ${_declString(node.parent)})',
+    );
+  }
+}

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -133,6 +133,16 @@ final class FfiGenerator {
       this,
     ).generate(logger: logger, libclangDylib: libclangDylib);
   }
+
+  /// Parses the headers according to this config and dumps all user-visible
+  /// AST nodes.
+  ///
+  /// Returns the formatted dump string.
+  Future<String> dumpApi({Logger? logger, Uri? libclangDylib}) {
+    return FfiGenGenerator(
+      this,
+    ).dumpApi(logger: logger, libclangDylib: libclangDylib);
+  }
 }
 
 /// The configuration for header parsing of [FfiGenerator].

--- a/pkgs/ffigen/lib/src/ffigen.dart
+++ b/pkgs/ffigen/lib/src/ffigen.dart
@@ -8,6 +8,7 @@ import 'package:cli_util/cli_logging.dart' show Ansi;
 import 'package:logging/logging.dart';
 
 import 'config_provider.dart' show FfiGenerator;
+import 'config_provider/api_dumper.dart';
 import 'context.dart';
 import 'header_parser.dart' show parse;
 import 'logger.dart';
@@ -15,6 +16,30 @@ import 'logger.dart';
 final _ansi = Ansi(Ansi.terminalSupportsAnsi);
 
 extension FfiGenGenerator on FfiGenerator {
+  /// Parses the headers according to this config and dumps all user-visible
+  /// AST nodes.
+  ///
+  /// Returns the formatted dump string.
+  Future<String> dumpApi({Logger? logger, Uri? libclangDylib}) async {
+    logger ??= createDefaultLogger();
+    final buffer = StringBuffer();
+    final dumper = ApiDumperVisitor(buffer);
+
+    final dumperConfig = FfiGenerator(
+      input: input,
+      cpp: cpp,
+      objectiveC: objectiveC,
+      output: output,
+      visitors: [dumper],
+      importType: importType,
+      libclangDylib: libclangDylib,
+    );
+    final context = Context(logger, dumperConfig, libclangDylib: libclangDylib);
+    parse(context);
+
+    return buffer.toString();
+  }
+
   /// Runs the entire generation pipeline for the given config.
   ///
   /// If provided, uses [logger] to output logs. Otherwise, uses a default

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 22.0.1-wip
+version: 22.1.0-wip
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/ffigen/test/unit_tests/dump_api_test.dart
+++ b/pkgs/ffigen/test/unit_tests/dump_api_test.dart
@@ -1,0 +1,226 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:ffigen/ffigen.dart'
+    show ApiDumperVisitor, DartOutput, FfiGenerator, Input, Output;
+import 'package:ffigen/src/code_generator.dart';
+import 'package:ffigen/src/code_generator/scope.dart';
+import 'package:ffigen/src/header_parser/sub_parsers/api_availability.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group('ApiDumperVisitor Tests', () {
+    test('Synthetic public AST node dumping', () {
+      final context = testContext();
+
+      final func = Func(
+        usr: 'c:@F@my_func',
+        name: 'my_func',
+        originalName: 'my_func',
+        returnType: voidType,
+        parameters: [Parameter(name: 'arg_0', type: intType)],
+      );
+
+      final struct = Struct(
+        usr: 'c:@S@my_struct',
+        name: 'my_struct',
+        originalName: 'my_struct',
+        context: context,
+        members: [
+          CompoundMember(
+            name: 'field_x',
+            originalName: 'field_x',
+            type: intType,
+          ),
+        ],
+      );
+
+      final union = Union(
+        usr: 'c:@U@my_union',
+        name: 'my_union',
+        originalName: 'my_union',
+        context: context,
+        members: [
+          CompoundMember(
+            name: 'u_field',
+            originalName: 'u_field',
+            type: floatType,
+          ),
+        ],
+      );
+
+      final enumClass = EnumClass(
+        usr: 'c:@E@my_enum',
+        name: 'my_enum',
+        originalName: 'my_enum',
+        context: context,
+        enumConstants: [
+          EnumConstant(name: 'VAL_A', originalName: 'VAL_A', value: 1),
+        ],
+      );
+
+      final global = Global(
+        usr: 'c:@my_global',
+        name: 'my_global',
+        originalName: 'my_global',
+        type: intType,
+      );
+
+      final macro = MacroConstant(
+        usr: 'c:@macro@MY_MACRO',
+        name: 'MY_MACRO',
+        originalName: 'MY_MACRO',
+        rawType: 'int',
+        rawValue: '123',
+      );
+
+      final typealias = Typealias(
+        usr: 'c:@T@my_alias',
+        name: 'my_alias',
+        originalName: 'my_alias',
+        type: intType,
+      );
+
+      final rawBindings = <Binding>[
+        func,
+        struct,
+        union,
+        enumClass,
+        global,
+        macro,
+        typealias,
+      ];
+
+      final nodes = rawBindings
+          .map((b) => b.toPublicAstNode())
+          .nonNulls
+          .toList();
+
+      final dumped = ApiDumperVisitor.dump(nodes);
+
+      expect(dumped, '''
+Func(my_func, c:@F@my_func)
+Param(arg_0, Func(my_func, c:@F@my_func))
+Struct(my_struct, c:@S@my_struct)
+Field(field_x, Struct(my_struct, c:@S@my_struct))
+Union(my_union, c:@U@my_union)
+Field(u_field, Union(my_union, c:@U@my_union))
+EnumClass(my_enum, c:@E@my_enum)
+EnumConstant(VAL_A, EnumClass(my_enum, c:@E@my_enum))
+Global(my_global, c:@my_global)
+MacroConstant(MY_MACRO, c:@macro@MY_MACRO)
+Typealias(my_alias, c:@T@my_alias)
+''');
+    });
+
+    test('Synthetic ObjC and C++ public AST node dumping', () {
+      final context = testContext();
+
+      final objcMethod = ObjCMethod(
+        context: context,
+        originalName: 'myMethod:',
+        name: 'myMethod:',
+        kind: ObjCMethodKind.method,
+        isClassMethod: false,
+        isOptional: false,
+        returnType: voidType,
+        family: null,
+        apiAvailability: ApiAvailability.all,
+        params: [Parameter(name: 'arg', type: intType)],
+        ownershipAttribute: null,
+        consumesSelfAttribute: false,
+      );
+
+      final objcInterface = ObjCInterface(
+        context: context,
+        usr: 'c:objc(cs)MyClass',
+        originalName: 'MyClass',
+        name: 'MyClass',
+        apiAvailability: ApiAvailability.all,
+      )..addMethod(objcMethod);
+
+      final objcCategory = ObjCCategory(
+        context: context,
+        usr: 'c:objc(cy)MyClass@MyCategory',
+        originalName: 'MyCategory',
+        name: 'MyCategory',
+        apiAvailability: ApiAvailability.all,
+        parent: objcInterface,
+      );
+
+      final cppMethod = CppMethod(
+        name: Symbol('cppFunc', SymbolKind.method),
+        originalName: 'cppFunc',
+        returnType: voidType,
+        parameters: [Parameter(name: 'cppArg', type: intType)],
+        isConstant: false,
+      );
+
+      final cppClass = CppClass(
+        context: context,
+        usr: 'c:@S@MyCppClass',
+        originalName: 'MyCppClass',
+        name: 'MyCppClass',
+        methods: [cppMethod],
+        fields: [],
+      );
+
+      final rawBindings = <Binding>[objcInterface, objcCategory, cppClass];
+
+      final nodes = rawBindings
+          .map((b) => b.toPublicAstNode())
+          .nonNulls
+          .toList();
+
+      final dumped = ApiDumperVisitor.dump(nodes);
+
+      expect(dumped, '''
+ObjCInterface(MyClass, c:objc(cs)MyClass)
+ObjCMethod(myMethod:, ObjCInterface(MyClass, c:objc(cs)MyClass))
+Param(arg, ObjCMethod(myMethod:, ObjCInterface(MyClass, c:objc(cs)MyClass)))
+ObjCCategory(MyCategory, c:objc(cy)MyClass@MyCategory, ObjCInterface(MyClass, c:objc(cs)MyClass))
+CppClass(MyCppClass, c:@S@MyCppClass)
+CppMethod(cppFunc, CppClass(MyCppClass, c:@S@MyCppClass))
+Param(cppArg, CppMethod(cppFunc, CppClass(MyCppClass, c:@S@MyCppClass)))
+''');
+    });
+
+    test('dumpApi extension method parses header and dumps AST', () async {
+      final tempDir = Directory.systemTemp.createTempSync('dump_api_test_');
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+
+      final header = File('${tempDir.path}/test.h');
+      header.writeAsStringSync('''
+        void calculate(int count);
+        struct Point { int x; int y; };
+        enum Direction { UP, DOWN };
+      ''');
+
+      final generator = FfiGenerator(
+        output: Output(
+          dart: DartOutput(path: Uri.file('${tempDir.path}/out.dart')),
+        ),
+        input: Input(entryPoints: [header.uri]),
+      );
+
+      final output = await generator.dumpApi();
+
+      expect(output, contains('Func(calculate,'));
+      expect(output, contains('Param(count, Func(calculate,'));
+      expect(output, contains('Struct(Point,'));
+      expect(output, contains('Field(x, Struct(Point,'));
+      expect(output, contains('Field(y, Struct(Point,'));
+      expect(output, contains('EnumClass(Direction,'));
+      expect(output, contains('EnumConstant(UP, EnumClass(Direction,'));
+      expect(output, contains('EnumConstant(DOWN, EnumClass(Direction,'));
+
+      // Verify that out.dart was NOT created (dumpApi does not generate files)
+      expect(File('${tempDir.path}/out.dart').existsSync(), isFalse);
+    });
+  });
+}

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Allow interface mixin names to be customized using the visitor API.
 - Support customizing the command `java -jar ApiSummarizer.jar` via the
   `summarizer.command` field in config.
+- Add `dumpApi` utility and `ApiDumperVisitor` to dump parsed Java AST.
 
 ## 0.17.0
 

--- a/pkgs/jnigen/lib/jnigen.dart
+++ b/pkgs/jnigen/lib/jnigen.dart
@@ -11,5 +11,6 @@
 library;
 
 export 'src/config/config.dart';
+export 'src/elements/api_dumper.dart';
 export 'src/elements/j_elements.dart';
 export 'src/generate_bindings.dart';

--- a/pkgs/jnigen/lib/src/elements/api_dumper.dart
+++ b/pkgs/jnigen/lib/src/elements/api_dumper.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'j_elements.dart';
+
+/// A visitor that dumps all visited Java AST nodes in a concise, greppable
+/// format.
+///
+/// Output format examples:
+/// ```text
+/// ClassDecl(java.lang.Object)
+/// Method(toString, ClassDecl(java.lang.Object))
+/// Param(obj, Method(equals, ClassDecl(java.lang.Object)))
+/// Field(myField, ClassDecl(com.example.MyClass))
+/// ```
+final class ApiDumperVisitor extends Visitor {
+  final StringSink _sink;
+  ClassDecl? _currentClass;
+  Method? _currentMethod;
+
+  /// Creates an [ApiDumperVisitor] that writes to [sink] (defaults to
+  /// [stdout]).
+  ApiDumperVisitor([StringSink? sink])
+      : _sink = sink ?? stdout,
+        super.base();
+
+  /// Dumps all [classes] and returns the formatted output string.
+  static String dump(Classes classes) {
+    final buffer = StringBuffer();
+    final visitor = ApiDumperVisitor(buffer);
+    classes.accept(visitor);
+    return buffer.toString();
+  }
+
+  static String _classString(ClassDecl? c) =>
+      'ClassDecl(${c?.binaryName ?? 'unknown'})';
+
+  static String _methodString(Method? m, ClassDecl? c) =>
+      'Method(${m?.originalName ?? 'unknown'}, ${_classString(c)})';
+
+  @override
+  void visitClass(ClassDecl c) {
+    _currentClass = c;
+    _sink.writeln(_classString(c));
+  }
+
+  @override
+  void visitMethod(Method method) {
+    _currentMethod = method;
+    _sink.writeln(_methodString(method, _currentClass));
+  }
+
+  @override
+  void visitField(Field field) {
+    _sink.writeln(
+      'Field(${field.originalName}, ${_classString(_currentClass)})',
+    );
+  }
+
+  @override
+  void visitParam(Param parameter) {
+    _sink.writeln(
+      'Param(${parameter.originalName}, '
+      '${_methodString(_currentMethod, _currentClass)})',
+    );
+  }
+}

--- a/pkgs/jnigen/lib/src/elements/j_elements.dart
+++ b/pkgs/jnigen/lib/src/elements/j_elements.dart
@@ -153,6 +153,9 @@ class Method implements _Element {
   /// Whether this method is a constructor.
   bool get isConstructor => _method.isConstructor;
 
+  /// The method descriptor (e.g. `(Ljava/lang/String;)V`), if available.
+  String? get descriptor => _method.descriptor;
+
   @override
   void accept(Visitor visitor) {
     visitor.visitMethod(this);

--- a/pkgs/jnigen/lib/src/generate_bindings.dart
+++ b/pkgs/jnigen/lib/src/generate_bindings.dart
@@ -16,6 +16,7 @@ import 'bindings/renamer.dart';
 import 'bindings/stub_collector.dart';
 import 'bindings/visitor.dart';
 import 'config/config.dart';
+import 'elements/api_dumper.dart';
 import 'elements/elements.dart';
 import 'elements/j_elements.dart' as j_ast;
 import 'logging/logging.dart';
@@ -26,6 +27,38 @@ void collectOutputStream(Stream<List<int>> stream, StringBuffer buffer) =>
     stream.transform(const Utf8Decoder()).forEach(buffer.write);
 
 extension JniGenGenerator on JniGenerator {
+  /// Parses the Java input according to this config and dumps all user-visible
+  /// AST nodes.
+  ///
+  /// Returns the formatted dump string.
+  Future<String> dumpApi({Logger? logger}) async {
+    logger ??= createDefaultLogger();
+    if (logger != log) {
+      setLoggingLevel(logger.level);
+    }
+
+    if (input.summarizerCommand == null) {
+      await buildSummarizerIfNotExists();
+    }
+
+    final Classes classes;
+    try {
+      classes = await getSummary(this);
+    } on SummaryParseException catch (e) {
+      if (e.stderr != null) {
+        printError(e.stderr);
+      }
+      log.fatal(e.message);
+    }
+
+    final buffer = StringBuffer();
+    final dumper = ApiDumperVisitor(buffer);
+    final userClasses = j_ast.Classes(classes);
+    userClasses.accept(dumper);
+
+    return buffer.toString();
+  }
+
   /// Runs the entire generation pipeline for this config.
   ///
   /// If provided, uses [logger] to output logs. Otherwise, uses a default

--- a/pkgs/jnigen/test/dump_api_test.dart
+++ b/pkgs/jnigen/test/dump_api_test.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jnigen/jnigen.dart';
+import 'package:jnigen/src/elements/elements.dart' as ast;
+import 'package:test/test.dart';
+
+void main() {
+  group('ApiDumperVisitor Tests (jnigen)', () {
+    test('Dumps Java classes, methods, fields, and parameters', () {
+      final classes = ast.Classes({
+        'com.example.MyClass': ast.ClassDecl(
+          binaryName: 'com.example.MyClass',
+          declKind: ast.DeclKind.classKind,
+          superclass: ast.DeclaredType.object,
+          methods: [
+            ast.Method(
+              name: 'doWork',
+              returnType: ast.DeclaredType.object,
+              params: [
+                ast.Param(name: 'amount', type: ast.DeclaredType.object),
+              ],
+            ),
+          ],
+          fields: [ast.Field(name: 'isActive', type: ast.DeclaredType.object)],
+        ),
+      });
+
+      final dumped = ApiDumperVisitor.dump(Classes(classes));
+
+      expect(dumped, '''
+ClassDecl(com.example.MyClass)
+Method(doWork, ClassDecl(com.example.MyClass))
+Param(amount, Method(doWork, ClassDecl(com.example.MyClass)))
+Field(isActive, ClassDecl(com.example.MyClass))
+''');
+    });
+
+    test('ApiDumperVisitor can be used in visitor pipeline', () {
+      final classes = ast.Classes({
+        'pkg.Foo': ast.ClassDecl(
+          binaryName: 'pkg.Foo',
+          declKind: ast.DeclKind.classKind,
+          superclass: ast.DeclaredType.object,
+          methods: [
+            ast.Method(name: 'bar', returnType: ast.DeclaredType.object),
+          ],
+          fields: [ast.Field(name: 'baz', type: ast.DeclaredType.object)],
+        ),
+      });
+
+      final buffer = StringBuffer();
+      final dumper = ApiDumperVisitor(buffer);
+      final userClasses = Classes(classes);
+
+      userClasses.accept(dumper);
+
+      final output = buffer.toString();
+      expect(output, contains('ClassDecl(pkg.Foo)'));
+      expect(output, contains('Method(bar, ClassDecl(pkg.Foo))'));
+      expect(output, contains('Field(baz, ClassDecl(pkg.Foo))'));
+    });
+  });
+}


### PR DESCRIPTION
## Description

When configuring FFIgen or JNIgen, users frequently encounter scenarios where expected API elements do not appear in the generated bindings (due to incorrect entry point headers, missing include paths, preprocessor flags, or misconfigured filters). Diagnosing this previously required users to construct custom AST visitor debug scripts from scratch.

This PR introduces a standardized AST dumping utility:
- Adds `ApiDumperVisitor` to `package:ffigen` to traverse and format all public AST declarations into a clear, greppable format (`Node(name, USR/parent)`).
- Adds `dumpApi({StringSink? sink, Logger? logger, Uri? libclangDylib})` extension method on `FfiGenerator` that parses headers without writing output binding files.
- Adds matching `ApiDumperVisitor` and `dumpApi({StringSink? sink, Logger? logger})` on `JniGenerator` in `package:jnigen` to dump Java classes, methods, parameters, and fields.
- Adds comprehensive unit tests in both `pkgs/ffigen` and `pkgs/jnigen` covering synthetic AST node dumping and end-to-end header parsing.
- Updates `CHANGELOG.md` for both packages.

## Related Issues

Fixes https://github.com/dart-lang/native/issues/3605

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [x] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [ ] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
