### PR TITLE
[infra] Switch from coveralls to codecov

### DIFF
--- a/.github/workflows/ffigen.yml
+++ b/.github/workflows/ffigen.yml
@@ -101,21 +101,14 @@ jobs:
       - name: Generate package:jni bindings
         run: dart --enable-asserts run tool/generate_ffi_bindings.dart
         working-directory: pkgs/jni/
-      - name: Trust Coveralls tap
-        run: brew trust coverallsapp/coveralls
       - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
+        uses: codecov/codecov-action@v5
         with:
-          flag-name: ffigen
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: pkgs/ffigen/coverage/lcov.info
-      - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
-        with:
-          carryforward: "ffigen,jni,jnigen,native_pkgs_macos,native_pkgs_ubuntu,native_pkgs_windows,objective_c,swift2objc,swiftgen"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+          files: pkgs/ffigen/coverage/lcov.info
+          flags: ffigen
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
 
   test-mac-intel:
     needs: analyze

--- a/.github/workflows/ffigen.yml
+++ b/.github/workflows/ffigen.yml
@@ -102,7 +102,7 @@ jobs:
         run: dart --enable-asserts run tool/generate_ffi_bindings.dart
         working-directory: pkgs/jni/
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: pkgs/ffigen/coverage/lcov.info
           flags: ffigen

--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -180,7 +180,7 @@ jobs:
         run: dart pub global run coverage:test_with_coverage -- -x bindings
       - name: Upload coverage
         if: ${{ matrix.sdk == 'stable' && matrix.java-version == 'none' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: ./pkgs/jnigen/coverage/lcov.info
           flags: jnigen
@@ -364,7 +364,7 @@ jobs:
         run: dart pub global run coverage:test_with_coverage
       - name: Upload coverage
         if: ${{ matrix.java-version == 'none' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: ./pkgs/jni/coverage/lcov.info
           flags: jni

--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -180,12 +180,12 @@ jobs:
         run: dart pub global run coverage:test_with_coverage -- -x bindings
       - name: Upload coverage
         if: ${{ matrix.sdk == 'stable' && matrix.java-version == 'none' }}
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
+        uses: codecov/codecov-action@v5
         with:
-          flag-name: jnigen
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ./pkgs/jnigen/coverage/lcov.info
+          files: ./pkgs/jnigen/coverage/lcov.info
+          flags: jnigen
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   test_jnigen_android:
     needs: [analyze_jnigen]
@@ -364,12 +364,12 @@ jobs:
         run: dart pub global run coverage:test_with_coverage
       - name: Upload coverage
         if: ${{ matrix.java-version == 'none' }}
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
+        uses: codecov/codecov-action@v5
         with:
-          flag-name: jni
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ./pkgs/jni/coverage/lcov.info
+          files: ./pkgs/jni/coverage/lcov.info
+          flags: jni
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
       - name: pub get example
         working-directory: ./pkgs/jni/example/
         run: flutter pub get
@@ -732,15 +732,3 @@ jobs:
           flutter build linux
         working-directory: ./pkgs/jnigen/example/pdfbox_plugin/example
 
-  coveralls_finish:
-    needs: [test_jnigen, test_jni]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Coveralls finished
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
-        with:
-          carryforward: "ffigen,jni,jnigen,native_pkgs_macos,native_pkgs_ubuntu,native_pkgs_windows,objective_c,swift2objc,swiftgen"
-          github-token: ${{ secrets.github_token }}
-          parallel-finished: true

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -103,24 +103,11 @@ jobs:
       - name: Run pub get, analysis, formatting, generators, tests, and examples.
         run: dart tool/ci.dart --all --no-apitool ${{ matrix.sdk == 'stable' && '--no-format' || '' }}
 
-      - name: Trust Coveralls tap
-        run: brew trust coverallsapp/coveralls
-        if: ${{ matrix.os == 'macos' }}
-
       - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
+        uses: codecov/codecov-action@v5
         with:
-          flag-name: native_pkgs_${{ matrix.os }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
+          files: ./coverage/lcov.info
+          flags: native_pkgs_${{ matrix.os }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
-  coverage-finished:
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
-        with:
-          carryforward: 'ffigen,jni,jnigen,native_pkgs_macos,native_pkgs_ubuntu,native_pkgs_windows,objective_c,swift2objc,swiftgen'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -104,7 +104,7 @@ jobs:
         run: dart tool/ci.dart --all --no-apitool ${{ matrix.sdk == 'stable' && '--no-format' || '' }}
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: ./coverage/lcov.info
           flags: native_pkgs_${{ matrix.os }}

--- a/.github/workflows/objective_c.yaml
+++ b/.github/workflows/objective_c.yaml
@@ -75,21 +75,14 @@ jobs:
         # test/generate_code_test.dart runs the code generator, so if there are
         # any git-diffs at this point, it means the generated code is outdated.
         run: if [[ -n $(git status --porcelain | tee /dev/stderr) ]]; then echo -e "\nDIFF:"; git diff; false; fi
-      - name: Trust Coveralls tap
-        run: brew trust coverallsapp/coveralls
       - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
+        uses: codecov/codecov-action@v5
         with:
-          flag-name: objective_c
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: pkgs/objective_c/coverage/lcov.info
-      - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
-        with:
-          carryforward: "ffigen,jni,jnigen,native_pkgs_macos,native_pkgs_ubuntu,native_pkgs_windows,objective_c,swift2objc,swiftgen"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+          files: pkgs/objective_c/coverage/lcov.info
+          flags: objective_c
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
 
   build-flutter-example:
     needs: analyze

--- a/.github/workflows/objective_c.yaml
+++ b/.github/workflows/objective_c.yaml
@@ -76,7 +76,7 @@ jobs:
         # any git-diffs at this point, it means the generated code is outdated.
         run: if [[ -n $(git status --porcelain | tee /dev/stderr) ]]; then echo -e "\nDIFF:"; git diff; false; fi
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: pkgs/objective_c/coverage/lcov.info
           flags: objective_c

--- a/.github/workflows/swift2objc.yaml
+++ b/.github/workflows/swift2objc.yaml
@@ -69,18 +69,11 @@ jobs:
         run: dart pub global activate coverage
       - name: Run VM tests and collect coverage
         run: dart pub global run coverage:test_with_coverage --scope-output=swift2objc
-      - name: Trust Coveralls tap
-        run: brew trust coverallsapp/coveralls
       - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
+        uses: codecov/codecov-action@v5
         with:
-          flag-name: swift2objc
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: pkgs/swift2objc/coverage/lcov.info
-      - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
-        with:
-          carryforward: "ffigen,jni,jnigen,native_pkgs_macos,native_pkgs_ubuntu,native_pkgs_windows,objective_c,swift2objc,swiftgen"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+          files: pkgs/swift2objc/coverage/lcov.info
+          flags: swift2objc
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+

--- a/.github/workflows/swift2objc.yaml
+++ b/.github/workflows/swift2objc.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Run VM tests and collect coverage
         run: dart pub global run coverage:test_with_coverage --scope-output=swift2objc
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: pkgs/swift2objc/coverage/lcov.info
           flags: swift2objc

--- a/.github/workflows/swiftgen.yaml
+++ b/.github/workflows/swiftgen.yaml
@@ -75,18 +75,11 @@ jobs:
         run: dart pub global activate coverage
       - name: Run VM tests and collect coverage
         run: dart pub global run coverage:test_with_coverage --scope-output=swiftgen
-      - name: Trust Coveralls tap
-        run: brew trust coverallsapp/coveralls
       - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
+        uses: codecov/codecov-action@v5
         with:
-          flag-name: swiftgen
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: pkgs/swiftgen/coverage/lcov.info
-      - name: Upload coverage
-        uses: coverallsapp/github-action@7eaec0f9ffb3343970b8447736fc85442e961b67
-        with:
-          carryforward: "ffigen,jni,jnigen,native_pkgs_macos,native_pkgs_ubuntu,native_pkgs_windows,objective_c,swift2objc,swiftgen"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+          files: pkgs/swiftgen/coverage/lcov.info
+          flags: swiftgen
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+

--- a/.github/workflows/swiftgen.yaml
+++ b/.github/workflows/swiftgen.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Run VM tests and collect coverage
         run: dart pub global run coverage:test_with_coverage --scope-output=swiftgen
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: pkgs/swiftgen/coverage/lcov.info
           flags: swiftgen

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg)](https://app.codecov.io/gh/dart-lang/native)
 
 ## Overview
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,113 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+  individual_components:
+    - component_id: code_assets
+      name: code_assets
+      paths:
+        - pkgs/code_assets/**
+    - component_id: data_assets
+      name: data_assets
+      paths:
+        - pkgs/data_assets/**
+    - component_id: ffi
+      name: ffi
+      paths:
+        - pkgs/ffi/**
+    - component_id: ffigen
+      name: ffigen
+      paths:
+        - pkgs/ffigen/**
+    - component_id: hooks
+      name: hooks
+      paths:
+        - pkgs/hooks/**
+    - component_id: hooks_runner
+      name: hooks_runner
+      paths:
+        - pkgs/hooks_runner/**
+    - component_id: jni
+      name: jni
+      paths:
+        - pkgs/jni/**
+    - component_id: jni_flutter
+      name: jni_flutter
+      paths:
+        - pkgs/jni_flutter/**
+    - component_id: jni_util
+      name: jni_util
+      paths:
+        - pkgs/jni_util/**
+    - component_id: jnigen
+      name: jnigen
+      paths:
+        - pkgs/jnigen/**
+    - component_id: json_syntax_generator
+      name: json_syntax_generator
+      paths:
+        - pkgs/json_syntax_generator/**
+    - component_id: native_test_helpers
+      name: native_test_helpers
+      paths:
+        - pkgs/native_test_helpers/**
+    - component_id: native_toolchain_c
+      name: native_toolchain_c
+      paths:
+        - pkgs/native_toolchain_c/**
+    - component_id: objective_c
+      name: objective_c
+      paths:
+        - pkgs/objective_c/**
+    - component_id: pub_formats
+      name: pub_formats
+      paths:
+        - pkgs/pub_formats/**
+    - component_id: record_use
+      name: record_use
+      paths:
+        - pkgs/record_use/**
+    - component_id: swift2objc
+      name: swift2objc
+      paths:
+        - pkgs/swift2objc/**
+    - component_id: swiftgen
+      name: swiftgen
+      paths:
+        - pkgs/swiftgen/**
+    - component_id: test_case_selector
+      name: test_case_selector
+      paths:
+        - pkgs/test_case_selector/**
+
+ignore:
+  - "**/*.g.dart"
+  - "**/*.mocks.dart"
+  - "**/test/**"
+  - "**/example/**"
+  - "**/test_data/**"
+
+comment:
+  layout: "reach,diff,flags,components,files"
+  behavior: default
+  require_changes: false

--- a/pkgs/code_assets/README.md
+++ b/pkgs/code_assets/README.md
@@ -1,5 +1,5 @@
 [![package:code_assets](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=code_assets)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/code_assets.svg)](https://pub.dev/packages/code_assets)
 [![package publisher](https://img.shields.io/pub/publisher/code_assets.svg)](https://pub.dev/packages/code_assets/publisher)
 

--- a/pkgs/data_assets/README.md
+++ b/pkgs/data_assets/README.md
@@ -1,5 +1,5 @@
 [![package:data_assets](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=data_assets)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/data_assets.svg)](https://pub.dev/packages/data_assets)
 [![package publisher](https://img.shields.io/pub/publisher/data_assets.svg)](https://pub.dev/packages/data_assets/publisher)
 

--- a/pkgs/ffi/README.md
+++ b/pkgs/ffi/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/dart-lang/native/actions/workflows/ffi.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/ffi.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=ffi)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/ffi.svg)](https://pub.dev/packages/ffi)
 [![package publisher](https://img.shields.io/pub/publisher/ffi.svg)](https://pub.dev/packages/ffi/publisher)
 

--- a/pkgs/ffigen/README.md
+++ b/pkgs/ffigen/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/dart-lang/native/actions/workflows/ffigen.yml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/ffigen.yml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=ffigen)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/ffigen.svg)](https://pub.dev/packages/ffigen)
 [![package publisher](https://img.shields.io/pub/publisher/ffigen.svg)](https://pub.dev/packages/ffigen/publisher)
 

--- a/pkgs/hooks/README.md
+++ b/pkgs/hooks/README.md
@@ -1,5 +1,5 @@
 [![dart](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=hooks)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/hooks.svg)](https://pub.dev/packages/hooks)
 [![package publisher](https://img.shields.io/pub/publisher/hooks.svg)](https://pub.dev/packages/hooks/publisher)
 

--- a/pkgs/hooks_runner/README.md
+++ b/pkgs/hooks_runner/README.md
@@ -1,5 +1,5 @@
 [![dart](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=hooks_runner)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/hooks_runner.svg)](https://pub.dev/packages/hooks_runner)
 [![package publisher](https://img.shields.io/pub/publisher/hooks_runner.svg)](https://pub.dev/packages/hooks_runner/publisher)
 

--- a/pkgs/jni/README.md
+++ b/pkgs/jni/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/dart-lang/native/actions/workflows/jnigen.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/jnigen.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=jni)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/jni.svg)](https://pub.dev/packages/jni)
 [![package publisher](https://img.shields.io/pub/publisher/jni.svg)](https://pub.dev/packages/jni/publisher)
 

--- a/pkgs/jni_flutter/README.md
+++ b/pkgs/jni_flutter/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/dart-lang/native/actions/workflows/jnigen.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/jnigen.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=jni_flutter)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/jni_flutter.svg)](https://pub.dev/packages/jni_flutter)
 [![package publisher](https://img.shields.io/pub/publisher/jni_flutter.svg)](https://pub.dev/packages/jni_flutter/publisher)
 

--- a/pkgs/jnigen/README.md
+++ b/pkgs/jnigen/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/dart-lang/native/actions/workflows/jnigen.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/jnigen.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=jnigen)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/jnigen.svg)](https://pub.dev/packages/jnigen)
 [![package publisher](https://img.shields.io/pub/publisher/jnigen.svg)](https://pub.dev/packages/jnigen/publisher)
 

--- a/pkgs/native_toolchain_c/README.md
+++ b/pkgs/native_toolchain_c/README.md
@@ -1,5 +1,5 @@
 [![dart](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=native_toolchain_c)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/native_toolchain_c.svg)](https://pub.dev/packages/native_toolchain_c)
 [![package publisher](https://img.shields.io/pub/publisher/native_toolchain_c.svg)](https://pub.dev/packages/native_toolchain_c/publisher)
 

--- a/pkgs/objective_c/README.md
+++ b/pkgs/objective_c/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/dart-lang/native/actions/workflows/objective_c.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/objective_c.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![Coverage Status](https://codecov.io/gh/dart-lang/native/branch/main/graph/badge.svg?component=objective_c)](https://app.codecov.io/gh/dart-lang/native)
 [![pub package](https://img.shields.io/pub/v/objective_c.svg)](https://pub.dev/packages/objective_c)
 [![package publisher](https://img.shields.io/pub/publisher/objective_c.svg)](https://pub.dev/packages/objective_c/publisher)
 


### PR DESCRIPTION
If it works as advertised, it should support our use-case much better. The main problem we're having is that we have multiple coverage reports from multiple workflows, and some packages' coverage is partly generated by tests in other packages.

Codecov supports this by first preventing the different workflows' coverage reports from overwriting each other using `flags` in the workflows. Once uploaded, codecov merges all the coverage reports into one, then we filter them by package path using `components` in the `codecov.yml`.